### PR TITLE
Byte order marks cause unit test failures with Java 1.8

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -369,7 +369,7 @@ public class ZUGFeRDImporter {
 	static String convertStreamToString(java.io.InputStream is) {
 		// source https://stackoverflow.com/questions/309424/how-do-i-read-convert-an-inputstream-into-a-string-in-java referring to
 		// https://community.oracle.com/blogs/pat/2004/10/23/stupid-scanner-tricks
-		Scanner s = new Scanner(is).useDelimiter("\\A");
+		Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
 		return s.hasNext() ? s.next() : "";
 	}
 

--- a/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
@@ -62,7 +62,7 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 
 			final byte[] UTF8ByteOrderMark = new byte[]{(byte) 0xef, (byte) 0xbb, (byte) 0xbf};
 			/* we have much more information than just in the basic profile (comfort or extended) but it's perfectly valid to provide more information, just not less. */
-			String ownZUGFeRDXML = new String(UTF8ByteOrderMark) + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+			String ownZUGFeRDXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 					"<rsm:CrossIndustryInvoice xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100\" xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100\" xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100\">\n" +
 					"	<rsm:ExchangedDocumentContext>\n" +
 					"		<ram:TestIndicator><udt:Indicator>false</udt:Indicator></ram:TestIndicator>\n" +


### PR DESCRIPTION
I stumbled on this while looking for something else.

Also: MustangReaderWriterTest.java references a resource `/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf`, which is not in the repository.