### PR TITLE
specify charset to avoid platform specific defaults

### DIFF
--- a/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
@@ -27,6 +27,7 @@ import org.junit.runners.MethodSorters;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class MustangReaderWriterCustomXMLTest extends TestCase {
@@ -64,7 +65,7 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 			/* we have much more information than just in the basic profile (comfort or extended) but it's perfectly valid to provide more information, just not less. 
 			 * test the export with bom (which is valid) because this will also test the import (which also needs to work and needs to be tested)
 			 * */
-			String ownZUGFeRDXML = new String(UTF8ByteOrderMark) + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+			String ownZUGFeRDXML = new String(UTF8ByteOrderMark, StandardCharsets.UTF_8) + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 					"<rsm:CrossIndustryInvoice xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100\" xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100\" xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100\">\n" +
 					"	<rsm:ExchangedDocumentContext>\n" +
 					"		<ram:TestIndicator><udt:Indicator>false</udt:Indicator></ram:TestIndicator>\n" +


### PR DESCRIPTION
This change fixes the build problem and lets `mvn test` succeed.