### PR TITLE
Use version from pom.xml instead java constant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filtering-java-templates</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <mailingLists>

--- a/src/main/java-templates/org/mustangproject/ZUGFeRD/Version.java
+++ b/src/main/java-templates/org/mustangproject/ZUGFeRD/Version.java
@@ -1,0 +1,5 @@
+package org.mustangproject.ZUGFeRD;
+
+public final class Version {
+    public static final String VERSION = "${project.version}";
+}

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -237,7 +237,6 @@ public class ZUGFeRDExporter implements Closeable {
 
 	// // MAIN CLASS
 	private PDFAConformanceLevel conformanceLevel = PDFAConformanceLevel.UNICODE;
-	private String versionStr = "1.4.1";
 
 	// BASIC, COMFORT etc - may be set from outside.
 	private ZUGFeRDConformanceLevel zUGFeRDConformanceLevel = ZUGFeRDConformanceLevel.EXTENDED;
@@ -466,7 +465,7 @@ public class ZUGFeRDExporter implements Closeable {
 			String creator, boolean attachZugferdHeaders) throws IOException,
 			TransformerException {
 		String fullProducer = producer + " (via mustangproject.org "
-				+ versionStr + ")";
+				+ Version.VERSION + ")";
 
 		PDDocumentCatalog cat = doc.getDocumentCatalog();
 		PDMetadata metadata = new PDMetadata(doc);

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA1Factory.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA1Factory.java
@@ -29,8 +29,6 @@ import java.io.InputStream;
 import java.util.GregorianCalendar;
 
 public class ZUGFeRDExporterFromA1Factory {
-    private static final String VERSION_STR = "1.4.0";
-
     private boolean ignoreA1Errors = false;
     private ZUGFeRDConformanceLevel zugferdConformanceLevel = ZUGFeRDConformanceLevel.EXTENDED;
     private PDFAConformanceLevel conformanceLevel = PDFAConformanceLevel.U;
@@ -89,7 +87,7 @@ public class ZUGFeRDExporterFromA1Factory {
     }
 
     private void makePDFA3compliant(PDDocument doc) throws IOException {
-        String fullProducer = producer + " (via mustangproject.org " + VERSION_STR + ")";
+        String fullProducer = producer + " (via mustangproject.org " + Version.VERSION + ")";
 
         PDDocumentCatalog cat = doc.getDocumentCatalog();
         PDMetadata metadata = new PDMetadata(doc);


### PR DESCRIPTION
You [previously mentioned](https://github.com/ZUGFeRD/mustangproject/pull/18#issuecomment-303210373) that you'd prefer to read the version number from the maven POM file rather than maintaining an additional constant in the project.

I think that makes sense. This pull request will do just that. When compiling with maven, it will add a class `Version` with a constant `VERSION` to the target/generated-sources directory, which can then be accessed normally.

Note that your IDE might complain about the missing file (although the project will build normally with maven): Build the project once with maven, so that maven generates the version class and then, in your IDE, mark the directory `target/generated-sources/java-templates` as "generated sources root" (IntelliJ IDEA) or only "src" or whatever you IDE uses as designator.