### PR TITLE
Refactored comparison operator for ChargeIndicator

### DIFF
--- a/src/main/resources/stylesheets/ZUGFeRD_1p0_c1p0_s1p0.xslt
+++ b/src/main/resources/stylesheets/ZUGFeRD_1p0_c1p0_s1p0.xslt
@@ -1007,7 +1007,7 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 																											<xsl:for-each select="ram:ChargeIndicator">
 																												<xsl:for-each select="udt:Indicator">
 																													<span>
-																														<xsl:value-of select="if (. eq fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
+																														<xsl:value-of select="if (. = fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
 																													</span>
 																												</xsl:for-each>
 																											</xsl:for-each>
@@ -1924,7 +1924,7 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 																				<xsl:for-each select="ram:ChargeIndicator">
 																					<xsl:for-each select="udt:Indicator">
 																						<span>
-																							<xsl:value-of select="if (. eq fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
+																							<xsl:value-of select="if (. = fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
 																						</span>
 																					</xsl:for-each>
 																				</xsl:for-each>
@@ -1982,7 +1982,7 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 																				<xsl:for-each select="ram:ActualAmount">
 																					<span>
 																						<xsl:variable name="altova:seqContentStrings_37">
-																							<xsl:value-of select="format-number(number(if (../ram:ChargeIndicator/udt:Indicator eq fn:true()) then . else -1 * .), '##0,00', 'format1')"/>
+																							<xsl:value-of select="format-number(number(if (../ram:ChargeIndicator/udt:Indicator = fn:true()) then . else -1 * .), '##0,00', 'format1')"/>
 																						</xsl:variable>
 																						<xsl:variable name="altova:sContent_37" select="string($altova:seqContentStrings_37)"/>
 																						<xsl:value-of select="$altova:sContent_37"/>


### PR DESCRIPTION
### Prerequisite
- default ZUGFeRD invoice from [ZUGFeRD_1p0_COMFORT_Rechnungskorrektur.pdf](https://github.com/ZUGFeRD/mustangproject/files/4193222/ZUGFeRD_1p0_COMFORT_Rechnungskorrektur.pdf)
- default ZUGFeRD stylesheet (this file)
- latest Saxon library

### Problem
When trying to create a HTML output for the electronic invoice mentioned above using the following batch file
`java -jar saxon9he.jar ZUGFeRD-invoice.xml ZUGFeRD_1p0_c1p0_s1p0.xslt > output.html
PAUSE`
the following error will be shown in the console

> Warning at char 27 in xsl:value-of/@select on line 1985 column 166 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at xsl:for-each on line 2083 column 78 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9009: An empty xsl:for-each instruction has no effect
Warning at char 6 in xsl:value-of/@select on line 1010 column 126 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 6 in xsl:value-of/@select on line 1927 column 119 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 27 in xsl:value-of/@select on line 1985 column 166 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 6 in xsl:value-of/@select on line 1010 column 126 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 6 in xsl:value-of/@select on line 1927 column 119 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 27 in xsl:value-of/@select on line 1985 column 166 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Type error evaluating (. eq true()) in xsl:value-of/@select on line 1010 column 126 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
  XPTY0004: Cannot compare xs:untypedAtomic to xs:boolean
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#1008
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#1007
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#1003
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#952
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#951
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#756
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#755
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#78
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by unknown caller (class net.sf.saxon.expr.instruct.ForEach) at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#77
at template altova:Root on line 65 of ZUGFeRD_1p0_c1p0_s1p0.xslt:
     invoked by xsl:call-template at file:/C:/Users/meberl/Desktop/InvoiceToHtml/ZUGFeRD/stylesheet/ZUGFeRD_1p0_c1p0_s1p0.xslt#63
  In template rule with match="/" on line 62 of ZUGFeRD_1p0_c1p0_s1p0.xslt
Cannot compare xs:untypedAtomic to xs:boolean

### Cause
Line 1010 in the stylesheet:
The value of udt:Indicator (in this case **false**) has no type (xs:untypedAtomic).
The value of fn:true() is considered as xs:boolean.
The comparison with the operator "eg" fails, because the types of the two values are different and with the operator "eg" only values of the same type may be compared.

### Solution
Replacing the operator "eg" with the operator "=" ensures that the type is automatically determined for comparison (in this case the type of fn:true() which is boolean).
With my changes the HTML file can be created successfully.