### PR TITLE
Commandline: ability to set input parameters

### DIFF
--- a/src/main/java/org/mustangproject/toecount/Toecount.java
+++ b/src/main/java/org/mustangproject/toecount/Toecount.java
@@ -188,242 +188,264 @@ public class Toecount {
 
 		} while (!fileExistenceOK);
 
-			return selectedName;
+		return selectedName;
+	}
+
+	// /opt/local/bin/mvn clean compile assembly:single
+	public static void main(String[] args) {
+		CmdLineParser parser = new CmdLineParser();
+		Option<String> dirnameOption = parser.addStringOption('d', "directory");
+		Option<Boolean> filesFromStdInOption = parser.addBooleanOption('l', "listfromstdin");
+		Option<Boolean> ignoreFileExtOption = parser.addBooleanOption('i', "ignorefileextension");
+		Option<Boolean> combineOption = parser.addBooleanOption('c', "combine");
+		Option<Boolean> extractOption = parser.addBooleanOption('e', "extract");
+		Option<Boolean> helpOption = parser.addBooleanOption('h', "help");
+		Option<Boolean> upgradeOption = parser.addBooleanOption('u', "upgrade");
+		Option<Boolean> a3onlyOption = parser.addBooleanOption('a', "a3only");
+		
+		try {
+			parser.parse(args);
+		} catch (CmdLineParser.OptionException e) {
+			System.err.println(e.getMessage());
+			printUsage();
+			System.exit(2);
 		}
 
-		// /opt/local/bin/mvn clean compile assembly:single
-		public static void main(String[] args) {
-			CmdLineParser parser = new CmdLineParser();
-			Option<String> dirnameOption = parser.addStringOption('d', "directory");
-			Option<Boolean> filesFromStdInOption = parser.addBooleanOption('l', "listfromstdin");
-			Option<Boolean> ignoreFileExtOption = parser.addBooleanOption('i', "ignorefileextension");
-			Option<Boolean> combineOption = parser.addBooleanOption('c', "combine");
-			Option<Boolean> extractOption = parser.addBooleanOption('e', "extract");
-			Option<Boolean> helpOption = parser.addBooleanOption('h', "help");
-			Option<Boolean> upgradeOption = parser.addBooleanOption('u', "upgrade");
-			Option<Boolean> a3onlyOption = parser.addBooleanOption('a', "a3only");
+		String directoryName = parser.getOptionValue(dirnameOption);
 
-			try {
-				parser.parse(args);
-			} catch (CmdLineParser.OptionException e) {
-				System.err.println(e.getMessage());
-				printUsage();
-				System.exit(2);
-			}
+		Boolean filesFromStdIn = parser.getOptionValue(filesFromStdInOption, Boolean.FALSE);
 
-			String directoryName = parser.getOptionValue(dirnameOption);
+		Boolean combineRequested = parser.getOptionValue(combineOption, Boolean.FALSE);
 
-			Boolean filesFromStdIn = parser.getOptionValue(filesFromStdInOption, Boolean.FALSE);
+		Boolean extractRequested = parser.getOptionValue(extractOption, Boolean.FALSE);
 
-			Boolean combineRequested = parser.getOptionValue(combineOption, Boolean.FALSE);
+		Boolean helpRequested = parser.getOptionValue(helpOption, Boolean.FALSE);
 
-			Boolean extractRequested = parser.getOptionValue(extractOption, Boolean.FALSE);
+		Boolean upgradeRequested = parser.getOptionValue(upgradeOption, Boolean.FALSE);
 
-			Boolean helpRequested = parser.getOptionValue(helpOption, Boolean.FALSE);
+		Boolean ignoreFileExt = parser.getOptionValue(ignoreFileExtOption, Boolean.FALSE);
 
-			Boolean upgradeRequested = parser.getOptionValue(upgradeOption, Boolean.FALSE);
+		Boolean a3only = parser.getOptionValue(a3onlyOption, Boolean.FALSE);
 
-			Boolean ignoreFileExt = parser.getOptionValue(ignoreFileExtOption, Boolean.FALSE);
+		if (helpRequested) {
+			printHelp();
+		}
 
-			Boolean a3only = parser.getOptionValue(a3onlyOption, Boolean.FALSE);
-
-			if (helpRequested) {
-				printHelp();
-			}
-
-			else if (((directoryName != null) && (directoryName.length() > 0)) || filesFromStdIn.booleanValue()) {
-
-				StatRun sr = new StatRun();
-				if (ignoreFileExt) {
-					sr.ignoreFileExtension();
-				}
-				if (directoryName != null) {
-					Path startingDir = Paths.get(directoryName);
-
-					if (Files.isRegularFile(startingDir)) {
-						String filename = startingDir.toString();
-						FileChecker fc = new FileChecker(filename, sr);
-
-						fc.checkForZUGFeRD();
-						System.out.print(fc.getOutputLine());
-
-					} else if (Files.isDirectory(startingDir)) {
-						FileTraverser pf = new FileTraverser(sr);
-						try {
-							Files.walkFileTree(startingDir, pf);
-						} catch (IOException e) {
-							// TODO Auto-generated catch block
-							e.printStackTrace();
-						}
-
-					}
-
-				}
-
-				if (filesFromStdIn) {
-					BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
-					String s;
-					try {
-						while ((s = in.readLine()) != null && s.length() != 0) {
-							FileChecker fc = new FileChecker(s, sr);
-
-							fc.checkForZUGFeRD();
-							System.out.print(fc.getOutputLine());
-
-						}
-					} catch (IOException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-
-				}
-				System.out.println(sr.getSummaryLine());
-			} else if (combineRequested) {
-				/*
-				 * ZUGFeRDExporter ze= new ZUGFeRDExporterFromA1Factory()
-				 * .setProducer("toecount") .setCreator(System.getProperty("user.name"))
-				 * .loadFromPDFA1("invoice.pdf");
-				 */
-				String pdfName = "";
-				String xmlName = "";
-				String outName = "";
-
-				try {
-
-					pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
-					xmlName = getFilenameFromUser("ZUGFeRD XML", "ZUGFeRD-invoice.xml", "xml", true, false);
-					outName = getFilenameFromUser("Ouput PDF", "invoice.ZUGFeRD.pdf", "pdf", false, true);
-					String versionInput = "";
-					try {
-						versionInput = getStringFromUser("ZUGFeRD version (1 or 2)", "1", "1|2");
-
-					} catch (Exception e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
-					}
-
-					String profileInput = "";
-					int zfIntVersion=Integer.valueOf(versionInput);
-
-					ZUGFeRDConformanceLevel profile=ZUGFeRDConformanceLevel.EXTENDED;
-					if (zfIntVersion==1) {
-						try {
-							profileInput = getStringFromUser("ZUGFeRD profile b)asic, c)omfort or e)xtended", "e", "B|b|C|c|E|e").toLowerCase();
-
-						} catch (Exception e) {
-							// TODO Auto-generated catch block
-							e.printStackTrace();
-						}
-						if (profileInput.equals("b")) {
-							profile=ZUGFeRDConformanceLevel.BASIC;
-						} else if (profileInput.equals("c")) {
-							profile=ZUGFeRDConformanceLevel.COMFORT;
-						} else if (profileInput.equals("e")) {
-							profile=ZUGFeRDConformanceLevel.EXTENDED;
-
-						}
-
-					} else if (zfIntVersion==2) {
-						try {
-							profileInput = getStringFromUser("ZUGFeRD profile  [M]INIMUM, BASIC [W]L, [B]ASIC,\n" +
-									"[C]IUS, [E]N16931, E[X]TENDED", "E", "M|m|W|w|B|b|C|c|E|e|X|x|").toLowerCase();
-
-						} catch (Exception e) {
-							// TODO Auto-generated catch block
-							e.printStackTrace();
-						}
-						if (profileInput.equals("m")) {
-							profile=ZUGFeRDConformanceLevel.MINIMUM;
-						} else if (profileInput.equals("w")) {
-							profile=ZUGFeRDConformanceLevel.BASICWL;
-						} else if (profileInput.equals("b")) {
-							profile=ZUGFeRDConformanceLevel.BASIC;
-						} else if (profileInput.equals("c")) {
-							profile=ZUGFeRDConformanceLevel.CIUS;
-						} else if (profileInput.equals("e")) {
-							profile=ZUGFeRDConformanceLevel.EN16931;
-						} else if (profileInput.equals("x")) {
-							profile=ZUGFeRDConformanceLevel.EXTENDED;
-						}
-
-					}
-
-					ZUGFeRDExporter ze = new ZUGFeRDExporterFromA1Factory().setProducer("Toecount")
-							.setCreator(System.getProperty("user.name")).setZUGFeRDConformanceLevel(profile).load(pdfName);
-					ze.setZUGFeRDVersion(zfIntVersion);
-
-					ze.setZUGFeRDXMLData(Files.readAllBytes(Paths.get(xmlName)));
-
-					ze.export(outName);
-				} catch (IOException e) {
-					e.printStackTrace();
-					// } catch (JAXBException e) {
-					// e.printStackTrace();
-				}
-				System.out.println("Written to " + outName);
-			} else if (extractRequested) {
-				ZUGFeRDImporter zi = new ZUGFeRDImporter();
-				String pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
-				String xmlName = getFilenameFromUser("ZUGFeRD XML", "ZUGFeRD-invoice.xml", "xml", false, true);
-
-				zi.extract(pdfName);
-				try {
-					byte[] XMLContent=zi.getRawXML();
-					if (XMLContent==null) {
-						System.err.println("No ZUGFeRD XML found in PDF file");
-						
-					} else {
-						Files.write(Paths.get(xmlName), XMLContent);
-						System.out.println("Written to " + xmlName);
-					}
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-
-			} else if (a3only) {
-				/*
-				 * ZUGFeRDExporter ze= new ZUGFeRDExporterFromA1Factory()
-				 * .setProducer("toecount") .setCreator(System.getProperty("user.name"))
-				 * .loadFromPDFA1("invoice.pdf");
-				 */
-				String pdfName = "";
-				String outName = "";
-				try {
-					pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
-					outName = getFilenameFromUser("Target PDF", "invoice.a3.pdf", "pdf", false, true);
-
-					ZUGFeRDExporter ze = new ZUGFeRDExporterFromA1Factory().setAttachZUGFeRDHeaders(false).load(pdfName);
-
-					ze.export(outName);
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-				System.out.println("Written to " + outName);
-			} else if (upgradeRequested) {
-                try {
-                    String xmlName = "";
-                    String outName = "";
-
-                    xmlName = getFilenameFromUser("ZUGFeRD 1.0 XML source", "ZUGFeRD-invoice.xml", "xml", true, false);
-                    outName = getFilenameFromUser("ZUGFeRD 2.0 XML target", "factur-x.xml", "xml", false, true);
-
-                    ZUGFeRDMigrator zmi = new ZUGFeRDMigrator();
-                    String xml = null;
-                    xml = zmi.migrateFromV1ToV2(xmlName);
-                    Files.write(Paths.get(outName), xml.getBytes());
-                    System.out.println("Written to " + outName);
-                } catch (FileNotFoundException ex) {
-                    Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
-                } catch (TransformerException | UnsupportedEncodingException ex) {
-                    Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
-                } catch (IOException ex) {
-                    Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
-                }
-			} else {
-				// no argument or argument unknown
-				printUsage();
-				System.exit(2);
-
-			}
+		else if (((directoryName != null) && (directoryName.length() > 0)) || filesFromStdIn.booleanValue()) {
+			performMetrics(directoryName, filesFromStdIn, ignoreFileExt);
+		} else if (combineRequested) {
+			performCombine();
+		} else if (extractRequested) {
+			performExtract();
+		} else if (a3only) {
+			performConvert();
+		} else if (upgradeRequested) {
+			performUpgrade();
+		} else {
+			// no argument or argument unknown
+			printUsage();
+			System.exit(2);
 		}
 	}
+
+	private static void performUpgrade() {
+		try {
+			String xmlName = "";
+			String outName = "";
+
+			xmlName = getFilenameFromUser("ZUGFeRD 1.0 XML source", "ZUGFeRD-invoice.xml", "xml", true, false);
+			outName = getFilenameFromUser("ZUGFeRD 2.0 XML target", "factur-x.xml", "xml", false, true);
+
+			ZUGFeRDMigrator zmi = new ZUGFeRDMigrator();
+			String xml = null;
+			xml = zmi.migrateFromV1ToV2(xmlName);
+			Files.write(Paths.get(outName), xml.getBytes());
+			System.out.println("Written to " + outName);
+		} catch (FileNotFoundException ex) {
+			Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
+		} catch (TransformerException | UnsupportedEncodingException ex) {
+			Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
+		} catch (IOException ex) {
+			Logger.getLogger(Toecount.class.getName()).log(Level.SEVERE, null, ex);
+		}
+	}
+
+	private static void performConvert() {
+		/*
+		 * ZUGFeRDExporter ze= new ZUGFeRDExporterFromA1Factory()
+		 * .setProducer("toecount") .setCreator(System.getProperty("user.name"))
+		 * .loadFromPDFA1("invoice.pdf");
+		 */
+		String pdfName = "";
+		String outName = "";
+		try {
+			pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
+			outName = getFilenameFromUser("Target PDF", "invoice.a3.pdf", "pdf", false, true);
+
+			ZUGFeRDExporter ze = new ZUGFeRDExporterFromA1Factory().setAttachZUGFeRDHeaders(false).load(pdfName);
+
+			ze.export(outName);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		System.out.println("Written to " + outName);
+	}
+
+	private static void performExtract() {
+		
+		ZUGFeRDImporter zi = new ZUGFeRDImporter();
+		String pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
+		String xmlName = getFilenameFromUser("ZUGFeRD XML", "ZUGFeRD-invoice.xml", "xml", false, true);
+
+		zi.extract(pdfName);
+		try {
+			byte[] XMLContent=zi.getRawXML();
+			if (XMLContent==null) {
+				System.err.println("No ZUGFeRD XML found in PDF file");
+				
+			} else {
+				Files.write(Paths.get(xmlName), XMLContent);
+				System.out.println("Written to " + xmlName);
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static void performCombine() {
+		/*
+		 * ZUGFeRDExporter ze= new ZUGFeRDExporterFromA1Factory()
+		 * .setProducer("toecount") .setCreator(System.getProperty("user.name"))
+		 * .loadFromPDFA1("invoice.pdf");
+		 */
+		String pdfName = "";
+		String xmlName = "";
+		String outName = "";
+
+		try {
+
+			pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
+			xmlName = getFilenameFromUser("ZUGFeRD XML", "ZUGFeRD-invoice.xml", "xml", true, false);
+			outName = getFilenameFromUser("Ouput PDF", "invoice.ZUGFeRD.pdf", "pdf", false, true);
+			String versionInput = "";
+			try {
+				versionInput = getStringFromUser("ZUGFeRD version (1 or 2)", "1", "1|2");
+
+			} catch (Exception e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+			String profileInput = "";
+			int zfIntVersion=Integer.valueOf(versionInput);
+
+			ZUGFeRDConformanceLevel profile=ZUGFeRDConformanceLevel.EXTENDED;
+			if (zfIntVersion==1) {
+				try {
+					profileInput = getStringFromUser("ZUGFeRD profile b)asic, c)omfort or e)xtended", "e", "B|b|C|c|E|e").toLowerCase();
+
+				} catch (Exception e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+				if (profileInput.equals("b")) {
+					profile=ZUGFeRDConformanceLevel.BASIC;
+				} else if (profileInput.equals("c")) {
+					profile=ZUGFeRDConformanceLevel.COMFORT;
+				} else if (profileInput.equals("e")) {
+					profile=ZUGFeRDConformanceLevel.EXTENDED;
+
+				}
+
+			} else if (zfIntVersion==2) {
+				try {
+					profileInput = getStringFromUser("ZUGFeRD profile  [M]INIMUM, BASIC [W]L, [B]ASIC,\n" +
+							"[C]IUS, [E]N16931, E[X]TENDED", "E", "M|m|W|w|B|b|C|c|E|e|X|x|").toLowerCase();
+
+				} catch (Exception e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+				if (profileInput.equals("m")) {
+					profile=ZUGFeRDConformanceLevel.MINIMUM;
+				} else if (profileInput.equals("w")) {
+					profile=ZUGFeRDConformanceLevel.BASICWL;
+				} else if (profileInput.equals("b")) {
+					profile=ZUGFeRDConformanceLevel.BASIC;
+				} else if (profileInput.equals("c")) {
+					profile=ZUGFeRDConformanceLevel.CIUS;
+				} else if (profileInput.equals("e")) {
+					profile=ZUGFeRDConformanceLevel.EN16931;
+				} else if (profileInput.equals("x")) {
+					profile=ZUGFeRDConformanceLevel.EXTENDED;
+				}
+
+			}
+
+			ZUGFeRDExporter ze = new ZUGFeRDExporterFromA1Factory().setProducer("Toecount")
+					.setCreator(System.getProperty("user.name")).setZUGFeRDConformanceLevel(profile).load(pdfName);
+			ze.setZUGFeRDVersion(zfIntVersion);
+
+			ze.setZUGFeRDXMLData(Files.readAllBytes(Paths.get(xmlName)));
+
+			ze.export(outName);
+		} catch (IOException e) {
+			e.printStackTrace();
+			// } catch (JAXBException e) {
+			// e.printStackTrace();
+		}
+
+		System.out.println("Written to " + outName);
+	}
+
+	private static void performMetrics(String directoryName, Boolean filesFromStdIn, Boolean ignoreFileExt) {
+
+		StatRun sr = new StatRun();
+		if (ignoreFileExt) {
+			sr.ignoreFileExtension();
+		}
+		if (directoryName != null) {
+			Path startingDir = Paths.get(directoryName);
+
+			if (Files.isRegularFile(startingDir)) {
+				String filename = startingDir.toString();
+				FileChecker fc = new FileChecker(filename, sr);
+
+				fc.checkForZUGFeRD();
+				System.out.print(fc.getOutputLine());
+
+			} else if (Files.isDirectory(startingDir)) {
+				FileTraverser pf = new FileTraverser(sr);
+				try {
+					Files.walkFileTree(startingDir, pf);
+				} catch (IOException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+
+			}
+
+		}
+
+		if (filesFromStdIn) {
+			BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+			String s;
+			try {
+				while ((s = in.readLine()) != null && s.length() != 0) {
+					FileChecker fc = new FileChecker(s, sr);
+
+					fc.checkForZUGFeRD();
+					System.out.print(fc.getOutputLine());
+
+				}
+			} catch (IOException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+		}
+		System.out.println(sr.getSummaryLine());
+	}
+
+	
+}


### PR DESCRIPTION
As discussed in #66 

I reworked only the `Toecount.java` file to offer more input arguments.
If an input argument is not set, then the user will be prompted like before (no change in behavior here).

The help message looks like this now:
```
Mustangproject.org 1.5.5-SNAPSHOT
A Apache Public License library and command line tool for statistics on PDF invoices with
ZUGFeRD Metadata (http://www.zugferd.org)

Usage: [-d,--directory] [-l,--listfromstdin] [-i,--ignorefileextension] | [-c,--combine] | [-e,--extract] | [-u,--upgrade] | [-a,--a3only] | [-h,--help]

* Count operations
        -d, --directory count ZUGFeRD files in directory to be scanned
                If it is a directory, it will recurse.
        -l, --listfromstdin     count ZUGFeRD files from a list of linefeed separated files on runtime.
                It will start once a blank line has been entered.

        Additional parameter for both count operations
        [-i, --ignorefileextension]     Check for all files (*.*) instead of PDF files only (*.pdf)

* Merge operations
        -e, --extract   extract ZUGFeRD PDF to XML file
                Additional parameters (optional - user will be prompted if not defined)
                [--source <filename>]: set input PDF file
                [--out <filename>]: set output XML file
        -u, --upgrade   upgrade ZUGFeRD XML to ZUGFeRD 2 XML
                Additional parameters (optional - user will be prompted if not defined)
                [--source <filename>]: set input XML ZUGFeRD 1 file
                [--out <filename>]: set output XML ZUGFeRD 2 file
        -a, --a3only    upgrade from PDF/A1 to A3 only (no ZUGFeRD data attached)
                Additional parameters (optional - user will be prompted if not defined)
                [--source <filename>]: set input PDF file
                [--out <filename>]: set output PDF file
        -c, --combine   combine XML and PDF file to ZUGFeRD PDF file
                Additional parameters (optional - user will be prompted if not defined)
                [--source <filename>]: set input PDF file
                [--source-xml <filename>]: set input XML file
                [--out <filename>]: set output PDF file
                [--zugferd-version <1|2>]: set ZUGFeRD version
                [--zugferd-profile <...>]: set ZUGFeRD profile
                        For ZUGFeRD v1: <B>ASIC, <C>OMFORT or <E>XTENDED
                        For ZUGFeRD v2: <M>INIMUM, BASIC <W>L, <B>ASIC, <C>IUS, <E>N16931, E<X>TENDED
```