### PR TITLE
Fixing ZUGFeRD 1.0 to 2.0 XSL transformation by adding latest SAXON. …

### DIFF
--- a/ZUGFeRD2-invoice.xml
+++ b/ZUGFeRD2-invoice.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"><!--
+Migrated by Mustangproject XSLT
+--><rsm:ExchangedDocumentContext>
+        <ram:TestIndicator>
+            <udt:Indicator>false</udt:Indicator>
+        </ram:TestIndicator>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:ferd:CrossIndustryDocument:invoice:1p0:extended</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+   <rsm:ExchangedDocument xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100">
+        <ram:ID>RE-20170509/505</ram:ID>
+        <ram:Name>RECHNUNG</ram:Name>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20170509</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+   <rsm:SupplyChainTradeTransaction xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100">
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+                <ram:Name>Künstlerische Gestaltung (Stunde): Einer Beispielrechnung</ram:Name>
+                <ram:Description/>
+            </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">160.0000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">160.0000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="HUR">1.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">160.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+                <ram:Name>Luftballon: Bunt, ca. 500ml</ram:Name>
+                <ram:Description/>
+            </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.7900</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.7900</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">400.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">316.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>3</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+                <ram:Name>Heiße Luft pro Liter</ram:Name>
+                <ram:Description/>
+            </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.1000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.1000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="LTR">200.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">20.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Bei Spiel GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>12345</ram:PostcodeCode>
+                    <ram:LineOne>Ecke 12</ram:LineOne>
+                    <ram:CityName>Stadthausen</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="FC">22/815/0815/4</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE136695976</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Theodor Est</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>88802</ram:PostcodeCode>
+                    <ram:LineOne>Bahnstr. 42</ram:LineOne>
+                    <ram:CityName>Spielkreis</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE999999999</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      <ram:ApplicableHeaderTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20170507</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+      <ram:ApplicableHeaderTradeSettlement>
+            <ram:PaymentReference>RE-20170509/505</ram:PaymentReference>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>42</ram:TypeCode>
+                <ram:Information>Überweisung</ram:Information>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:IBANID>DE88 2008 0000 0970 3757 00</ram:IBANID>
+                </ram:PayeePartyCreditorFinancialAccount>
+                <ram:PayeeSpecifiedCreditorFinancialInstitution>
+                    <ram:BICID>COBADEFFXXX</ram:BICID>
+                    <ram:Name>Commerzbank</ram:Name>
+                </ram:PayeeSpecifiedCreditorFinancialInstitution>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount currencyID="EUR">11.20</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount currencyID="EUR">160.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount currencyID="EUR">63.84</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount currencyID="EUR">336.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>Zahlbar ohne Abzug bis zum 30.05.2017</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20170530</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount currencyID="EUR">496.00</ram:LineTotalAmount>
+                <ram:ChargeTotalAmount currencyID="EUR">0.00</ram:ChargeTotalAmount>
+                <ram:AllowanceTotalAmount currencyID="EUR">0.00</ram:AllowanceTotalAmount>
+                <ram:TaxBasisTotalAmount currencyID="EUR">496.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">75.04</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount currencyID="EUR">571.04</ram:GrandTotalAmount>
+                <ram:DuePayableAmount currencyID="EUR">571.04</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+   </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>
+

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.mustangproject.ZUGFeRD</groupId>
   <artifactId>mustang</artifactId>
   <name>Mustang</name>
-  <version>1.4.2-SNAPSHOT</version>
+  <version>1.5.2-SNAPSHOT</version>
   <description>The Mustang project is a java library to read and write ZUGFeRD meta data inside your invoice PDFs</description>
   <url>http://www.mustangproject.org/</url>
   <mailingLists>
@@ -41,24 +41,19 @@
   <scm>
     <connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
     <developerConnection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</developerConnection>
-    <tag>v1.4.0</tag>
+    <tag>mustang-1.5.0</tag>
     <url>https://github.com/ZUGFeRD/mustangproject</url>
   </scm>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifest>
-              <mainClass>org.mustangproject.toecount.Toecount</mainClass>
-            </manifest>
-          </archive>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
@@ -86,7 +81,7 @@
       <plugin>
         <groupId>com.github.github</groupId>
         <artifactId>site-maven-plugin</artifactId>
-        <version>0.11</version>
+        <version>0.12</version>
         <executions>
           <execution>
             <phase>deploy</phase>
@@ -125,7 +120,38 @@
           </execution>
         </executions>
         <configuration>
+          <transformers>
+            <transformer>
+              <mainClass>org.mustangproject.toecount.Toecount</mainClass>
+            </transformer>
+          </transformers>
           <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>log4j:log4j</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+            <filter>
+              <artifact>commons-logging:commons-logging</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+            <filter>
+              <artifact>com.sun.xml.bind:jaxb-impl</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+            <filter>
+              <artifact>com.sun.xml.bind:jaxb-core</artifact>
+              <includes>
+                <include>**</include>
+              </includes>
+            </filter>
+          </filters>
         </configuration>
       </plugin>
       <plugin>
@@ -157,7 +183,7 @@
           <target>2.1</target>
           <packageName>org.mustangproject.ZUGFeRD.model</packageName>
           <sources>
-            <source>src/main/schema/ZUGFeRD1p0.xsd</source>
+            <source>src/main/resources/schema/ZUGFeRD1p0.xsd</source>
           </sources>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,293 +1,298 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.mustangproject.ZUGFeRD</groupId>
-	<artifactId>mustang</artifactId>
-	<version>1.5.2-SNAPSHOT</version>
-	<packaging>jar</packaging>
-	<name>Mustang</name>
-	<description>The Mustang project is a java library to read and write ZUGFeRD meta data inside your invoice PDFs</description>
-	<url>http://www.mustangproject.org/</url>
-	<scm>
-		<connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
-		<developerConnection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</developerConnection>
-		<url>https://github.com/ZUGFeRD/mustangproject</url>
-		<tag>mustang-1.5.0</tag>
-	</scm>
-	<repositories>
-		<repository><!-- for jargs -->
-			<id>sonatype-oss-public</id>
-			<url>https://oss.sonatype.org/content/groups/public/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-	<distributionManagement>
-		<repository>
-			<id>internal.repo</id>
-			<name>Temporary Staging Repository</name>
-			<url>file://${project.build.directory}/mvn-repo</url>
-		</repository>
-	</distributionManagement>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<github.global.server>github</github.global.server>
-		<additionalparam>-Xdoclint:none</additionalparam>
-		<!-- Skip error check for javadoc -->
-		<maven.compiler.compilerVersion>1.7</maven.compiler.compilerVersion>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
-	</properties>
-	<dependencies>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mustangproject.ZUGFeRD</groupId>
+    <artifactId>mustang</artifactId>
+    <version>1.5.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Mustang</name>
+    <description>The Mustang project is a java library to read and write ZUGFeRD meta data inside your invoice PDFs</description>
+    <url>http://www.mustangproject.org/</url>
+    <scm>
+        <connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
+        <developerConnection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</developerConnection>
+        <url>https://github.com/ZUGFeRD/mustangproject</url>
+        <tag>mustang-1.5.0</tag>
+    </scm>
+    <repositories>
+        <repository><!-- for jargs -->
+            <id>sonatype-oss-public</id>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <github.global.server>github</github.global.server>
+        <additionalparam>-Xdoclint:none</additionalparam>
+        <!-- Skip error check for javadoc -->
+        <maven.compiler.compilerVersion>1.7</maven.compiler.compilerVersion>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/net.sf.saxon/Saxon-HE -->
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.8.0-11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>preflight</artifactId>
+            <version>2.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.helger</groupId>
+            <artifactId>ph-schematron</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- For Toecount -->
+        <dependency>
+            <groupId>com.sanityinc</groupId>
+            <artifactId>jargs</artifactId>
+            <version>2.0-SNAPSHOT</version>
+        </dependency>
 
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.2.11</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.2.11</version>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish.jaxb</groupId>
-			<artifactId>jaxb-runtime</artifactId>
-			<version>2.2.11</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.pdfbox</groupId>
-			<artifactId>preflight</artifactId>
-			<version>2.0.5</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.pdfbox</groupId>
-			<artifactId>pdfbox</artifactId>
-			<version>2.0.5</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.helger</groupId>
-			<artifactId>ph-schematron</artifactId>
-			<version>4.3.1</version>
-			<scope>test</scope>
-		</dependency>
-		<!-- For Toecount -->
-		<dependency>
-			<groupId>com.sanityinc</groupId>
-			<artifactId>jargs</artifactId>
-			<version>2.0-SNAPSHOT</version>
-		</dependency>
-
-	</dependencies>
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin><!-- mvn help:effective-pom will otherwise tell it just defaults 
+    </dependencies>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin><!-- mvn help:effective-pom will otherwise tell it just defaults 
 						to 2.3.2 - which does not release in the maven repo, and neither shows any 
 						error message :-( -->
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-		<plugins>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
 
-			<!-- toecount -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<mainClass>org.mustangproject.toecount.Toecount</mainClass>
-						</manifest>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven 
-						mvn clean compile assembly:single -->
-					<!-- or whatever version you use -->
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
+            <!-- toecount -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>org.mustangproject.toecount.Toecount</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven 
+                    mvn clean compile assembly:single -->
+                    <!-- or whatever version you use -->
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
 
 
-			<!-- /toecount -->
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
-				<configuration>
-					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>com.github.github</groupId>
-				<artifactId>site-maven-plugin</artifactId>
-				<version>0.12</version>
-				<configuration>
-					<message>Maven artifacts for ${project.version}</message>
-					<!-- git commit message -->
-					<noJekyll>true</noJekyll>
-					<!-- disable webpage processing -->
-					<outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
-					<!-- matches distribution management repository url above -->
-					<branch>refs/heads/mvn-repo</branch>
-					<!-- remote branch name -->
-					<includes>
-						<include>**/*</include>
-					</includes>
-					<merge>true</merge>
-					<repositoryName>mustangproject</repositoryName>
-					<!-- github repo name -->
-					<repositoryOwner>ZUGFeRD</repositoryOwner>
-					<!-- github username -->
-				</configuration>
-				<executions>
-					<!-- run site-maven-plugin's 'site' target as part of the build's normal 
-						'deploy' phase -->
-					<execution>
-						<goals>
-							<goal>site</goal>
-						</goals>
-						<phase>deploy</phase>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.3</version>
-				<configuration>
-					<transformers>
-						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-							<mainClass>org.mustangproject.toecount.Toecount</mainClass>
-						</transformer>
-					</transformers>
-					<minimizeJar>true</minimizeJar>
-					<filters>
-						<filter>
-							<artifact>log4j:log4j</artifact>
-							<includes>
-								<include>**</include>
-							</includes>
-						</filter>
-						<filter>
-							<artifact>commons-logging:commons-logging</artifact>
-							<includes>
-								<include>**</include>
-							</includes>
-						</filter>
-						<filter>
-							<artifact>com.sun.xml.bind:jaxb-impl</artifact>
-							<includes>
-								<include>**</include>
-							</includes>
-						</filter>
-						<filter>
-							<artifact>com.sun.xml.bind:jaxb-core</artifact>
-							<includes>
-								<include>**</include>
-							</includes>
-						</filter>
-					</filters>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<excludes>
-									<!--exclude>classworlds:classworlds</exclude> <exclude>junit:junit</exclude> 
-										<exclude>jmock:*</exclude> <exclude>*:xml-apis</exclude> <exclude>org.apache.maven:lib:tests</exclude> 
-										<exclude>log4j:log4j:jar:</exclude -->
-								</excludes>
-							</artifactSet>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>templating-maven-plugin</artifactId>
-				<version>1.0.0</version>
-				<executions>
-					<execution>
-						<id>filtering-java-templates</id>
-						<goals>
-							<goal>filter-sources</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>2.3.1</version>
-				<executions>
-					<execution>
-						<id>xjc</id>
-						<goals>
-							<goal>xjc</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<target>2.1</target>
-					<packageName>org.mustangproject.ZUGFeRD.model</packageName>
-					<sources>
-						<source>src/main/resources/schema/ZUGFeRD1p0.xsd</source>
-					</sources>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-	<mailingLists>
-		<mailingList>
-			<name>User List</name>
-			<archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
-		</mailingList>
-	</mailingLists>
-	<licenses>
-		<license>
-			<name>Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-			<comments>A business-friendly OSS license</comments>
-		</license>
-	</licenses>
-	<developers>
-		<developer>
-			<name>Jochen Stärk</name>
-			<email>jstaerk@usegroup.de</email>
-			<roles>
-				<role>architect</role>
-				<role>developer</role>
-			</roles>
-		</developer>
-		<developer>
-			<name>Alexander Schmidt</name>
-			<email>schmidt.alexander@mail.de</email>
-			<roles>
-				<role>developer</role>
-			</roles>
-		</developer>
-	</developers>
+            <!-- /toecount -->
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.12</version>
+                <configuration>
+                    <message>Maven artifacts for ${project.version}</message>
+                    <!-- git commit message -->
+                    <noJekyll>true</noJekyll>
+                    <!-- disable webpage processing -->
+                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory>
+                    <!-- matches distribution management repository url above -->
+                    <branch>refs/heads/mvn-repo</branch>
+                    <!-- remote branch name -->
+                    <includes>
+                        <include>**/*</include>
+                    </includes>
+                    <merge>true</merge>
+                    <repositoryName>mustangproject</repositoryName>
+                    <!-- github repo name -->
+                    <repositoryOwner>ZUGFeRD</repositoryOwner>
+                    <!-- github username -->
+                </configuration>
+                <executions>
+                    <!-- run site-maven-plugin's 'site' target as part of the build's normal 
+                    'deploy' phase -->
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.mustangproject.toecount.Toecount</mainClass>
+                        </transformer>
+                    </transformers>
+                    <minimizeJar>true</minimizeJar>
+                    <filters>
+                        <filter>
+                            <artifact>log4j:log4j</artifact>
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </filter>
+                        <filter>
+                            <artifact>commons-logging:commons-logging</artifact>
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </filter>
+                        <filter>
+                            <artifact>com.sun.xml.bind:jaxb-impl</artifact>
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </filter>
+                        <filter>
+                            <artifact>com.sun.xml.bind:jaxb-core</artifact>
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <!--exclude>classworlds:classworlds</exclude> <exclude>junit:junit</exclude> 
+                                    <exclude>jmock:*</exclude> <exclude>*:xml-apis</exclude> <exclude>org.apache.maven:lib:tests</exclude> 
+                                    <exclude>log4j:log4j:jar:</exclude -->
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>filtering-java-templates</id>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>2.3.1</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <target>2.1</target>
+                    <packageName>org.mustangproject.ZUGFeRD.model</packageName>
+                    <sources>
+                        <source>src/main/resources/schema/ZUGFeRD1p0.xsd</source>
+                    </sources>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <mailingLists>
+        <mailingList>
+            <name>User List</name>
+            <archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
+        </mailingList>
+    </mailingLists>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Jochen Stärk</name>
+            <email>jstaerk@usegroup.de</email>
+            <roles>
+                <role>architect</role>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <name>Alexander Schmidt</name>
+            <email>schmidt.alexander@mail.de</email>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 </project>

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDMigrator.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDMigrator.java
@@ -1,89 +1,99 @@
+/** **********************************************************************
+ *
+ * Copyright 2018 Jochen Staerk
+ *
+ * Use is subject to license terms.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0. You can also
+ * obtain a copy of the License at http://odftoolkit.org/docs/license.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *********************************************************************** */
 package org.mustangproject.ZUGFeRD;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
-
-
 public class ZUGFeRDMigrator {
-	static final ClassLoader cl = ZUGFeRDMigrator.class.getClassLoader();
-	private static TransformerFactory factory = null;
-	private static final String resourcePath = ""; //$NON-NLS-1$
 
-	private static TransformerFactory getTransformerFactory() {
-		//TransformerFactory fact = new net.sf.saxon.TransformerFactoryImpl();
-		TransformerFactory fact = TransformerFactory.newInstance();
-		fact.setURIResolver(new ClasspathResourceURIResolver());
-		return fact;
-	}
-	public String migrateFromV1ToV2(String xmlFilename) {
-/***
- * http://www.unece.org/fileadmin/DAM/cefact/xml/XML-Naming-And-Design-Rules-V2_1.pdf
- * http://www.ferd-net.de/upload/Dokumente/FACTUR-X_ZUGFeRD_2p0_Teil1_Profil_EN16931_1p03.pdf
-http://countwordsfree.com/xmlviewer
- */
-		ByteArrayOutputStream baos=new ByteArrayOutputStream();
-		try {
-			applySchematronXsl(new FileInputStream(xmlFilename), baos);
-		} catch (FileNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (TransformerException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		String res=null;
-		try {
-			res=baos.toString("UTF-8");
-		} catch (UnsupportedEncodingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return res;
-	}
+    static final ClassLoader CLASS_LOADER = ZUGFeRDMigrator.class.getClassLoader();
+    private static final String RESOURCE_PATH = ""; //$NON-NLS-1$
+    private static final Logger LOG = Logger.getLogger(ZUGFeRDMigrator.class.getName());
+//    private static File createTempFileResult(final Transformer transformer, final StreamSource toTransform,
+//            final String suffix) throws TransformerException, IOException {
+//        File result = File.createTempFile("ZUV_", suffix); //$NON-NLS-1$
+//        result.deleteOnExit();
+//
+//        try (FileOutputStream fos = new FileOutputStream(result)) {
+//            transformer.transform(toTransform, new StreamResult(fos));
+//        }
+//        return result;
+//    }
+    private TransformerFactory mFactory = null;
+    private Templates mXsltTemplate = null;
 
-	private static File createTempFileResult(final Transformer transformer, final StreamSource toTransform,
-			final String suffix) throws TransformerException, IOException {
-		File result = File.createTempFile("ZUV_", suffix); //$NON-NLS-1$
-		result.deleteOnExit();
+    public ZUGFeRDMigrator() {
+            mFactory = new net.sf.saxon.TransformerFactoryImpl();
+            //fact = TransformerFactory.newInstance();
+            mFactory.setURIResolver(new ClasspathResourceURIResolver());
+        try {
+            mXsltTemplate = mFactory.newTemplates(new StreamSource(CLASS_LOADER.getResourceAsStream(RESOURCE_PATH + "COMFORTtoEN16931.xsl")));
+        } catch (TransformerConfigurationException ex) {
+            LOG.log(Level.SEVERE, null, ex);
+        }
+    }
 
-		try (FileOutputStream fos = new FileOutputStream(result)) {
-			transformer.transform(toTransform, new StreamResult(fos));
-		}
-		return result;
-	}
-	
-	private static class ClasspathResourceURIResolver implements URIResolver {
-		ClasspathResourceURIResolver() {
-			// Do nothing, just prevents synthetic access warning.
-		}
+    public String migrateFromV1ToV2(String xmlFilename) throws FileNotFoundException, TransformerException, UnsupportedEncodingException {
+        /**
+         * *
+         * http://www.unece.org/fileadmin/DAM/cefact/xml/XML-Naming-And-Design-Rules-V2_1.pdf
+         * http://www.ferd-net.de/upload/Dokumente/FACTUR-X_ZUGFeRD_2p0_Teil1_Profil_EN16931_1p03.pdf
+         * http://countwordsfree.com/xmlviewer
+         */
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        applySchematronXsl(new FileInputStream(xmlFilename), baos);
+        String res = null;
+        res = baos.toString("UTF-8");
+        return res;
+    }
 
-		@Override
-		public Source resolve(String href, String base) throws TransformerException {
-			return new StreamSource(cl.getResourceAsStream(resourcePath + href));
-		}
-	}
-	
-	public static void applySchematronXsl(final InputStream xmlFile,
-			final OutputStream EN16931Outstream) throws TransformerException {
-		factory=getTransformerFactory();
-		Transformer transformer = factory.newTransformer(new StreamSource(cl.getResourceAsStream(resourcePath+"COMFORTtoEN16931.xsl")));
-		transformer.transform(new StreamSource(xmlFile), new StreamResult(EN16931Outstream));
-	}
+    public void applySchematronXsl(final InputStream xmlFile,
+            final OutputStream EN16931Outstream) throws TransformerException {
+        Transformer transformer = mXsltTemplate.newTransformer();
+        transformer.transform(new StreamSource(xmlFile), new StreamResult(EN16931Outstream));
+    }
 
+    private static class ClasspathResourceURIResolver implements URIResolver {
+        ClasspathResourceURIResolver() {
+            // Do nothing, just prevents synthetic access warning.
+        }
+
+        @Override
+        public Source resolve(String href, String base) throws TransformerException {
+            return new StreamSource(CLASS_LOADER.getResourceAsStream(RESOURCE_PATH + href));
+        }
+    }
 }

--- a/src/main/java/org/mustangproject/toecount/Toecount.java
+++ b/src/main/java/org/mustangproject/toecount/Toecount.java
@@ -2,26 +2,29 @@ package org.mustangproject.toecount;
 
 /***
  * This is the command line interface to mustangproject
- * 
+ *
  */
 
+import com.sanityinc.jargs.CmdLineParser;
+import com.sanityinc.jargs.CmdLineParser.Option;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.transform.TransformerException;
 import org.mustangproject.ZUGFeRD.ZUGFeRDConformanceLevel;
 import org.mustangproject.ZUGFeRD.ZUGFeRDExporter;
 import org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA1Factory;
 import org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA3Factory;
 import org.mustangproject.ZUGFeRD.ZUGFeRDImporter;
 import org.mustangproject.ZUGFeRD.ZUGFeRDMigrator;
-
-import com.sanityinc.jargs.CmdLineParser;
-import com.sanityinc.jargs.CmdLineParser.Option;
 
 public class Toecount {
 	// build with: /opt/local/bin/mvn clean compile assembly:single
@@ -53,7 +56,7 @@ public class Toecount {
 	/***
 	 * Asks the user for a String (offering a defaultValue) conforming to a Regex
 	 * pattern
-	 * 
+	 *
 	 * @param prompt
 	 * @param defaultValue
 	 * @param pattern
@@ -98,10 +101,10 @@ public class Toecount {
 	 * Prompts the user for a input or output filename
 	 * @param prompt
 	 * @param defaultFilename
-	 * @param expectedExtension will warn if filename does not match expected file extension 
+	 * @param expectedExtension will warn if filename does not match expected file extension
 	 * @param ensureFileExists will warn if file does NOT exist (for input files)
 	 * @param ensureFileNotExists will warn if file DOES exist (for output files)
-	 * 
+	 *
 	 * @return String
 	 */
 	protected static String getFilenameFromUser(String prompt, String defaultFilename, String expectedExtension, boolean ensureFileExists, boolean ensureFileNotExists) {
@@ -147,7 +150,7 @@ public class Toecount {
 					System.out.println("File does not exist, try again or CTRL+C to cancel");
 					// discard the input, a scanner.reset is not sufficient
 					fileExistenceOK = false;
-				}			
+				}
 			} else {
 				fileExistenceOK=true;
 
@@ -158,7 +161,7 @@ public class Toecount {
 						System.out.println("Output file already exists, try again or CTRL+C to cancel");
 						// discard the input, a scanner.reset is not sufficient
 
-					}			
+					}
 				} else {
 					fileExistenceOK=true;
 				}
@@ -275,12 +278,12 @@ public class Toecount {
 					String versionInput = "";
 					try {
 						versionInput = getStringFromUser("ZUGFeRD version (1 or 2)", "1", "1|2");
-						
+
 					} catch (Exception e) {
 						// TODO Auto-generated catch block
 						e.printStackTrace();
 					}
-					
+
 					String profileInput = "";
 					int zfIntVersion=Integer.valueOf(versionInput);
 
@@ -288,7 +291,7 @@ public class Toecount {
 					if (zfIntVersion==1) {
 						try {
 							profileInput = getStringFromUser("ZUGFeRD profile b)asic, c)omfort or e)xtended", "e", "B|b|C|c|E|e").toLowerCase();
-							
+
 						} catch (Exception e) {
 							// TODO Auto-generated catch block
 							e.printStackTrace();
@@ -296,17 +299,17 @@ public class Toecount {
 						if (profileInput.equals("b")) {
 							profile=ZUGFeRDConformanceLevel.BASIC;
 						} else if (profileInput.equals("c")) {
-							profile=ZUGFeRDConformanceLevel.COMFORT;						
+							profile=ZUGFeRDConformanceLevel.COMFORT;
 						} else if (profileInput.equals("e")) {
 							profile=ZUGFeRDConformanceLevel.EXTENDED;
-							
+
 						}
-						
+
 					} else if (zfIntVersion==2) {
 						try {
-							profileInput = getStringFromUser("ZUGFeRD profile  [M]INIMUM, BASIC [W]L, [B]ASIC,\n" + 
+							profileInput = getStringFromUser("ZUGFeRD profile  [M]INIMUM, BASIC [W]L, [B]ASIC,\n" +
 									"[C]IUS, [E]N16931, E[X]TENDED", "E", "M|m|W|w|B|b|C|c|E|e|X|x|").toLowerCase();
-							
+
 						} catch (Exception e) {
 							// TODO Auto-generated catch block
 							e.printStackTrace();
@@ -314,7 +317,7 @@ public class Toecount {
 						if (profileInput.equals("m")) {
 							profile=ZUGFeRDConformanceLevel.MINIMUM;
 						} else if (profileInput.equals("w")) {
-							profile=ZUGFeRDConformanceLevel.BASICWL;						
+							profile=ZUGFeRDConformanceLevel.BASICWL;
 						} else if (profileInput.equals("b")) {
 							profile=ZUGFeRDConformanceLevel.BASIC;
 						} else if (profileInput.equals("c")) {
@@ -324,13 +327,13 @@ public class Toecount {
 						} else if (profileInput.equals("x")) {
 							profile=ZUGFeRDConformanceLevel.EXTENDED;
 						}
-						
+
 					}
-					
+
 					ZUGFeRDExporter ze = new ZUGFeRDExporterFromA3Factory().setProducer("Toecount")
 							.setCreator(System.getProperty("user.name")).setZUGFeRDConformanceLevel(profile).load(pdfName);
 					ze.setZUGFeRDVersion(zfIntVersion);
-				
+
 					ze.setZUGFeRDXMLData(Files.readAllBytes(Paths.get(xmlName)));
 
 					ze.export(outName);
@@ -373,21 +376,25 @@ public class Toecount {
 				}
 				System.out.println("Written to " + outName);
 			} else if (upgradeRequested) {
-				String xmlName = "";
-				String outName = "";
+                try {
+                    String xmlName = "";
+                    String outName = "";
 
-				try {
-					xmlName = getFilenameFromUser("ZUGFeRD 1.0 XML source", "ZUGFeRD-invoice.xml", "xml", true, false);
-					outName = getFilenameFromUser("ZUGFeRD 2.0 XML target", "factur-x.xml", "xml", false, true);
+                    xmlName = getFilenameFromUser("ZUGFeRD 1.0 XML source", "ZUGFeRD-invoice.xml", "xml", true, false);
+                    outName = getFilenameFromUser("ZUGFeRD 2.0 XML target", "factur-x.xml", "xml", false, true);
 
-					ZUGFeRDMigrator zmi = new ZUGFeRDMigrator();
-					String xml = zmi.migrateFromV1ToV2(xmlName);
-					Files.write(Paths.get(outName), xml.getBytes());
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-				System.out.println("Written to " + outName);
-
+                    ZUGFeRDMigrator zmi = new ZUGFeRDMigrator();
+                    String xml = null;
+                    xml = zmi.migrateFromV1ToV2(xmlName);
+                    Files.write(Paths.get(outName), xml.getBytes());
+                    System.out.println("Written to " + outName);
+                } catch (FileNotFoundException ex) {
+                    Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
+                } catch (TransformerException | UnsupportedEncodingException ex) {
+                    Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
+                } catch (IOException ex) {
+                    Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
+                }
 			} else {
 				// no argument or argument unknown
 				printUsage();

--- a/src/test/java/org/mustangproject/ZUGFeRD/UpdateZUGFeRDTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/UpdateZUGFeRDTest.java
@@ -1,0 +1,88 @@
+/** **********************************************************************
+ *
+ * Copyright 2018 Jochen Staerk
+ *
+ * Use is subject to license terms.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0. You can also
+ * obtain a copy of the License at http://odftoolkit.org/docs/license.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *********************************************************************** */
+package org.mustangproject.ZUGFeRD;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.xml.transform.TransformerException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UpdateZUGFeRDTest {
+
+    private static final Logger LOG = Logger.getLogger(UpdateZUGFeRDTest.class.getName());
+
+    private static final String TEST_INPUT_NAME = "ZUGFeRD1-invoice_test-input.xml";
+    private static final String TEST_OUTPUT_NAME = "ZUGFeRD2-invoice_test-output.xml";
+    private static final String TEST_REF_NAME = "ZUGFeRD2-invoice_output-reference.xml";
+
+    private static final String TEST_INPUT_DIR = "src" + File.separator + "test" + File.separator + "resources" + File.separator;
+    private static final String TEST_OUTPUT_DIR = "target" + File.separator + "test-classes" + File.separator;
+
+    private static String readFile(Charset encoding, String path) throws IOException {
+        byte[] encoded = Files.readAllBytes(Paths.get(path));
+        return new String(encoded, encoding);
+    }
+
+    private static void saveFile(String content, String path) throws FileNotFoundException {
+        try (PrintWriter out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(new File(path)), StandardCharsets.UTF_8), true)) {
+            out.println(content);
+        }
+    }
+
+    @Test
+    public void testMigration() {
+        try {
+            String tmp = new ZUGFeRDMigrator().migrateFromV1ToV2(TEST_INPUT_DIR + TEST_INPUT_NAME);
+            saveFile(tmp, TEST_OUTPUT_DIR + TEST_OUTPUT_NAME);
+            LOG.log(Level.INFO, "***\nZUGFeRD 2.0:\n***\n{0}", tmp);
+
+            // we need to save the string and reload it otherwise two bytes are missing (likely EOF related)
+            String refXML = readFile(StandardCharsets.UTF_8, TEST_INPUT_DIR + TEST_REF_NAME);
+            String outXML = readFile(StandardCharsets.UTF_8, TEST_OUTPUT_DIR + TEST_OUTPUT_NAME);
+            int t = outXML.length();
+            int r = refXML.length();
+            if (t != r || !(outXML.equals(refXML))) {
+                LOG.info("Please compare:"
+                        + "\nZUGFeRD 2.0 Test Output: " + TEST_OUTPUT_DIR + TEST_OUTPUT_NAME
+                        + "\nZUGFeRD 2.0 Test Reference: " + TEST_INPUT_DIR  + TEST_REF_NAME);
+                LOG.info("\n\nFile sizes:\n "
+                        + "\nZUGFeRD 2.0 Test Output: " + t
+                        + "\nZUGFeRD 2.0 Test Reference: " + r);
+                Assert.fail("Version update failed, as test result and reference are different!");
+            }else{
+                LOG.log(Level.INFO, "***\nZUGFeRD 2.0 invoice:\n***\n{0}", outXML);
+            }
+        } catch (IOException | TransformerException t) {
+            LOG.log(Level.SEVERE, t.getMessage(), t);
+            Assert.fail("Failed with " + t.getClass().getName() + ": '" + t.getMessage() + "'");
+        }
+    }
+}

--- a/src/test/resources/ZUGFeRD1-invoice_test-input.xml
+++ b/src/test/resources/ZUGFeRD1-invoice_test-input.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rsm:CrossIndustryDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15" xmlns:rsm="urn:ferd:CrossIndustryDocument:invoice:1p0">
+    <rsm:SpecifiedExchangedDocumentContext>
+        <ram:TestIndicator>
+            <udt:Indicator>false</udt:Indicator>
+        </ram:TestIndicator>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:ferd:CrossIndustryDocument:invoice:1p0:extended</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:SpecifiedExchangedDocumentContext>
+    <rsm:HeaderExchangedDocument>
+        <ram:ID>RE-20170509/505</ram:ID>
+        <ram:Name>RECHNUNG</ram:Name>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20170509</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:HeaderExchangedDocument>
+    <rsm:SpecifiedSupplyChainTradeTransaction>
+        <ram:ApplicableSupplyChainTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Bei Spiel GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>12345</ram:PostcodeCode>
+                    <ram:LineOne>Ecke 12</ram:LineOne>
+                    <ram:CityName>Stadthausen</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="FC">22/815/0815/4</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE136695976</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Theodor Est</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>88802</ram:PostcodeCode>
+                    <ram:LineOne>Bahnstr. 42</ram:LineOne>
+                    <ram:CityName>Spielkreis</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE999999999</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableSupplyChainTradeAgreement>
+        <ram:ApplicableSupplyChainTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20170507</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableSupplyChainTradeDelivery>
+        <ram:ApplicableSupplyChainTradeSettlement>
+            <ram:PaymentReference>RE-20170509/505</ram:PaymentReference>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>42</ram:TypeCode>
+                <ram:Information>Überweisung</ram:Information>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:IBANID>DE88 2008 0000 0970 3757 00</ram:IBANID>
+                </ram:PayeePartyCreditorFinancialAccount>
+                <ram:PayeeSpecifiedCreditorFinancialInstitution>
+                    <ram:BICID>COBADEFFXXX</ram:BICID>
+                    <ram:Name>Commerzbank</ram:Name>
+                </ram:PayeeSpecifiedCreditorFinancialInstitution>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount currencyID="EUR">11.20</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount currencyID="EUR">160.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:ApplicablePercent>7.00</ram:ApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount currencyID="EUR">63.84</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount currencyID="EUR">336.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:ApplicablePercent>19.00</ram:ApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>Zahlbar ohne Abzug bis zum 30.05.2017</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20170530</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementMonetarySummation>
+                <ram:LineTotalAmount currencyID="EUR">496.00</ram:LineTotalAmount>
+                <ram:ChargeTotalAmount currencyID="EUR">0.00</ram:ChargeTotalAmount>
+                <ram:AllowanceTotalAmount currencyID="EUR">0.00</ram:AllowanceTotalAmount>
+                <ram:TaxBasisTotalAmount currencyID="EUR">496.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">75.04</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount currencyID="EUR">571.04</ram:GrandTotalAmount>
+                <ram:DuePayableAmount currencyID="EUR">571.04</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementMonetarySummation>
+        </ram:ApplicableSupplyChainTradeSettlement>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedSupplyChainTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">160.0000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">160.0000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedSupplyChainTradeAgreement>
+            <ram:SpecifiedSupplyChainTradeDelivery>
+                <ram:BilledQuantity unitCode="HUR">1.0000</ram:BilledQuantity>
+            </ram:SpecifiedSupplyChainTradeDelivery>
+            <ram:SpecifiedSupplyChainTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:ApplicablePercent>7.00</ram:ApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">160.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementMonetarySummation>
+            </ram:SpecifiedSupplyChainTradeSettlement>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Künstlerische Gestaltung (Stunde): Einer Beispielrechnung</ram:Name>
+                <ram:Description></ram:Description>
+            </ram:SpecifiedTradeProduct>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedSupplyChainTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.7900</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.7900</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedSupplyChainTradeAgreement>
+            <ram:SpecifiedSupplyChainTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">400.0000</ram:BilledQuantity>
+            </ram:SpecifiedSupplyChainTradeDelivery>
+            <ram:SpecifiedSupplyChainTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:ApplicablePercent>19.00</ram:ApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">316.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementMonetarySummation>
+            </ram:SpecifiedSupplyChainTradeSettlement>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Luftballon: Bunt, ca. 500ml</ram:Name>
+                <ram:Description></ram:Description>
+            </ram:SpecifiedTradeProduct>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>3</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedSupplyChainTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.1000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.1000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedSupplyChainTradeAgreement>
+            <ram:SpecifiedSupplyChainTradeDelivery>
+                <ram:BilledQuantity unitCode="LTR">200.0000</ram:BilledQuantity>
+            </ram:SpecifiedSupplyChainTradeDelivery>
+            <ram:SpecifiedSupplyChainTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:ApplicablePercent>19.00</ram:ApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">20.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementMonetarySummation>
+            </ram:SpecifiedSupplyChainTradeSettlement>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Heiße Luft pro Liter</ram:Name>
+                <ram:Description></ram:Description>
+            </ram:SpecifiedTradeProduct>
+        </ram:IncludedSupplyChainTradeLineItem>
+    </rsm:SpecifiedSupplyChainTradeTransaction>
+</rsm:CrossIndustryDocument>

--- a/src/test/resources/ZUGFeRD2-invoice_output-reference.xml
+++ b/src/test/resources/ZUGFeRD2-invoice_output-reference.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:qdt="urn:un:unece:uncefact:data:Standard:QualifiedDataType:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"><!--
+Migrated by Mustangproject XSLT
+--><rsm:ExchangedDocumentContext>
+        <ram:TestIndicator>
+            <udt:Indicator>false</udt:Indicator>
+        </ram:TestIndicator>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:ferd:CrossIndustryDocument:invoice:1p0:extended</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+   <rsm:ExchangedDocument xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100">
+        <ram:ID>RE-20170509/505</ram:ID>
+        <ram:Name>RECHNUNG</ram:Name>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20170509</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+   <rsm:SupplyChainTradeTransaction xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100">
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+                <ram:Name>Künstlerische Gestaltung (Stunde): Einer Beispielrechnung</ram:Name>
+                <ram:Description/>
+            </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">160.0000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">160.0000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="HUR">1.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">160.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+                <ram:Name>Luftballon: Bunt, ca. 500ml</ram:Name>
+                <ram:Description/>
+            </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.7900</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.7900</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">400.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">316.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>3</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+                <ram:Name>Heiße Luft pro Liter</ram:Name>
+                <ram:Description/>
+            </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.1000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">1.0000</ram:BasisQuantity>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">0.1000</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">1.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="LTR">200.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">20.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Bei Spiel GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>12345</ram:PostcodeCode>
+                    <ram:LineOne>Ecke 12</ram:LineOne>
+                    <ram:CityName>Stadthausen</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="FC">22/815/0815/4</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE136695976</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Theodor Est</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>88802</ram:PostcodeCode>
+                    <ram:LineOne>Bahnstr. 42</ram:LineOne>
+                    <ram:CityName>Spielkreis</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE999999999</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+      <ram:ApplicableHeaderTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20170507</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+      <ram:ApplicableHeaderTradeSettlement>
+            <ram:PaymentReference>RE-20170509/505</ram:PaymentReference>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentMeans>
+                <ram:TypeCode>42</ram:TypeCode>
+                <ram:Information>Überweisung</ram:Information>
+                <ram:PayeePartyCreditorFinancialAccount>
+                    <ram:IBANID>DE88 2008 0000 0970 3757 00</ram:IBANID>
+                </ram:PayeePartyCreditorFinancialAccount>
+                <ram:PayeeSpecifiedCreditorFinancialInstitution>
+                    <ram:BICID>COBADEFFXXX</ram:BICID>
+                    <ram:Name>Commerzbank</ram:Name>
+                </ram:PayeeSpecifiedCreditorFinancialInstitution>
+            </ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount currencyID="EUR">11.20</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount currencyID="EUR">160.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount currencyID="EUR">63.84</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount currencyID="EUR">336.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>Zahlbar ohne Abzug bis zum 30.05.2017</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20170530</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount currencyID="EUR">496.00</ram:LineTotalAmount>
+                <ram:ChargeTotalAmount currencyID="EUR">0.00</ram:ChargeTotalAmount>
+                <ram:AllowanceTotalAmount currencyID="EUR">0.00</ram:AllowanceTotalAmount>
+                <ram:TaxBasisTotalAmount currencyID="EUR">496.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">75.04</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount currencyID="EUR">571.04</ram:GrandTotalAmount>
+                <ram:DuePayableAmount currencyID="EUR">571.04</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+   </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>
+


### PR DESCRIPTION
…In addition, adding JUnit test, some copyright header, etc.

Some of the suggestions have been made by my Netbeans 8 IDE, like autoformatting including the ordering of imports, etc.

1) I have added latest SAXON, the prior issue of namespaces included in all XML children was obviously a bug of the XALAN XSLT processor bundled by the JDK. The bundling provides stability to users of various JDKs.
2) I have added AL2 Copyright header to files, so I learned it from various projects.
3) I exchanged all System.out within the adopted classes with Java Logging to allow future server usage.
4) Updated pom.xml to latest Maven compiler plugin

Some suggestions:
a) IIt might make sense to capsulate the XSLT migration into an own JAR, but this might be just taste and the size of SAXON might not be a problem.
b) I find it helpful understanding new Java software when it has been modulized by packages declaring  semantic packages. We might discuss this by phone.
c) I suggest to overtake 2) and 3) from above.


I might have missed some things, we just have a chat by phone next week..

Cheers,
Svante


