### PR TITLE
Removed JAXBExceptions from the public API of the ZUGFeRDExporter

### DIFF
--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExportException.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExportException.java
@@ -1,0 +1,18 @@
+package org.mustangproject.ZUGFeRD;
+
+public class ZUGFeRDExportException extends RuntimeException {
+    public ZUGFeRDExportException() {
+    }
+
+    public ZUGFeRDExportException(String message) {
+        super(message);
+    }
+
+    public ZUGFeRDExportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ZUGFeRDExportException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
This is a subset of what was proposed in PR #18, so we can review and discuss in smaller steps.

I removed JAXB exceptions from public API to improve encapsulation. I think the user of the library should not know which method is used to serialize the objects to XML. This also makes it possible to exchange/upgrade the XML generation library without changing the public API in case this becomes necessary. As far as I can tell there is nothing a user could do about a JAXBException if he caught one, because he has no influence of the usage.