### PR TITLE
Use enum values for PDF/A conformance levels and ZUGFeRD conformance levels

### DIFF
--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/PDFAConformanceLevel.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/PDFAConformanceLevel.java
@@ -1,0 +1,24 @@
+package org.mustangproject.ZUGFeRD;
+
+public enum PDFAConformanceLevel {
+    ACCESSIBLE("A"), BASIC("B"), UNICODE("U");
+
+    private final String letter;
+
+    PDFAConformanceLevel(String letter) {
+        this.letter = letter;
+    }
+
+    public String getLetter() {
+        return letter;
+    }
+
+    public static PDFAConformanceLevel findByLetter(String letter) {
+        for (PDFAConformanceLevel candidate : values()) {
+            if (candidate.letter.equals(letter)) {
+                return candidate;
+            }
+        }
+        throw new IllegalArgumentException("PDF conformance level <" + letter + "> is unknown.");
+    }
+}

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaZugferd.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaZugferd.java
@@ -15,12 +15,12 @@ public class XMPSchemaZugferd extends XMPSchema {
     /**
      * This is what needs to be added to the RDF metadata - basically the name of the embedded Zugferd file
      */
-    public XMPSchemaZugferd(XMPMetadata metadata, String conformanceLevel) {
+    public XMPSchemaZugferd(XMPMetadata metadata, ZUGFeRDConformanceLevel conformanceLevel) {
         super(metadata, "urn:ferd:pdfa:CrossIndustryDocument:invoice:1p0#", "zf", "ZUGFeRD Schema");
 
         setAboutAsSimple("");
 
-        setTextPropertyValue("ConformanceLevel", conformanceLevel);
+        setTextPropertyValue("ConformanceLevel", conformanceLevel.name());
         setTextPropertyValue("DocumentType", "INVOICE");
         setTextPropertyValue("DocumentFileName", "ZUGFeRD-invoice.xml");
         setTextPropertyValue("Version", "1.0");

--- a/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDConformanceLevel.java
+++ b/mustang/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDConformanceLevel.java
@@ -1,0 +1,5 @@
+package org.mustangproject.ZUGFeRD;
+
+public enum ZUGFeRDConformanceLevel {
+    BASIC, COMFORT, EXTENDED;
+}


### PR DESCRIPTION
This is a subset of what is proposed in #18.

This pull request proposes that the conformance levels for PDF documents ("A", "B", "U") and ZUGFeRD documents (BASIC, COMFORT, EXTENDED) are used as enums and not as strings, to improve readability and eliminate the possibility of illegal conformance levels being used by the user.