### PR TITLE
deliveryDate in different date formats (#136)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,12 +79,12 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>preflight</artifactId>
-			<version>[2.0.15,)</version>
+			<version>[2.0.15,2.0.17]</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>pdfbox</artifactId>
-			<version>[2.0.15,)</version>
+			<version>[2.0.15,2.0.17]</version>
 		</dependency>
 		<dependency>
 			<groupId>org.dom4j</groupId>

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDDate.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDDate.java
@@ -1,0 +1,13 @@
+package org.mustangproject.ZUGFeRD;
+
+import java.util.Date;
+
+public interface IZUGFeRDDate {
+
+	Date getDate();
+
+	default ZUGFeRDDateFormat getFormat() {
+		return ZUGFeRDDateFormat.DATE;
+	}
+
+}

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
@@ -124,4 +124,13 @@ public interface IZUGFeRDExportableContact {
 		return null;
 	}
 
+	/**
+	 * returns additional address information which is display in xml tag "LineTwo"
+	 * 
+	 * @return additional address information
+	 */
+	default String getAdditionalAddress() {
+		return null;
+	}
+
 }

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
@@ -131,6 +131,7 @@ public interface IZUGFeRDExportableTransaction {
 	 * @deprecated use getTradeSettlement
 	 * @return an array of IZUGFeRDTradeSettlementPayment
 	 */
+	@Deprecated
 	default IZUGFeRDTradeSettlementPayment[] getTradeSettlementPayment() {		
 		return null;
 	}
@@ -230,6 +231,16 @@ public interface IZUGFeRDExportableTransaction {
 	 * @return the day the goods have been delivered
 	 */
 	Date getDeliveryDate();
+
+	/**
+	 * get delivery date in more specific form. If this and getDeliveryDate() are
+	 * specified, this value will be taken
+	 * 
+	 * @return instance holding date and format
+	 */
+	default IZUGFeRDDate getZFDeliveryDate() {
+		return null;
+	}
 
 
 	/**

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDDateFormat.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDDateFormat.java
@@ -1,0 +1,28 @@
+package org.mustangproject.ZUGFeRD;
+
+import java.text.SimpleDateFormat;
+
+import org.mustangproject.ZUGFeRD.model.DateTimeTypeConstants;
+
+public enum ZUGFeRDDateFormat {
+
+	MONTH_OF_YEAR(DateTimeTypeConstants.MONTH, new SimpleDateFormat("yyyyMM")),
+	WEEK_OF_YEAR(DateTimeTypeConstants.WEEK, new SimpleDateFormat("yyyyww")),
+	DATE(DateTimeTypeConstants.DATE, new SimpleDateFormat("yyyyMMdd"));
+
+	private String dateTimeType;
+	private SimpleDateFormat formatter;
+
+	private ZUGFeRDDateFormat(String dateTimeType, SimpleDateFormat formatter) {
+		this.dateTimeType = dateTimeType;
+		this.formatter = formatter;
+	}
+
+	public String getDateTimeType() {
+		return dateTimeType;
+	}
+
+	public SimpleDateFormat getFormatter() {
+		return formatter;
+	}
+}

--- a/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverter.java
@@ -248,6 +248,12 @@ class ZUGFeRDTransactionModelConverter {
 		buyerAddress.setValue(trans.getRecipient().getStreet());
 		buyerAddressType.setLineOne(buyerAddress);
 
+		if (trans.getRecipient().getAdditionalAddress() != null) {
+			TextType buyerAdditionalAddress = xmlFactory.createTextType();
+			buyerAdditionalAddress.setValue(trans.getRecipient().getAdditionalAddress());
+			buyerAddressType.setLineTwo(buyerAdditionalAddress);
+		}
+
 		CodeType buyerPostcode = xmlFactory.createCodeType();
 		buyerPostcode.setValue(trans.getRecipient().getZIP());
 		buyerAddressType.getPostcodeCode().add(buyerPostcode);
@@ -385,9 +391,18 @@ class ZUGFeRDTransactionModelConverter {
 		DateTimeType deliveryDate = xmlFactory.createDateTimeType();
 		DateTimeType.DateTimeString deliveryDateString = xmlFactory
 				.createDateTimeTypeDateTimeString();
-		deliveryDateString.setFormat(DateTimeTypeConstants.DATE);
-		deliveryDateString.setValue(zugferdDateFormat.format(trans
-				.getDeliveryDate()));
+		IZUGFeRDDate zfDeliveryDate = trans.getZFDeliveryDate();
+		if (zfDeliveryDate != null) {
+			ZUGFeRDDateFormat deliveryDateFormat = zfDeliveryDate.getFormat();
+			deliveryDateString.setFormat(deliveryDateFormat.getDateTimeType());
+			deliveryDateString.setValue(
+					deliveryDateFormat.getFormatter().format(zfDeliveryDate.getDate()));
+		} else if (trans.getDeliveryDate() != null) {
+			deliveryDateString.setFormat(DateTimeTypeConstants.DATE);
+			deliveryDateString.setValue(zugferdDateFormat.format(trans.getDeliveryDate()));
+		} else {
+			throw new IllegalStateException("No delivery date provided");
+		}
 		deliveryDate.setDateTimeString(deliveryDateString);
 		deliveryEvent.getOccurrenceDateTime().add(deliveryDate);
 		tradeDelivery.getActualDeliverySupplyChainEvent().add(deliveryEvent);

--- a/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDDateImpl.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDDateImpl.java
@@ -1,0 +1,30 @@
+package org.mustangproject.ZUGFeRD;
+
+import java.util.Date;
+
+public class IZUGFeRDDateImpl implements IZUGFeRDDate {
+
+	private Date date;
+	private ZUGFeRDDateFormat format = ZUGFeRDDateFormat.DATE;
+
+	public IZUGFeRDDateImpl setDate(Date date) {
+		this.date = date;
+		return this;
+	}
+
+	public IZUGFeRDDateImpl setFormat(ZUGFeRDDateFormat format) {
+		this.format = format;
+		return this;
+	}
+
+	@Override
+	public Date getDate() {
+		return date;
+	}
+
+	@Override
+	public ZUGFeRDDateFormat getFormat() {
+		return format;
+	}
+
+}

--- a/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransactionImpl.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransactionImpl.java
@@ -32,6 +32,7 @@ public class IZUGFeRDExportableTransactionImpl implements IZUGFeRDExportableTran
 	private IZUGFeRDExportableItem[] zFItems;
 	private IZUGFeRDExportableContact recipient;
 	private IZUGFeRDTradeSettlementPayment[] settlementPayments;
+	private IZUGFeRDDate zfDeliveryDate;
 	private String ownTaxID;
 	private String ownVATID;
 	private String ownOrganisationName;
@@ -149,6 +150,11 @@ public class IZUGFeRDExportableTransactionImpl implements IZUGFeRDExportableTran
 		return referenceNumber;
 	}
 
+	@Override
+	public IZUGFeRDDate getZFDeliveryDate() {
+		return zfDeliveryDate;
+	}
+
 	public IZUGFeRDExportableTransactionImpl setNumber(String number) {
 		this.number = number;
 		return this;
@@ -231,6 +237,11 @@ public class IZUGFeRDExportableTransactionImpl implements IZUGFeRDExportableTran
 
 	public IZUGFeRDExportableTransactionImpl setDeliveryDate(Date deliveryDate) {
 		this.deliveryDate = deliveryDate;
+		return this;
+	}
+
+	public IZUGFeRDExportableTransactionImpl setZfDeliveryDate(IZUGFeRDDate zfDeliveryDate) {
+		this.zfDeliveryDate = zfDeliveryDate;
 		return this;
 	}
 

--- a/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
@@ -19,11 +19,6 @@
  *********************************************************************** */
 package org.mustangproject.ZUGFeRD;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,6 +27,12 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZF2EdgeTest extends MustangReaderTestCase implements IZUGFeRDExportableTransaction {
@@ -286,7 +287,6 @@ public class ZF2EdgeTest extends MustangReaderTestCase implements IZUGFeRDExport
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 

--- a/src/test/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverterTest.java
+++ b/src/test/java/org/mustangproject/ZUGFeRD/ZUGFeRDTransactionModelConverterTest.java
@@ -18,13 +18,14 @@
  *********************************************************************** */
 package org.mustangproject.ZUGFeRD;
 
-import org.junit.Test;
-import org.mustangproject.ZUGFeRD.model.CrossIndustryDocumentType;
-
-import javax.xml.bind.JAXBElement;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
+import javax.xml.bind.JAXBElement;
+
+import org.junit.Test;
+import org.mustangproject.ZUGFeRD.model.CrossIndustryDocumentType;
 
 public class ZUGFeRDTransactionModelConverterTest {
 	@Test
@@ -65,10 +66,108 @@ public class ZUGFeRDTransactionModelConverterTest {
 		// evaluation
 		ZUGFeRDXMLAssert.assertValidZugferd(actual);
 	}
+	
+	@Test
+	public void convertToModel_convertsWithDateFormatToValidXml() throws Exception {
+		// setup
+		IZUGFeRDExportableTransaction transaction = new IZUGFeRDExportableTransactionImpl()
+				.setIssueDate(createDate(2000, 1, 1))
+				.setZfDeliveryDate(createZfDate(2000, 1, 2, ZUGFeRDDateFormat.DATE)).setDueDate(createDate(2000, 1, 3))
+				.setNumber("num")
+				.setRecipient(new IZUGFeRDExportableContactImpl().setName("recipient name")
+						.setStreet("recipient street").setLocation("recipient city").setCountry("recipient country"))
+				.setOwnOrganisationName("own org").setOwnStreet("own street").setOwnCountry("own country")
+				.setOwnLocation("own city")
+				.setTradeSettlementPayment(new IZUGFeRDTradeSettlementPaymentImpl().setOwnBankName("own bank"))
+				.setZFItems(new IZUGFeRDExportableItemImpl()
+						.setProduct(new IZUGFeRDExportableProductImpl().setVatPercent(new BigDecimal("1.19"))
+								.setName("product name").setDescription("product description").setUnit("product unit"))
+						.setQuantity(BigDecimal.ONE).setPrice(BigDecimal.TEN));
+
+		// execution
+		final JAXBElement<CrossIndustryDocumentType> actual = new ZUGFeRDTransactionModelConverter(transaction)
+				.convertToModel();
+
+		// evaluation
+		ZUGFeRDXMLAssert.assertValidZugferd(actual);
+	}
+
+	@Test
+	public void convertToModel_convertsWithWeekFormatToValidXml() throws Exception {
+		// setup
+		IZUGFeRDExportableTransaction transaction = new IZUGFeRDExportableTransactionImpl()
+				.setIssueDate(createDate(2000, 1, 1))
+				.setZfDeliveryDate(createZfDate(2000, 1, 2, ZUGFeRDDateFormat.WEEK_OF_YEAR))
+				.setDueDate(createDate(2000, 1, 3)).setNumber("num")
+				.setRecipient(new IZUGFeRDExportableContactImpl().setName("recipient name")
+						.setStreet("recipient street").setLocation("recipient city").setCountry("recipient country"))
+				.setOwnOrganisationName("own org").setOwnStreet("own street").setOwnCountry("own country")
+				.setOwnLocation("own city")
+				.setTradeSettlementPayment(new IZUGFeRDTradeSettlementPaymentImpl().setOwnBankName("own bank"))
+				.setZFItems(new IZUGFeRDExportableItemImpl()
+						.setProduct(new IZUGFeRDExportableProductImpl().setVatPercent(new BigDecimal("1.19"))
+								.setName("product name").setDescription("product description").setUnit("product unit"))
+						.setQuantity(BigDecimal.ONE).setPrice(BigDecimal.TEN));
+
+		// execution
+		final JAXBElement<CrossIndustryDocumentType> actual = new ZUGFeRDTransactionModelConverter(transaction)
+				.convertToModel();
+
+		// evaluation
+		ZUGFeRDXMLAssert.assertValidZugferd(actual);
+	}
+
+	@Test
+	public void convertToModel_convertsWithMonthFormatToValidXml() throws Exception {
+		// setup
+		IZUGFeRDExportableTransaction transaction = new IZUGFeRDExportableTransactionImpl()
+				.setIssueDate(createDate(2000, 1, 1))
+				.setZfDeliveryDate(createZfDate(2000, 1, 2, ZUGFeRDDateFormat.MONTH_OF_YEAR))
+				.setDueDate(createDate(2000, 1, 3))
+				.setNumber("num")
+				.setRecipient(new IZUGFeRDExportableContactImpl()
+								.setName("recipient name")
+								.setStreet("recipient street")
+								.setLocation("recipient city")
+								.setCountry("recipient country")
+				)
+				.setOwnOrganisationName("own org")
+				.setOwnStreet("own street")
+				.setOwnCountry("own country")
+				.setOwnLocation("own city")
+				.setTradeSettlementPayment(new IZUGFeRDTradeSettlementPaymentImpl().setOwnBankName("own bank"))
+				.setZFItems(
+						new IZUGFeRDExportableItemImpl()
+								.setProduct(new IZUGFeRDExportableProductImpl()
+												.setVatPercent(new BigDecimal("1.19"))
+												.setName("product name")
+												.setDescription("product description")
+												.setUnit("product unit")
+								)
+								.setQuantity(BigDecimal.ONE)
+								.setPrice(BigDecimal.TEN)
+				);
+
+		// execution
+		final JAXBElement<CrossIndustryDocumentType> actual =
+				new ZUGFeRDTransactionModelConverter(transaction).convertToModel();
+
+		// evaluation
+		ZUGFeRDXMLAssert.assertValidZugferd(actual);
+	}
 
 	private static Date createDate(int year, int month, int day) {
 		final GregorianCalendar calendar = new GregorianCalendar();
 		calendar.set(year, month - 1, day);
 		return calendar.getTime();
+	}
+	
+	private static IZUGFeRDDate createZfDate(int year, int month, int day, ZUGFeRDDateFormat format) {
+		final GregorianCalendar calendar = new GregorianCalendar();
+		calendar.set(year, month - 1, day);
+		IZUGFeRDDateImpl date = new IZUGFeRDDateImpl();
+		date.setDate(calendar.getTime());
+		date.setFormat(format);
+		return date;
 	}
 }


### PR DESCRIPTION
This pull request addresses issue #136 by
- Added possibility to specify delivery date in "week of year" or "month of year" format, through introduction of new IZUGFeRDDate interface. Keeping backward compatibility by providing both methods in IZUGFeRDExportableTransaction

- Added possibility to specify "LineTwo" in Recipient Address

- Limited pdfbox version to maximum 2.0.17 because otherwise 3.0.0-SNAPSHOT was pulled in which was broken because of missing ByteArrayDataSource