### PR TITLE
Bugfix in ZUGFeRD2PullProvider.generateXML: try getPaymentTermDescription() before constructing one

### DIFF
--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -252,12 +252,13 @@ public class ZUGFeRD2PullProvider implements IXMLProvider, IProfileProvider {
 		SimpleDateFormat zugferdDateFormat = new SimpleDateFormat("yyyyMMdd"); //$NON-NLS-1$
 		String exemptionReason="";
 
+		if (trans.getPaymentTermDescription()!=null) {
+			paymentTermsDescription=trans.getPaymentTermDescription();
+		}
+
 		if (paymentTermsDescription==null) {
 			paymentTermsDescription= "Zahlbar ohne Abzug bis " + germanDateFormat.format(trans.getDueDate());
 			
-		}
-		if (trans.getPaymentTermDescription()!=null) {
-			paymentTermsDescription=trans.getPaymentTermDescription();
 		}
 
 		String senderReg = "";


### PR DESCRIPTION
or the program throws a NullPointerException if 'trans' only overwrites 'getPaymentTermDescription()' but not the default 'getDueDate()'.

Fix for issue #155