### PR TITLE
Wrong currency in xml part

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
@@ -88,6 +88,7 @@ class ZUGFeRDTransactionModelConverter {
     ZUGFeRDTransactionModelConverter(IZUGFeRDExportableTransaction trans) {
         this.trans = trans;
         totals = new Totals();
+        this.currency = trans.getCurrency() != null ? trans.getCurrency(): currency;
     }
 
 


### PR DESCRIPTION
Die Rechnung wird in einer Fremdwährung z.B. CHF (Schweitzer Franken) gestellt. Auf dem PDF wir der korrekte Währungscode angegeben, das ZUGFeRD-XML bekommt aber immer EUR.
So bekommt man anstelle einer 100,00 CHF Rechnung eine 100,00 EUR Rechnung.
