### PR TITLE
Fix Issue #90: PDF/A-3 conversion missing in ZUGFeRDExporter.export(O…

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -354,7 +354,10 @@ public class ZUGFeRDExporter implements Closeable {
 	}
 
 	public void export(OutputStream output) throws IOException {
-		if (!fileAttached) {
+		if (!documentPrepared) {
+			prepareDocument();
+		}
+		if ((!fileAttached) && (attachZUGFeRDHeaders)) {
 			throw new IOException(
 					"File must be attached (usually with PDFattachZugferdFile) before perfoming this operation");
 		}


### PR DESCRIPTION
Fix for Issue #90: PDF/A-3 conversion missing in ZUGFeRDExporter.export(OutputStream output)
https://github.com/ZUGFeRD/mustangproject/issues/90

I added a PDF/A-3 check function to `MustangReaderWriterTest` and created `testMigratePDFA1ToA3Stream` to test the change. Additionally I called the PDF/A-3 check from the existing `testMigratePDFA1ToA3` which already converts to PDF/A-3.