### PR TITLE
Add extraction methods

### DIFF
--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportablePostalTradeAddress.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportablePostalTradeAddress.java
@@ -1,0 +1,11 @@
+package org.mustangproject.ZUGFeRD;
+
+public interface IZUGFeRDExportablePostalTradeAddress {
+	default String getPostcodeCode(){return null;}
+	default String getLineOne() {return null;}
+	default String getLineTwo() {return null;}
+	default String getLineThree() {return null;}
+	default String getCityName() {return null;}
+	default String getCountryID() {return null;}
+	default String getCountrySubDivisionName() {return null;}
+}

--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/PostalTradeAddress.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/PostalTradeAddress.java
@@ -1,0 +1,75 @@
+package org.mustangproject.ZUGFeRD;
+
+public class PostalTradeAddress implements IZUGFeRDExportablePostalTradeAddress {
+
+	private String postCodeCode;
+	private String lineOne;
+	private String lineTwo;
+	private String lineThree;
+	private String cityName;
+	private String countryID;
+	private String CountrySubDivisionName;
+
+	public void setPostCodeCode(String postCodeCode) {
+		this.postCodeCode = postCodeCode;
+	}
+
+	public void setLineOne(String lineOne) {
+		this.lineOne = lineOne;
+	}
+
+	public void setLineTwo(String lineTwo) {
+		this.lineTwo = lineTwo;
+	}
+
+	public void setLineThree(String lineThree) {
+		this.lineThree = lineThree;
+	}
+
+	public void setCityName(String cityName) {
+		this.cityName = cityName;
+	}
+
+	public void setCountryID(String countryID) {
+		this.countryID = countryID;
+	}
+
+	public void setCountrySubDivisionName(String countrySubDivisionName) {
+		CountrySubDivisionName = countrySubDivisionName;
+	}
+
+	@Override
+	public String getPostcodeCode() {
+		return this.postCodeCode;
+	}
+
+	@Override
+	public String getLineOne() {
+		return this.lineOne;
+	}
+
+	@Override
+	public String getLineTwo() {
+		return this.lineTwo;
+	}
+
+	@Override
+	public String getLineThree() {
+		return this.lineThree;
+	}
+
+	@Override
+	public String getCityName() {
+		return this.cityName;
+	}
+
+	@Override
+	public String getCountryID() {
+		return this.countryID;
+	}
+
+	@Override
+	public String getCountrySubDivisionName() {
+		return this.CountrySubDivisionName;
+	}
+}

--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -30,9 +30,7 @@ import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.*;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
@@ -41,6 +39,8 @@ import org.apache.pdfbox.pdmodel.common.PDNameTreeNode;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
 import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 public class ZUGFeRDImporter {
@@ -235,21 +235,11 @@ public class ZUGFeRDImporter {
 
 
 	/**
-	 * Wrapper for protected method
+	 * Wrapper for protected method exracteString
 	 * @return the extracted String for the specific path in the document
 	 */
 	public String wExtractString(String xpathStr) {
 		return extractString(xpathStr);
-	}
-
-
-	/**
-	 * @return an ISO XXX coded datetime string
-	 */
-	public String getISOdate(String xpathString) {
-		String date = extractString(xpathString);
-		//do some conversion magic here
-		return date;
 	}
 
 
@@ -466,6 +456,75 @@ public class ZUGFeRDImporter {
 		// https://community.oracle.com/blogs/pat/2004/10/23/stupid-scanner-tricks
 		Scanner s = new Scanner(is, "UTF-8").useDelimiter("\\A");
 		return s.hasNext() ? s.next() : "";
+	}
+
+	public PostalTradeAddress getSellerTradePartyAddress() {
+
+		NodeList nl = null;
+		PostalTradeAddress address = new PostalTradeAddress();
+
+		try {
+			if (getVersion() == 1) {
+				nl = getNodeListByPath("//CrossIndustryDocument//SpecifiedSupplyChainTradeTransaction//ApplicableSupplyChainTradeAgreement//SellerTradeParty//PostalTradeAddress");
+			} else {
+				nl = getNodeListByPath("//CrossIndustryInvoice//SupplyChainTradeTransaction//ApplicableHeaderTradeAgreement//SellerTradeParty//PostalTradeAddress");
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+			return address;
+		}
+
+		if (nl != null) {
+			for (int i = 0; i < nl.getLength(); i++) {
+				Node n = nl.item(i);
+				NodeList nodes = n.getChildNodes();
+				for (int j = 0; j < nodes.getLength(); j++) {
+					n = nodes.item(j);
+					short nodeType = n.getNodeType();
+					if (nodeType==Node.ELEMENT_NODE){
+						switch (n.getNodeName()) {
+							case "ram:PostcodeCode":
+								address.setPostCodeCode(n.getFirstChild().getNodeValue());
+								break;
+							case "ram:LineOne":
+								address.setLineOne(n.getFirstChild().getNodeValue());
+								break;
+							case "ram:LineTwo":
+								address.setLineTwo(n.getFirstChild().getNodeValue());
+								break;
+							case "ram:LineThree":
+								address.setLineThree(n.getFirstChild().getNodeValue());
+								break;
+							case "ram:CityName":
+								address.setCityName(n.getFirstChild().getNodeValue());
+								break;
+							case "ram:CountryID":
+								address.setCountryID(n.getFirstChild().getNodeValue());
+								break;
+							case "ram:CountrySubDivisionName":
+								address.setCountrySubDivisionName(n.getFirstChild().getNodeValue());
+								break;
+						}
+					}
+				}
+			}
+		}
+		return address;
+	}
+
+	public NodeList getNodeListByPath(String path) {
+
+		XPathFactory xpathFact = XPathFactory.newInstance();
+		XPath xPath = xpathFact.newXPath();
+		String s = path;
+
+		try {
+			XPathExpression xpr = xPath.compile(s);
+			return (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
 	}
 
 }

--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -235,6 +235,25 @@ public class ZUGFeRDImporter {
 
 
 	/**
+	 * Wrapper for protected method
+	 * @return the extracted String for the specific path in the document
+	 */
+	public String wExtractString(String xpathStr) {
+		return extractString(xpathStr);
+	}
+
+
+	/**
+	 * @return an ISO XXX coded datetime string
+	 */
+	public String getISOdate(String xpathString) {
+		String date = extractString(xpathString);
+		//do some conversion magic here
+		return date;
+	}
+
+
+	/**
 	 * @return the reference (purpose) the sender specified for this invoice
 	 */
 	public String getForeignReference() {

--- a/libraryBasic/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
+++ b/libraryBasic/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterTest.java
@@ -203,6 +203,13 @@ public class MustangReaderWriterTest extends MustangReaderTestCase {
 		assertEquals(zi.getHolder(), getOwnOrganisationName());
 		assertEquals(zi.getForeignReference(), "RE-20170509/505");
 		assertEquals(zi.getBankName(), "Commerzbank");
+		assertEquals(zi.getSellerTradePartyAddress().getCityName(), "Stadthausen");
+		assertEquals(zi.getSellerTradePartyAddress().getCountryID(), "DE");
+		assertEquals(zi.getSellerTradePartyAddress().getCountrySubDivisionName(), null);
+		assertEquals(zi.getSellerTradePartyAddress().getLineOne(), "Ecke 12");
+		assertEquals(zi.getSellerTradePartyAddress().getLineThree(), null);
+		assertEquals(zi.getSellerTradePartyAddress().getLineTwo(), null);
+		assertEquals(zi.getSellerTradePartyAddress().getPostcodeCode(), "12345");
 	}
 
 	public void testForeignImport() {

--- a/libraryBasic/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
+++ b/libraryBasic/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
@@ -213,7 +213,13 @@ public class ZF2Test extends MustangReaderTestCase {
 		assertEquals(zi.getIBAN(),getTradeSettlementPayment()[0].getOwnIBAN());
 		assertEquals(zi.getHolder(), getOwnOrganisationName());
 		assertEquals(zi.getForeignReference(), getNumber());
-		
+		assertEquals(zi.getSellerTradePartyAddress().getPostcodeCode(), "12345");
+		assertEquals(zi.getSellerTradePartyAddress().getLineOne(), "Ecke 12");
+		assertEquals(zi.getSellerTradePartyAddress().getLineTwo(), null);
+		assertEquals(zi.getSellerTradePartyAddress().getLineThree(), null);
+		assertEquals(zi.getSellerTradePartyAddress().getCountrySubDivisionName(), null);
+		assertEquals(zi.getSellerTradePartyAddress().getCountryID(), "DE");
+		assertEquals(zi.getSellerTradePartyAddress().getCityName(), "Stadthausen");
 		
 		try {
 			assertEquals(zi.getVersion(), 2);


### PR DESCRIPTION
Implemented method "getSellerTradePartyAddress" to ZUGFeRDImporter.java which gets an instance of PostalTradeAddress.
Removed method "getISODate" from last Commit due lack of implementation - will be implemented at a later time.
Also Added Tests for "getSellerTradePartyAddress" to match ZF1 and ZF2 