### PR TITLE
FIX: Moved propterties "SellerAssignedID" and "BuyerAssignedID" from …

### DIFF
--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/Item.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/Item.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
 
 public class Item implements IZUGFeRDExportableItem {
 	protected BigDecimal price, quantity, tax, grossPrice, lineTotalAmount;
-	protected String id, sellerAssignedID, buyerAssignedID;
+	protected String id;
 	protected Product product;
 
 	public Item(Product product, BigDecimal price, BigDecimal quantity) {
@@ -23,24 +23,6 @@ public class Item implements IZUGFeRDExportableItem {
 
 	public Item setLineTotalAmount(BigDecimal lineTotalAmount) {
 		this.lineTotalAmount = lineTotalAmount;
-		return this;
-	}
-
-	public String getSellerAssignedID() {
-		return sellerAssignedID;
-	}
-
-	public Item setSellerAssignedID(String sellerAssignedID) {
-		this.sellerAssignedID = sellerAssignedID;
-		return this;
-	}
-
-	public String getBuyerAssignedID() {
-		return buyerAssignedID;
-	}
-
-	public Item setBuyerAssignedID(String buyerAssignedID) {
-		this.buyerAssignedID = buyerAssignedID;
 		return this;
 	}
 

--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/Product.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/Product.java
@@ -5,9 +5,8 @@ import org.mustangproject.ZUGFeRD.IZUGFeRDExportableProduct;
 import java.math.BigDecimal;
 
 public class Product implements IZUGFeRDExportableProduct {
-	protected String unit, name, description;
+	protected String unit, name, description, sellerAssignedID, buyerAssignedID;
 	protected BigDecimal VATPercent;
-
 
 	public Product(String name, String description, String unit, BigDecimal VATPercent) {
 		this.unit = unit;
@@ -16,6 +15,24 @@ public class Product implements IZUGFeRDExportableProduct {
 		this.VATPercent = VATPercent;
 	}
 
+
+	public String getSellerAssignedID() {
+		return sellerAssignedID;
+	}
+
+	public Product setSellerAssignedID(String sellerAssignedID) {
+		this.sellerAssignedID = sellerAssignedID;
+		return this;
+	}
+
+	public String getBuyerAssignedID() {
+		return buyerAssignedID;
+	}
+
+	public Product setBuyerAssignedID(String buyerAssignedID) {
+		this.buyerAssignedID = buyerAssignedID;
+		return this;
+	}
 
 	@Override
 	public String getUnit() {

--- a/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/libraryBasic/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -576,10 +576,10 @@ public class ZUGFeRDImporter {
 					case "ram:SpecifiedTradeProduct":
 
 						node = getNodeByName(nn.getChildNodes(), "ram:SellerAssignedID");
-						lineItem.setSellerAssignedID(getNodeValue(node));
+						lineItem.product.setSellerAssignedID(getNodeValue(node));
 
 						node = getNodeByName(nn.getChildNodes(), "ram:BuyerAssignedID");
-						lineItem.setBuyerAssignedID(getNodeValue(node));
+						lineItem.product.setBuyerAssignedID(getNodeValue(node));
 
 						node = getNodeByName(nn.getChildNodes(), "ram:Name");
 						lineItem.product.setName(getNodeValue(node));

--- a/libraryBasic/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
+++ b/libraryBasic/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
@@ -225,12 +225,11 @@ public class ZF2Test extends MustangReaderTestCase {
 
 		List<org.mustangproject.ZUGFeRD.Item> li = zi.getLineItemList();
 		assertEquals(zi.getLineItemList().get(0).getId().toString(), "1");
-		assertEquals(zi.getLineItemList().get(0).getBuyerAssignedID(), "");
-		assertEquals(zi.getLineItemList().get(0).getSellerAssignedID(), "");
+		assertEquals(zi.getLineItemList().get(0).product.getBuyerAssignedID(), "");
+		assertEquals(zi.getLineItemList().get(0).product.getSellerAssignedID(), "");
 		assertEquals(zi.getLineItemList().get(0).getLineTotalAmount().toString(), "160.00");
 		assertEquals(zi.getLineItemList().get(0).getQuantity().toString(), "1.0000");
 		assertEquals(zi.getLineItemList().get(0).getGrossPrice().toString(), "171.2000");
-		assertEquals(zi.getLineItemList().get(0).getBuyerAssignedID(), "");
 		assertEquals(zi.getLineItemList().get(0).product.getVATPercent().toString(), "7.00");
 		assertEquals(zi.getLineItemList().get(0).product.getName(), "Künstlerische Gestaltung (Stunde): Einer Beispielrechnung");
 		assertEquals(zi.getLineItemList().get(0).product.getDescription(), "");
@@ -241,6 +240,5 @@ public class ZF2Test extends MustangReaderTestCase {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		
 	}
 }


### PR DESCRIPTION
Moved properties "SellerAssignedID" and "BuyerAssignedID" from "Item" to "Product" to fit ZUGFeRD XML schema.
Altered Tests