### PR TITLE
Interface Methodes to default; Seller- / BuyerTradeParty: ID added; removed unnessesary this/typecast code

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
@@ -19,9 +19,7 @@
 package org.mustangproject.ZUGFeRD;
 
 /**
- * Mustangproject's ZUGFeRD implementation
- * Neccessary interface for ZUGFeRD exporter
- * Licensed under the APLv2
+ * Mustangproject's ZUGFeRD implementation Neccessary interface for ZUGFeRD exporter Licensed under the APLv2
  *
  * @author jstaerk
  * @version 1.2.0
@@ -32,11 +30,22 @@ package org.mustangproject.ZUGFeRD;
 public interface IZUGFeRDExportableContact {
 
 	/**
+	 * customer identification assigned by the seller
+	 *
+	 * @return customer identification
+	 */
+	default String getID() {
+		return null;
+	}
+
+
+	/**
 	 * First and last name of the recipient
 	 *
 	 * @return First and last name of the recipient
 	 */
 	String getName();
+
 
 	/**
 	 * Postal code of the recipient
@@ -45,12 +54,14 @@ public interface IZUGFeRDExportableContact {
 	 */
 	String getZIP();
 
+
 	/**
 	 * VAT ID (Umsatzsteueridentifikationsnummer) of the contact
 	 *
 	 * @return VAT ID (Umsatzsteueridentifikationsnummer) of the contact
 	 */
 	String getVATID();
+
 
 	/**
 	 * two-letter country code of the contact
@@ -59,12 +70,14 @@ public interface IZUGFeRDExportableContact {
 	 */
 	String getCountry();
 
+
 	/**
 	 * Returns the city of the contact
 	 *
 	 * @return Returns the city of the recipient
 	 */
 	String getLocation();
+
 
 	/**
 	 * Returns the street address (street+number) of the contact

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
@@ -36,45 +36,54 @@ public interface IZUGFeRDExportableTransaction {
 	 *
 	 * @return invoice number
 	 */
-	String getNumber();
+	default String getNumber() {
+		return null;
+	}
+
 
 	/**
 	 * the date when the invoice was created
 	 *
 	 * @return when the invoice was created
 	 */
-	Date getIssueDate();
+	default Date getIssueDate() {
+		return null;
+	}
+
 
 	/**
-	 * this should be the full sender institution name, details, manager and tax registration.
-	 * It is one of the few functions which may return null.
-	 * e.g.
+	 * this should be the full sender institution name, details, manager and tax registration. It is one of the few functions which may return null. e.g.
 	 * <p/>
-	 * Lieferant GmbH
-	 * Lieferantenstraße 20
-	 * 80333 München
-	 * Deutschland
-	 * Geschäftsführer: Hans Muster
-	 * Handelsregisternummer: H A 123
+	 * Lieferant GmbH Lieferantenstraße 20 80333 München Deutschland Geschäftsführer: Hans Muster Handelsregisternummer: H A 123
 	 *
 	 * @return null or full sender institution name, details, manager and tax registration
 	 */
-	String getOwnOrganisationFullPlaintextInfo();
+	default String getOwnOrganisationFullPlaintextInfo() {
+		return null;
+	}
+
 
 	/**
 	 * when the invoice is to be paid
 	 *
 	 * @return when the invoice is to be paid
 	 */
-	Date getDueDate();
+	default Date getDueDate() {
+		return null;
+	}
+
 
 	IZUGFeRDAllowanceCharge[] getZFAllowances();
 
+
 	IZUGFeRDAllowanceCharge[] getZFCharges();
+
 
 	IZUGFeRDAllowanceCharge[] getZFLogisticsServiceCharges();
 
+
 	IZUGFeRDExportableItem[] getZFItems();
+
 
 	/**
 	 * the recipient
@@ -83,89 +92,136 @@ public interface IZUGFeRDExportableTransaction {
 	 */
 	IZUGFeRDExportableContact getRecipient();
 
+
 	/**
 	 * BIC of the sender
 	 *
 	 * @return the BIC code of the recipient sender's bank
 	 */
-	String getOwnBIC();
+	default String getOwnBIC() {
+		return null;
+	}
+
 
 	/**
 	 * BLZ of the sender
 	 *
 	 * @return the BLZ code of the recipient sender's bank
 	 */
-	String getOwnBLZ();
+	default String getOwnBLZ() {
+		return null;
+	}
+
 
 	/**
 	 * Bank name of the sender
 	 *
 	 * @return the name of the sender's bank
 	 */
-	String getOwnBankName();
+	default String getOwnBankName() {
+		return null;
+	}
+
 
 	/**
 	 * IBAN of the sender
 	 *
 	 * @return the IBAN of the invoice sender's bank account
 	 */
-	String getOwnIBAN();
+	default String getOwnIBAN() {
+		return null;
+	}
+
 
 	/**
 	 * IBAN of the sender
 	 *
 	 * @return the Account Number of the invoice sender's bank account
 	 */
-	String getOwnKto();
+	default String getOwnKto() {
+		return null;
+	}
+
 
 	/**
 	 * Tax ID (not VAT ID) of the sender
 	 *
 	 * @return Tax ID (not VAT ID) of the sender
 	 */
-	String getOwnTaxID();
+	default String getOwnTaxID() {
+		return null;
+	}
+
 
 	/**
 	 * VAT ID (Umsatzsteueridentifikationsnummer) of the sender
 	 *
 	 * @return VAT ID (Umsatzsteueridentifikationsnummer) of the sender
 	 */
-	String getOwnVATID();
+	default String getOwnVATID() {
+		return null;
+	}
+
+
+	/**
+	 * supplier identification assigned by the costumer
+	 *
+	 * @return the sender's identification
+	 */
+	default String getOwnForeignOrganisationID() {
+		return null;
+	}
+
 
 	/**
 	 * own name
 	 *
 	 * @return the sender's organisation name
 	 */
-	String getOwnOrganisationName();
+	default String getOwnOrganisationName() {
+		return null;
+	}
+
 
 	/**
 	 * own street address
 	 *
 	 * @return sender street address
 	 */
-	String getOwnStreet();
+	default String getOwnStreet() {
+		return null;
+	}
+
 
 	/**
 	 * own street postal code
 	 *
 	 * @return sender postal code
 	 */
-	String getOwnZIP();
+	default String getOwnZIP() {
+		return null;
+	}
+
 
 	/**
 	 * own city
 	 *
 	 * @return the invoice sender's city
 	 */
-	String getOwnLocation();
+	default String getOwnLocation() {
+		return null;
+	}
+
 
 	/**
 	 * own two digit country code
 	 *
 	 * @return the invoice senders two character country iso code
 	 */
-	String getOwnCountry();
+	default String getOwnCountry() {
+		return null;
+	}
+
 
 	/**
 	 * get delivery date
@@ -174,35 +230,44 @@ public interface IZUGFeRDExportableTransaction {
 	 */
 	Date getDeliveryDate();
 
+
 	/**
 	 * get main invoice currency used on the invoice
 	 *
 	 * @return three character currency of this invoice
 	 */
-	String getCurrency();
+	default String getCurrency() {
+		return null;
+	}
+
 
 	/**
 	 * get payment information text. e.g. Bank transfer
 	 *
 	 * @return payment information text
 	 */
-	String getOwnPaymentInfoText();
+	default String getOwnPaymentInfoText() {
+		return null;
+	}
+
 
 	/**
-	 * get payment term descriptional text
-	 * e.g. Bis zum 22.10.2015 ohne Abzug
+	 * get payment term descriptional text e.g. Bis zum 22.10.2015 ohne Abzug
 	 *
 	 * @return get payment terms
 	 */
-	String getPaymentTermDescription();
+	default String getPaymentTermDescription() {
+		return null;
+	}
+
 
 	/**
-	 * get reference document number
-	 * typically used for Invoice Corrections
-	 * Will be added as IncludedNote in comfort profile
+	 * get reference document number typically used for Invoice Corrections Will be added as IncludedNote in comfort profile
 	 *
 	 * @return the ID of the document this document refers to
 	 */
-	String getReferenceNumber();
+	default String getReferenceNumber() {
+		return null;
+	}
 
 }

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
@@ -18,14 +18,65 @@
  *********************************************************************** */
 package org.mustangproject.ZUGFeRD;
 
-import org.mustangproject.ZUGFeRD.model.*;
-
-import javax.xml.bind.JAXBElement;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import javax.xml.bind.JAXBElement;
+
+import org.mustangproject.ZUGFeRD.model.AmountType;
+import org.mustangproject.ZUGFeRD.model.CodeType;
+import org.mustangproject.ZUGFeRD.model.CountryIDType;
+import org.mustangproject.ZUGFeRD.model.CreditorFinancialAccountType;
+import org.mustangproject.ZUGFeRD.model.CreditorFinancialInstitutionType;
+import org.mustangproject.ZUGFeRD.model.CrossIndustryDocumentType;
+import org.mustangproject.ZUGFeRD.model.DateTimeType;
+import org.mustangproject.ZUGFeRD.model.DateTimeTypeConstants;
+import org.mustangproject.ZUGFeRD.model.DocumentCodeType;
+import org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants;
+import org.mustangproject.ZUGFeRD.model.DocumentContextParameterType;
+import org.mustangproject.ZUGFeRD.model.DocumentContextParameterTypeConstants;
+import org.mustangproject.ZUGFeRD.model.DocumentLineDocumentType;
+import org.mustangproject.ZUGFeRD.model.ExchangedDocumentContextType;
+import org.mustangproject.ZUGFeRD.model.ExchangedDocumentType;
+import org.mustangproject.ZUGFeRD.model.IDType;
+import org.mustangproject.ZUGFeRD.model.IndicatorType;
+import org.mustangproject.ZUGFeRD.model.LogisticsServiceChargeType;
+import org.mustangproject.ZUGFeRD.model.NoteType;
+import org.mustangproject.ZUGFeRD.model.NoteTypeConstants;
+import org.mustangproject.ZUGFeRD.model.ObjectFactory;
+import org.mustangproject.ZUGFeRD.model.PaymentMeansCodeType;
+import org.mustangproject.ZUGFeRD.model.PaymentMeansCodeTypeConstants;
+import org.mustangproject.ZUGFeRD.model.PercentType;
+import org.mustangproject.ZUGFeRD.model.QuantityType;
+import org.mustangproject.ZUGFeRD.model.SupplyChainEventType;
+import org.mustangproject.ZUGFeRD.model.SupplyChainTradeAgreementType;
+import org.mustangproject.ZUGFeRD.model.SupplyChainTradeDeliveryType;
+import org.mustangproject.ZUGFeRD.model.SupplyChainTradeLineItemType;
+import org.mustangproject.ZUGFeRD.model.SupplyChainTradeSettlementType;
+import org.mustangproject.ZUGFeRD.model.SupplyChainTradeTransactionType;
+import org.mustangproject.ZUGFeRD.model.TaxCategoryCodeType;
+import org.mustangproject.ZUGFeRD.model.TaxCategoryCodeTypeConstants;
+import org.mustangproject.ZUGFeRD.model.TaxRegistrationType;
+import org.mustangproject.ZUGFeRD.model.TaxRegistrationTypeConstants;
+import org.mustangproject.ZUGFeRD.model.TaxTypeCodeType;
+import org.mustangproject.ZUGFeRD.model.TaxTypeCodeTypeConstants;
+import org.mustangproject.ZUGFeRD.model.TextType;
+import org.mustangproject.ZUGFeRD.model.TradeAddressType;
+import org.mustangproject.ZUGFeRD.model.TradeAllowanceChargeType;
+import org.mustangproject.ZUGFeRD.model.TradePartyType;
+import org.mustangproject.ZUGFeRD.model.TradePaymentTermsType;
+import org.mustangproject.ZUGFeRD.model.TradePriceType;
+import org.mustangproject.ZUGFeRD.model.TradeProductType;
+import org.mustangproject.ZUGFeRD.model.TradeSettlementMonetarySummationType;
+import org.mustangproject.ZUGFeRD.model.TradeSettlementPaymentMeansType;
+import org.mustangproject.ZUGFeRD.model.TradeTaxType;
 
 class ZUGFeRDTransactionModelConverter {
 	private static final SimpleDateFormat zugferdDateFormat = new SimpleDateFormat("yyyyMMdd");
@@ -36,10 +87,11 @@ class ZUGFeRDTransactionModelConverter {
 	private boolean isTest;
 	private String currency = "EUR";
 
+
 	ZUGFeRDTransactionModelConverter(IZUGFeRDExportableTransaction trans) {
 		this.trans = trans;
 		totals = new Totals();
-		this.currency = trans.getCurrency() != null ? trans.getCurrency() : currency;
+		currency = trans.getCurrency() != null ? trans.getCurrency() : currency;
 	}
 
 
@@ -47,14 +99,14 @@ class ZUGFeRDTransactionModelConverter {
 		CrossIndustryDocumentType invoice = xmlFactory
 				.createCrossIndustryDocumentType();
 
-		invoice.setSpecifiedExchangedDocumentContext(this.getDocumentContext());
-		invoice.setHeaderExchangedDocument(this.getDocument());
-		invoice.setSpecifiedSupplyChainTradeTransaction(this
-				.getTradeTransaction());
+		invoice.setSpecifiedExchangedDocumentContext(getDocumentContext());
+		invoice.setHeaderExchangedDocument(getDocument());
+		invoice.setSpecifiedSupplyChainTradeTransaction(getTradeTransaction());
 
 		return xmlFactory
 				.createCrossIndustryDocument(invoice);
 	}
+
 
 	private ExchangedDocumentContextType getDocumentContext() {
 
@@ -74,6 +126,7 @@ class ZUGFeRDTransactionModelConverter {
 
 		return context;
 	}
+
 
 	private ExchangedDocumentType getDocument() {
 
@@ -124,36 +177,44 @@ class ZUGFeRDTransactionModelConverter {
 		return document;
 	}
 
+
 	private SupplyChainTradeTransactionType getTradeTransaction() {
 
 		SupplyChainTradeTransactionType transaction = xmlFactory
 				.createSupplyChainTradeTransactionType();
 		transaction.getApplicableSupplyChainTradeAgreement().add(
-				this.getTradeAgreement());
-		transaction.setApplicableSupplyChainTradeDelivery(this
-				.getTradeDelivery());
-		transaction.setApplicableSupplyChainTradeSettlement(this
-				.getTradeSettlement());
+				getTradeAgreement());
+		transaction.setApplicableSupplyChainTradeDelivery(getTradeDelivery());
+		transaction.setApplicableSupplyChainTradeSettlement(getTradeSettlement());
 		transaction.getIncludedSupplyChainTradeLineItem().addAll(
-				this.getLineItems());
+				getLineItems());
 
 		return transaction;
 	}
+
 
 	private SupplyChainTradeAgreementType getTradeAgreement() {
 
 		SupplyChainTradeAgreementType tradeAgreement = xmlFactory
 				.createSupplyChainTradeAgreementType();
 
-		tradeAgreement.setBuyerTradeParty(this.getBuyer());
-		tradeAgreement.setSellerTradeParty(this.getSeller());
+		tradeAgreement.setBuyerTradeParty(getBuyer());
+		tradeAgreement.setSellerTradeParty(getSeller());
 
 		return tradeAgreement;
 	}
 
+
 	private TradePartyType getBuyer() {
 
 		TradePartyType buyerTradeParty = xmlFactory.createTradePartyType();
+
+		if (trans.getRecipient().getID() != null) {
+			IDType buyerID = xmlFactory.createIDType();
+			buyerID.setValue(trans.getRecipient().getID());
+			buyerTradeParty.getID().add(buyerID);
+		}
+
 		TextType buyerName = xmlFactory.createTextType();
 		buyerName.setValue(trans.getRecipient().getName());
 		buyerTradeParty.setName(buyerName);
@@ -189,9 +250,17 @@ class ZUGFeRDTransactionModelConverter {
 		return buyerTradeParty;
 	}
 
+
 	private TradePartyType getSeller() {
 
 		TradePartyType sellerTradeParty = xmlFactory.createTradePartyType();
+
+		if (trans.getOwnForeignOrganisationID() != null) {
+			IDType sellerID = xmlFactory.createIDType();
+			sellerID.setValue(trans.getOwnForeignOrganisationID());
+			sellerTradeParty.getID().add(sellerID);
+		}
+
 		TextType sellerName = xmlFactory.createTextType();
 		sellerName.setValue(trans.getOwnOrganisationName());
 		sellerTradeParty.setName(sellerName);
@@ -238,6 +307,7 @@ class ZUGFeRDTransactionModelConverter {
 		return sellerTradeParty;
 	}
 
+
 	private SupplyChainTradeDeliveryType getTradeDelivery() {
 
 		SupplyChainTradeDeliveryType tradeDelivery = xmlFactory
@@ -257,6 +327,7 @@ class ZUGFeRDTransactionModelConverter {
 		return tradeDelivery;
 	}
 
+
 	private SupplyChainTradeSettlementType getTradeSettlement() {
 		SupplyChainTradeSettlementType tradeSettlement = xmlFactory
 				.createSupplyChainTradeSettlementType();
@@ -270,28 +341,28 @@ class ZUGFeRDTransactionModelConverter {
 		tradeSettlement.setInvoiceCurrencyCode(currencyCode);
 
 		tradeSettlement.getSpecifiedTradeSettlementPaymentMeans().add(
-				this.getPaymentData());
-		tradeSettlement.getApplicableTradeTax().addAll(this.getTradeTax());
+				getPaymentData());
+		tradeSettlement.getApplicableTradeTax().addAll(getTradeTax());
 		tradeSettlement.getSpecifiedTradePaymentTerms().addAll(
-				this.getPaymentTerms());
+				getPaymentTerms());
 		if (trans.getZFAllowances() != null) {
 			tradeSettlement.getSpecifiedTradeAllowanceCharge().addAll(
-					this.getHeaderAllowances());
+					getHeaderAllowances());
 		}
 		if (trans.getZFLogisticsServiceCharges() != null) {
 			tradeSettlement.getSpecifiedLogisticsServiceCharge().addAll(
-					this.getHeaderLogisticsServiceCharges());
+					getHeaderLogisticsServiceCharges());
 		}
 		if (trans.getZFCharges() != null) {
 			tradeSettlement.getSpecifiedTradeAllowanceCharge().addAll(
-					this.getHeaderCharges());
+					getHeaderCharges());
 		}
 
-		tradeSettlement.setSpecifiedTradeSettlementMonetarySummation(this
-				.getMonetarySummation());
+		tradeSettlement.setSpecifiedTradeSettlementMonetarySummation(getMonetarySummation());
 
 		return tradeSettlement;
 	}
+
 
 	private TradeSettlementPaymentMeansType getPaymentData() {
 		TradeSettlementPaymentMeansType paymentData = xmlFactory
@@ -335,8 +406,9 @@ class ZUGFeRDTransactionModelConverter {
 		return paymentData;
 	}
 
+
 	private Collection<TradeTaxType> getTradeTax() {
-		List<TradeTaxType> tradeTaxTypes = new ArrayList<TradeTaxType>();
+		List<TradeTaxType> tradeTaxTypes = new ArrayList<>();
 
 		HashMap<BigDecimal, VATAmount> VATPercentAmountMap = this
 				.getVATPercentAmountMap();
@@ -375,8 +447,9 @@ class ZUGFeRDTransactionModelConverter {
 		return tradeTaxTypes;
 	}
 
+
 	private Collection<TradeAllowanceChargeType> getHeaderAllowances() {
-		List<TradeAllowanceChargeType> headerAllowances = new ArrayList<TradeAllowanceChargeType>();
+		List<TradeAllowanceChargeType> headerAllowances = new ArrayList<>();
 
 		for (IZUGFeRDAllowanceCharge iAllowance : trans.getZFAllowances()) {
 
@@ -426,8 +499,9 @@ class ZUGFeRDTransactionModelConverter {
 		return headerAllowances;
 	}
 
+
 	private Collection<TradeAllowanceChargeType> getHeaderCharges() {
-		List<TradeAllowanceChargeType> headerCharges = new ArrayList<TradeAllowanceChargeType>();
+		List<TradeAllowanceChargeType> headerCharges = new ArrayList<>();
 
 		for (IZUGFeRDAllowanceCharge iCharge : trans.getZFCharges()) {
 
@@ -477,8 +551,9 @@ class ZUGFeRDTransactionModelConverter {
 		return headerCharges;
 	}
 
+
 	private Collection<LogisticsServiceChargeType> getHeaderLogisticsServiceCharges() {
-		List<LogisticsServiceChargeType> headerServiceCharge = new ArrayList<LogisticsServiceChargeType>();
+		List<LogisticsServiceChargeType> headerServiceCharge = new ArrayList<>();
 
 		for (IZUGFeRDAllowanceCharge iServiceCharge : trans
 				.getZFLogisticsServiceCharges()) {
@@ -526,8 +601,9 @@ class ZUGFeRDTransactionModelConverter {
 		return headerServiceCharge;
 	}
 
+
 	private Collection<TradePaymentTermsType> getPaymentTerms() {
-		List<TradePaymentTermsType> paymentTerms = new ArrayList<TradePaymentTermsType>();
+		List<TradePaymentTermsType> paymentTerms = new ArrayList<>();
 
 		TradePaymentTermsType paymentTerm = xmlFactory
 				.createTradePaymentTermsType();
@@ -552,6 +628,7 @@ class ZUGFeRDTransactionModelConverter {
 
 		return paymentTerms;
 	}
+
 
 	private TradeSettlementMonetarySummationType getMonetarySummation() {
 		TradeSettlementMonetarySummationType monetarySummation = xmlFactory
@@ -630,9 +707,10 @@ class ZUGFeRDTransactionModelConverter {
 		return monetarySummation;
 	}
 
+
 	private Collection<SupplyChainTradeLineItemType> getLineItems() {
 
-		ArrayList<SupplyChainTradeLineItemType> lineItems = new ArrayList<SupplyChainTradeLineItemType>();
+		ArrayList<SupplyChainTradeLineItemType> lineItems = new ArrayList<>();
 		int lineID = 0;
 		for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
 			lineID++;
@@ -777,21 +855,26 @@ class ZUGFeRDTransactionModelConverter {
 		return lineItems;
 	}
 
+
 	private BigDecimal vatFormat(BigDecimal value) {
 		return nDigitFormat(value, 2);
 	}
+
 
 	private BigDecimal currencyFormat(BigDecimal value) {
 		return nDigitFormat(value, 2);
 	}
 
+
 	private BigDecimal priceFormat(BigDecimal value) {
 		return nDigitFormat(value, 4);
 	}
 
+
 	private BigDecimal quantityFormat(BigDecimal value) {
 		return nDigitFormat(value, 4);
 	}
+
 
 	private BigDecimal nDigitFormat(BigDecimal value, int scale) {
 		/*
@@ -837,11 +920,10 @@ class ZUGFeRDTransactionModelConverter {
 
 	}
 
+
 	/**
-	 * which taxes have been used with which amounts in this transaction, empty
-	 * for no taxes, or e.g. 19=>190 and 7=>14 if 1000 Eur were applicable to
-	 * 19% VAT (=>190 EUR VAT) and 200 EUR were applicable to 7% (=>14 EUR VAT)
-	 * 190 Eur
+	 * which taxes have been used with which amounts in this transaction, empty for no taxes, or e.g. 19=>190 and 7=>14 if 1000 Eur were applicable to 19% VAT
+	 * (=>190 EUR VAT) and 200 EUR were applicable to 7% (=>14 EUR VAT) 190 Eur
 	 *
 	 * @return HashMap<BigDecimal, VATAmount> which taxes have been used with which amounts
 	 */
@@ -849,9 +931,10 @@ class ZUGFeRDTransactionModelConverter {
 		return getVATPercentAmountMap(false);
 	}
 
+
 	private HashMap<BigDecimal, VATAmount> getVATPercentAmountMap(
 			Boolean itemOnly) {
-		HashMap<BigDecimal, VATAmount> hm = new HashMap<BigDecimal, VATAmount>();
+		HashMap<BigDecimal, VATAmount> hm = new HashMap<>();
 
 		for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
 			BigDecimal percent = currentItem.getProduct().getVATPercent();
@@ -874,8 +957,8 @@ class ZUGFeRDTransactionModelConverter {
 				BigDecimal percent = headerAllowance.getTaxPercent();
 				VATAmount itemVATAmount = new VATAmount(
 						headerAllowance.getTotalAmount(), headerAllowance
-						.getTotalAmount().multiply(percent)
-						.divide(new BigDecimal(100)));
+								.getTotalAmount().multiply(percent)
+								.divide(new BigDecimal(100)));
 				VATAmount current = hm.get(percent);
 				if (current == null) {
 					hm.put(percent, itemVATAmount);
@@ -907,7 +990,7 @@ class ZUGFeRDTransactionModelConverter {
 				BigDecimal percent = charge.getTaxPercent();
 				VATAmount itemVATAmount = new VATAmount(
 						charge.getTotalAmount(), charge.getTotalAmount()
-						.multiply(percent).divide(new BigDecimal(100)));
+								.multiply(percent).divide(new BigDecimal(100)));
 				VATAmount current = hm.get(percent);
 				if (current == null) {
 					hm.put(percent, itemVATAmount);
@@ -920,6 +1003,7 @@ class ZUGFeRDTransactionModelConverter {
 		return hm;
 	}
 
+
 	ZUGFeRDTransactionModelConverter withTest(boolean isTest) {
 		this.isTest = isTest;
 		return this;
@@ -931,6 +1015,7 @@ class ZUGFeRDTransactionModelConverter {
 		private BigDecimal itemTotalNetAmount;
 		private BigDecimal itemTotalVATAmount;
 		private BigDecimal itemNetAmount;
+
 
 		public LineCalc(IZUGFeRDExportableItem currentItem) {
 			BigDecimal totalAllowance = BigDecimal.ZERO;
@@ -974,13 +1059,16 @@ class ZUGFeRDTransactionModelConverter {
 							BigDecimal.ROUND_HALF_UP);
 		}
 
+
 		public BigDecimal getItemTotalNetAmount() {
 			return itemTotalNetAmount;
 		}
 
+
 		public BigDecimal getItemTotalVATAmount() {
 			return itemTotalVATAmount;
 		}
+
 
 		public BigDecimal getItemNetAmount() {
 			return itemNetAmount;
@@ -994,6 +1082,7 @@ class ZUGFeRDTransactionModelConverter {
 		private BigDecimal lineTotalAmount;
 		private BigDecimal totalTaxAmount;
 
+
 		public Totals() {
 			BigDecimal res = BigDecimal.ZERO;
 			for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
@@ -1001,7 +1090,7 @@ class ZUGFeRDTransactionModelConverter {
 				res = res.add(lc.getItemTotalNetAmount());
 			}
 			// Set line total
-			this.lineTotalAmount = res;
+			lineTotalAmount = res;
 
 			if (trans.getZFAllowances() != null) {
 				for (IZUGFeRDAllowanceCharge headerAllowance : trans
@@ -1024,7 +1113,7 @@ class ZUGFeRDTransactionModelConverter {
 			}
 
 			// Set total net amount
-			this.totalNetAmount = res;
+			totalNetAmount = res;
 
 			HashMap<BigDecimal, VATAmount> VATPercentAmountMap = getVATPercentAmountMap();
 			for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
@@ -1033,23 +1122,27 @@ class ZUGFeRDTransactionModelConverter {
 			}
 
 			// Set total gross amount
-			this.totalGrossAmount = res;
+			totalGrossAmount = res;
 
-			this.totalTaxAmount = this.totalGrossAmount
-					.subtract(this.totalNetAmount);
+			totalTaxAmount = totalGrossAmount
+					.subtract(totalNetAmount);
 		}
+
 
 		public BigDecimal getTotalNet() {
 			return totalNetAmount;
 		}
 
+
 		public BigDecimal getTotalGross() {
 			return totalGrossAmount;
 		}
 
+
 		public BigDecimal getLineTotal() {
 			return lineTotalAmount;
 		}
+
 
 		public BigDecimal getTaxTotal() {
 			return totalTaxAmount;


### PR DESCRIPTION
IZUGFeRDExportableTransaction: Interface-Methodes switched to default, so they don't have to be implementend in inheriting classes when not needed

IZUGFeRDExportableContact: added getID() to return a unique customer ID
assigned by the seller > BuyerTradeParty.ID

ZUGFeRDTransactionModelConverter: getBuyer() and getSeller() adjusted.
add ID to XML if available

removed unnecessary this. and typecast