### PR TITLE
Make ZUGFeRDExporter closeable to avoid warning "You did not close a PDF Document"

### DIFF
--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -11,6 +11,7 @@ package org.mustangproject.ZUGFeRD;
  */
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,7 +63,7 @@ import org.apache.xmpbox.type.BadFieldValueException;
 import org.apache.xmpbox.xml.XmpSerializer;
 import org.mustangproject.ZUGFeRD.model.*;
 
-public class ZUGFeRDExporter {
+public class ZUGFeRDExporter implements Closeable {
 
 	/**
 	 * * You will need Apache PDFBox. To use the ZUGFeRD exporter, implement
@@ -537,6 +538,12 @@ public class ZUGFeRDExporter {
                 metadata.importXMPMetadata( baos.toByteArray() );
                 
 		return cat;
+	}
+
+	public void close() throws IOException {
+		if (doc != null) {
+			doc.close();
+		}
 	}
 
 	private static final ObjectFactory xmlFactory = new ObjectFactory();


### PR DESCRIPTION
When I use the ZUGFeRDExporter in my application I get these warnings:

> WARN COSDocument:637 - Warning: You did not close a PDF Document

(Note that the warning comes from a destructor of pdfbox. So this warning will only appear in applications that run long enough to trigger the garbage collector)

These warnings will disappear when I call `zugFeRDExporter.getDoc().close();` one I am done with the Exporter. However I this seems unintuitive and it breaks the law of demeter. I think the exporter should have a close method, which delegates the close-call to the document.