### PR TITLE
Remove javadoc for not-existing parameter

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -1380,8 +1380,6 @@ public class ZUGFeRDExporter implements Closeable {
 	/**
 	 * Embeds the Zugferd XML structure in a file named ZUGFeRD-invoice.xml.
 	 *
-	 * @param doc
-	 *            PDDocument to attach an XML invoice to
 	 * @param trans
 	 *            a IZUGFeRDExportableTransaction that provides the data-model
 	 *            to populate the XML. This parameter may be null, if so the XML


### PR DESCRIPTION
The method `PDFattachZugferdFile` in class `ZUGFeRDExporter` has Javadoc for a parameter `doc`, but this parameter does not exist on the method, so the JavaDoc should be removed.