### PR TITLE
skip over BOM in XML input

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -180,9 +180,38 @@ public class ZUGFeRDImporter {
 		DocumentBuilderFactory xmlFact = DocumentBuilderFactory.newInstance();
 		xmlFact.setNamespaceAware(false);
 		DocumentBuilder builder = xmlFact.newDocumentBuilder();
-		Document doc = builder.parse(new ByteArrayInputStream(rawXML));
+		ByteArrayInputStream is = new ByteArrayInputStream(rawXML);
+		is.skip(guessBOMSize(is));
+		Document doc = builder.parse(is);
 		//prettyPrint(doc);
 		return doc;
+	}
+
+	/**
+	 * Skips over a BOM at the beginning of the given ByteArrayInputStream, if one exists.
+	 * @param is the ByteArrayInputStream used
+	 * @throws IOException
+	 * @see <a href="https://www.w3.org/TR/xml/#sec-guessing">Autodetection of Character Encodings</a>
+	 */
+	private int guessBOMSize(ByteArrayInputStream is) throws IOException {
+		byte[] pad = new byte[4];
+		is.read(pad);
+		is.reset();
+		int test2 = ((pad[0] & 0xFF) << 8) | (pad[1] & 0xFF);
+		int test3 = ((test2 & 0xFFFF) << 8) | (pad[2] & 0xFF);
+		int test4 = ((test3 & 0xFFFFFF) << 8) | (pad[3] & 0xFF);
+		//
+		if (test4 == 0x0000FEFF || test4 == 0xFFFE0000 || test4 == 0x0000FFFE || test4 == 0xFEFF0000) {
+			// UCS-4: BOM takes 4 bytes
+			return 4;
+		} else if (test3 == 0xEFBBFF) {
+			// UTF-8: BOM takes 3 bytes
+			return 3;
+		} else if (test2 == 0xFEFF || test2 == 0xFFFE) {
+			// UTF-16: BOM takes 2 bytes
+			return 2;
+		}
+		return 0;
 	}
 
 	private String extractString(String xpathStr) {


### PR DESCRIPTION
code for #99 :

We look at the first few bytes of the input stream to determine if there is a BOM. The input stream skips the number of bytes that have been detected before being parsed by the DocumentBuilder.