### PR TITLE
use RoundingMode enumeration and locale-safe BigDecimal.toPlainString

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
@@ -93,20 +94,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider, IProfileProvider {
 		 * end I decided to calculate myself and take eur+sparator+cents
 		 *
 		 */
-		value = value.setScale(scale, BigDecimal.ROUND_HALF_UP); // first, round so that e.g.
-																	// 1.189999999999999946709294817992486059665679931640625
-																	// becomes 1.19
-		char[] repeat = new char[scale];
-		Arrays.fill(repeat, '0');
-
-		DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols();
-		otherSymbols.setDecimalSeparator('.');
-		String baseFormat="0";
-		if (scale>0) { 
-		  baseFormat+=".";
-		}
-		DecimalFormat dec = new DecimalFormat(baseFormat + new String(repeat), otherSymbols);
-		return dec.format(value);
+		return value.setScale(scale, RoundingMode.HALF_UP).toPlainString();
 
 	}
 

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
@@ -19,6 +19,7 @@
 package org.mustangproject.ZUGFeRD;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
@@ -843,22 +844,22 @@ class ZUGFeRDTransactionModelConverter {
 
 
 	private BigDecimal vatFormat(BigDecimal value) {
-		return value.setScale(2, BigDecimal.ROUND_HALF_UP);
+		return value.setScale(2, RoundingMode.HALF_UP);
  	}
 
 
 	private BigDecimal currencyFormat(BigDecimal value) {
-		return value.setScale(2, BigDecimal.ROUND_HALF_UP);
+		return value.setScale(2, RoundingMode.HALF_UP);
  	}
 
 
 	private BigDecimal priceFormat(BigDecimal value) {
-		return value.setScale(4, BigDecimal.ROUND_HALF_UP);
+		return value.setScale(4, RoundingMode.HALF_UP);
  	}
 
 
 	private BigDecimal quantityFormat(BigDecimal value) {
-		return value.setScale(4, BigDecimal.ROUND_HALF_UP);
+		return value.setScale(4, RoundingMode.HALF_UP);
  	}
 
 


### PR DESCRIPTION
I checked the implementation of BigDecimal.toPlainString in OpenJDK 1.8 (and 12) and as far as I can tell, the decimal point comes from the following helper method, which hardcodes the `.`:
```
    /* Returns a digit.digit string */
    private String getValueString(int signum, String intString, int scale) {
        /* Insert decimal point */
        StringBuilder buf;
        int insertionPoint = intString.length() - scale;
        if (insertionPoint == 0) {  /* Point goes right before intVal */
            return (signum<0 ? "-0." : "0.") + intString;
        } else if (insertionPoint > 0) { /* Point goes inside intVal */
            buf = new StringBuilder(intString);
            buf.insert(insertionPoint, '.');
            if (signum < 0)
                buf.insert(0, '-');
        } else { /* We must insert zeros between point and intVal */
            buf = new StringBuilder(3-insertionPoint + intString.length());
            buf.append(signum<0 ? "-0." : "0.");
            for (int i=0; i<-insertionPoint; i++)
                buf.append('0');
            buf.append(intString);
        }
        return buf.toString();
    }
```
Also, all tests pass.