### PR TITLE
make document name and globalID configurable by implementers

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
@@ -38,6 +38,24 @@ public interface IZUGFeRDExportableContact {
 		return null;
 	}
 
+	/**
+	 * customer global identification assigned by the seller
+	 *
+	 * @return customer identification
+	 */
+	default String getGlobalID() {
+		return null;
+	}
+
+	/**
+	 * customer global identification scheme
+	 *
+	 * @return customer identification
+	 */
+	default String getGlobalIDScheme() {
+		return null;
+	}
+
 
 	/**
 	 * First and last name of the recipient

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
@@ -34,6 +34,14 @@ import java.util.Date;
 public interface IZUGFeRDExportableTransaction {
 
 	/**
+	 * appears in /rsm:CrossIndustryDocument/rsm:HeaderExchangedDocument/ram:Name
+	 * @return Name of document
+	 */
+	default String getDocumentName() {
+		return "RECHNUNG";
+	}
+
+	/**
 	 *
 	 *
 	 * @return Code of Document

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
@@ -149,7 +149,7 @@ class ZUGFeRDTransactionModelConverter {
 		document.setTypeCode(documentCodeType);
 
 		TextType name = xmlFactory.createTextType();
-		name.setValue("RECHNUNG");
+		name.setValue(trans.getDocumentName());
 		document.getName().add(name);
 
 		if (trans.getOwnOrganisationFullPlaintextInfo() != null) {
@@ -211,6 +211,12 @@ class ZUGFeRDTransactionModelConverter {
 			IDType buyerID = xmlFactory.createIDType();
 			buyerID.setValue(trans.getRecipient().getID());
 			buyerTradeParty.getID().add(buyerID);
+		}
+		if (trans.getRecipient().getGlobalID() != null) {
+			IDType globalID = xmlFactory.createIDType();
+			globalID.setValue(trans.getRecipient().getGlobalID());
+			globalID.setSchemeID(trans.getRecipient().getGlobalIDScheme());
+			buyerTradeParty.getGlobalID().add(globalID);
 		}
 
 		TextType buyerName = xmlFactory.createTextType();


### PR DESCRIPTION
I need this for a client who writes invoices to somebody who added a bunch of rules on top of ZUGFeRD v1, because, well, just because.