### PR TITLE
add test for ZUGFeRDImporter.getBankName ... and make it work

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -283,7 +283,7 @@ public class ZUGFeRDImporter {
 	 * @return the sender's bankname
 	 */
 	public String getBankName() {
-		return extractString("/CrossIndustryInvoice/SupplyChainTradeTransaction/ApplicableHeaderTradeSettlement/SpecifiedTradeSettlementPaymentMeans/PayeeSpecifiedCreditorFinancialInstitution/Name");
+		return extractString("//PayeeSpecifiedCreditorFinancialInstitution/Name");
 	}
 
 	public String getIBAN() {

--- a/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
@@ -202,6 +202,7 @@ public class MustangReaderWriterTest extends MustangReaderTestCase {
 		assertEquals(zi.getKTO(), getTradeSettlementPayment()[0].getOwnKto());
 		assertEquals(zi.getHolder(), getOwnOrganisationName());
 		assertEquals(zi.getForeignReference(), "RE-20170509/505");
+		assertEquals(zi.getBankName(), "Commerzbank");
 	}
 
 	public void testForeignImport() {


### PR DESCRIPTION
The original implementation uses the v2 toplevel element CrossIndustryInvoice, but the actual bank _name_ is only defined in v1.