### PR TITLE
avoid deprecated ZUGFeRDExporter methods

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporter.java
@@ -97,7 +97,7 @@ public class ZUGFeRDExporter implements Closeable {
 	 */
 	protected String producer = "mustangproject";
 	/**
-	 * Author/Creator attribute for PDF for PDF
+	 * Author/Creator attribute for PDF
 	 */
 	protected String creator = "mustangproject";
 	/**
@@ -709,4 +709,17 @@ public class ZUGFeRDExporter implements Closeable {
 		this.attachZUGFeRDHeaders = attachZUGFeRDHeaders;
 	}
 
+	/**
+	 * encapsulate the deprecated setters
+	 * @param zfVersion 1 or 2
+	 * @param zugferdConformanceLevel BASIC, COMFORT, EN16931, etc.
+	 * @param creator PDF creator
+	 * @param producer PDF producer
+	 */
+	public void configure(int zfVersion, ZUGFeRDConformanceLevel zugferdConformanceLevel, String creator, String producer) {
+		setZUGFeRDVersion(zfVersion);
+		setZUGFeRDConformanceLevel(zugferdConformanceLevel);
+		setCreator(creator);
+		setProducer(producer);
+	}
 }

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3Factory.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3Factory.java
@@ -63,20 +63,9 @@ public class ZUGFeRDExporterFromA3Factory implements IExporterFactory {
 	public ZUGFeRDExporter load(String pdfFilename) throws IOException {
 
 		ensurePDFIsValidPDFA(new FileDataSource(pdfFilename));
-		ZUGFeRDExporter zugFeRDExporter;
-		PDDocument doc = PDDocument.load(new File(pdfFilename));
-		zugFeRDExporter = new ZUGFeRDExporter(doc);
-		zugFeRDExporter.setZUGFeRDVersion(ZFVersion);
-		zugFeRDExporter.setZUGFeRDConformanceLevel(zugferdConformanceLevel);
-		zugFeRDExporter.setCreator(creator);
-		// Use creator as default for compatibility
-		zugFeRDExporter.setCreatorTool(creatorTool != null ? creatorTool : creator);
-		zugFeRDExporter.setProducer(producer);
-		zugFeRDExporter.setAttachZUGFeRDHeaders(attachZUGFeRDHeaders);
-		zugFeRDExporter.setPDFA3(ensurePDFisUpgraded);
-
-		return zugFeRDExporter;
-
+		try (FileInputStream pdf = new FileInputStream(pdfFilename)) {
+			return load(readAllBytes(pdf));
+		}
 	}
 
 
@@ -88,13 +77,9 @@ public class ZUGFeRDExporterFromA3Factory implements IExporterFactory {
 	 */
 	public ZUGFeRDExporter load(byte[] pdfBinary) throws IOException {
 		ensurePDFIsValidPDFA(new ByteArrayDataSource(new ByteArrayInputStream(pdfBinary)));
-		ZUGFeRDExporter zugFeRDExporter;
 		PDDocument doc = PDDocument.load(pdfBinary);
-		zugFeRDExporter = new ZUGFeRDExporter(doc);
-		zugFeRDExporter.setZUGFeRDVersion(ZFVersion);
-		zugFeRDExporter.setZUGFeRDConformanceLevel(zugferdConformanceLevel);
-		zugFeRDExporter.setCreator(creator);
-		zugFeRDExporter.setProducer(producer);
+		ZUGFeRDExporter zugFeRDExporter = new ZUGFeRDExporter(doc);
+		zugFeRDExporter.configure(ZFVersion, zugferdConformanceLevel, creator, producer);
 		zugFeRDExporter.setAttachZUGFeRDHeaders(attachZUGFeRDHeaders);
 		zugFeRDExporter.setPDFA3(ensurePDFisUpgraded);
 

--- a/src/main/java/org/mustangproject/toecount/Toecount.java
+++ b/src/main/java/org/mustangproject/toecount/Toecount.java
@@ -541,10 +541,10 @@ public class Toecount {
 
 			// All params are good! continue...
 			ZUGFeRDExporter ze = new ZUGFeRDExporterFromA1Factory().setProducer("Toecount")
+					.setZUGFeRDVersion(zfIntVersion)
 					.setCreator(System.getProperty("user.name")).setZUGFeRDConformanceLevel(zfConformanceLevelProfile)
 					.load(pdfName);
 
-			ze.setZUGFeRDVersion(zfIntVersion);
 			if (format.equals("fx")) {
 				ze.setFacturX();
 			}

--- a/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
@@ -300,7 +300,10 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 		try {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			ZUGFeRDExporter zea1 = new ZUGFeRDExporterFromA1Factory().setProducer("My Application").setCreator("Test").setZUGFeRDConformanceLevel(ZUGFeRDConformanceLevel.BASIC)
+			ZUGFeRDExporter zea1 = new ZUGFeRDExporterFromA1Factory()
+					.setProducer("My Application")
+					.setCreator("Test")
+					.setZUGFeRDConformanceLevel(ZUGFeRDConformanceLevel.BASIC)
 					.load(SOURCE_PDF);
 			/* we have much more information than just in the basic profile (comfort or extended) but it's perfectly valid to provide more information, just not less. */
 			String ownZUGFeRDXML = "<rsm:CrossIndustryDocument xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:12\" xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:15\" xmlns:rsm=\"urn:ferd:CrossIndustryDocument:invoice:1p0\">\n"

--- a/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterEdgeTest.java
@@ -208,9 +208,9 @@ public class MustangReaderWriterEdgeTest extends MustangReaderTestCase {
 			 ZUGFeRDExporter ze = new ZUGFeRDExporterFromA3Factory()
 					 .setProducer("My Application")
 					 .setCreator(System.getProperty("user.name"))
+				 	 .setZUGFeRDVersion(1)
 					 .ignorePDFAErrors()
 					 .load(SOURCE_PDF)) {
-			ze.setZUGFeRDVersion(1);
 			ze.PDFattachZugferdFile(this);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryDocument"));

--- a/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
@@ -183,10 +183,9 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 			 ZUGFeRDExporter ze = new ZUGFeRDExporterFromA3Factory()
 					 .setProducer("My Application")
 					 .setCreator(System.getProperty("user.name"))
-					 .setZUGFeRDVersion(2)
+					 .setZUGFeRDVersion(1)
 					 .ignorePDFAErrors()
 					 .load(SOURCE_PDF)) {
-			ze.setZUGFeRDVersion(1);
 			ze.PDFattachZugferdFile(this);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryDocument"));

--- a/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
@@ -183,7 +183,7 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 			 ZUGFeRDExporter ze = new ZUGFeRDExporterFromA3Factory()
 					 .setProducer("My Application")
 					 .setCreator(System.getProperty("user.name"))
-					 .setZUGFeRDVersion(1)
+					 .setZUGFeRDVersion(2)
 					 .ignorePDFAErrors()
 					 .load(SOURCE_PDF)) {
 			ze.PDFattachZugferdFile(this);


### PR DESCRIPTION
In most cases this is achieved by using the corresponding factory methods.
Since they have to be set _somehow_, I introduced a new public method
`ZUGFeRDExporter.configure` to keep these calls local to the class.
This is called once in `A3Factory.load(byte[])`.

The deprecated Exporter setters could now be made private but that could
break existing code.