### PR TITLE
PaymentTerms in ZUGFeRD 1

### DIFF
--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTransaction.java
@@ -262,6 +262,16 @@ public interface IZUGFeRDExportableTransaction {
 		return null;
 	}
 
+	/**
+	 * get payment terms. if set, getPaymentTermDescription() and getDueDate() are
+	 * ignored
+	 * 
+	 * @return
+	 */
+	default IZUGFeRDPaymentTerms getPaymentTerms() {
+		return null;
+	}
+
 
 	/**
 	 * get reference document number typically used for Invoice Corrections Will be added as IncludedNote in comfort profile

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDPaymentDiscountTerms.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDPaymentDiscountTerms.java
@@ -1,0 +1,15 @@
+package org.mustangproject.ZUGFeRD;
+
+import java.math.BigDecimal;
+
+public interface IZUGFeRDPaymentDiscountTerms {
+
+	BigDecimal getCalculationPercentage();
+
+	IZUGFeRDDate getBaseDate();
+
+	int getBasePeriodMeasure();
+
+	String getBasePeriodUnitCode();
+
+}

--- a/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDPaymentTerms.java
+++ b/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDPaymentTerms.java
@@ -1,0 +1,10 @@
+package org.mustangproject.ZUGFeRD;
+
+public interface IZUGFeRDPaymentTerms {
+
+	String getDescription();
+
+	IZUGFeRDDate getDueDate();
+
+	IZUGFeRDPaymentDiscountTerms getDiscountTerms();
+}


### PR DESCRIPTION
With this pull request it is possible to define `SpecifiedTradePaymentTerms` in ZUGFeRD 1 in a very comfortable way.

For ZUGFeRD 2 the same classes can be used too, so that it is no longer needed to generate the SpecifiedTradePaymentTerms XML manually.

With these changes it is possible to specify discount terms in both formats.