### PR TITLE
BigDecimal specific refactoring

### DIFF
--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -16,7 +16,7 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	protected String categoryCode;
 
 	public Charge() {
-		taxPercent=new BigDecimal(0);
+		taxPercent=BigDecimal.ZERO;
 	}
 
 	/***

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
@@ -12,8 +12,8 @@ public class LineCalculator {
 	private BigDecimal priceGross;
 	private BigDecimal itemTotalNetAmount;
 	private BigDecimal itemTotalVATAmount;
-	private BigDecimal allowance = new BigDecimal(0);
-	private BigDecimal charge = new BigDecimal(0);
+	private BigDecimal allowance = BigDecimal.ZERO;
+	private BigDecimal charge = BigDecimal.ZERO;
 
 	public LineCalculator(IZUGFeRDExportableItem currentItem) {
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/TransactionCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/TransactionCalculator.java
@@ -16,7 +16,7 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 
 	protected BigDecimal getTotalPrepaid() {
 		if (trans.getTotalPrepaidAmount() == null) {
-			return new BigDecimal(0);
+			return BigDecimal.ZERO;
 		} else {
 			return trans.getTotalPrepaidAmount();
 		}
@@ -39,11 +39,11 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 	 * @return the total amount
 	 */
 	protected BigDecimal getChargesForPercent(BigDecimal percent) {
-		BigDecimal res = new BigDecimal(0);
+		BigDecimal res = BigDecimal.ZERO;
 		IZUGFeRDAllowanceCharge[] charges = trans.getZFCharges();
 		if ((charges != null) && (charges.length > 0)) {
 			for (IZUGFeRDAllowanceCharge currentCharge : charges) {
-				if ((percent==null)||(currentCharge.getTaxPercent().equals(percent))) {
+				if ((percent==null)||(currentCharge.getTaxPercent().compareTo(percent)==0)) {
 					res = res.add(currentCharge.getTotalAmount(this));
 				}
 			}
@@ -61,7 +61,7 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 		IZUGFeRDAllowanceCharge[] charges = trans.getZFCharges();
 		if ((charges != null) && (charges.length > 0)) {
 			for (IZUGFeRDAllowanceCharge currentCharge : charges) {
-				if ((percent==null)||(currentCharge.getTaxPercent().equals(percent))) {
+				if ((percent==null)||(currentCharge.getTaxPercent().compareTo(percent)==0)) {
 					if (currentCharge.getReason()!=null) {
 						res = res+currentCharge.getReason()+" ";
 					}
@@ -85,7 +85,7 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 		IZUGFeRDAllowanceCharge[] allowances = trans.getZFAllowances();
 		if ((allowances != null) && (allowances.length > 0)) {
 			for (IZUGFeRDAllowanceCharge currentAllowance : allowances) {
-				if ((percent==null)||(currentAllowance.getTaxPercent().equals(percent))) {
+				if ((percent==null)||(currentAllowance.getTaxPercent().compareTo(percent)==0)) {
 					if (currentAllowance.getReason()!=null) {
 						res = res+currentAllowance.getReason()+" ";
 					}
@@ -106,11 +106,11 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 	 * @return the total amount
 	 */
 	protected BigDecimal getAllowancesForPercent(BigDecimal percent) {
-		BigDecimal res = new BigDecimal(0);
+		BigDecimal res = BigDecimal.ZERO;
 		IZUGFeRDAllowanceCharge[] allowances = trans.getZFAllowances();
 		if ((allowances != null) && (allowances.length > 0)) {
 			for (IZUGFeRDAllowanceCharge currentAllowance : allowances) {
-				if ((percent==null)||(currentAllowance.getTaxPercent().equals(percent))) {
+				if ((percent==null)||(currentAllowance.getTaxPercent().compareTo(percent)==0)) {
 					res = res.add(currentAllowance.getTotalAmount(this));
 				}
 			}
@@ -119,7 +119,7 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 	}
 
 	protected BigDecimal getTotal() {
-		BigDecimal res = new BigDecimal(0);
+		BigDecimal res = BigDecimal.ZERO;
 		for (IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
 			LineCalculator lc = new LineCalculator(currentItem);
 			res = res.add(lc.getItemTotalGrossAmount());
@@ -147,11 +147,11 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 			LineCalculator lc = new LineCalculator(currentItem);
 			VATAmount itemVATAmount = new VATAmount(lc.getItemTotalNetAmount(), lc.getItemTotalVATAmount(),
 					trans.getDocumentCode());
-			VATAmount current = hm.get(percent);
+			VATAmount current = hm.get(percent.stripTrailingZeros());
 			if (current == null) {
-				hm.put(percent, itemVATAmount);
+				hm.put(percent.stripTrailingZeros(), itemVATAmount);
 			} else {
-				hm.put(percent, current.add(itemVATAmount));
+				hm.put(percent.stripTrailingZeros(), current.add(itemVATAmount));
 			}
 		}
 
@@ -159,28 +159,28 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 		IZUGFeRDAllowanceCharge[] charges = trans.getZFCharges();
 		if ((charges != null) && (charges.length > 0)) {
 			for (IZUGFeRDAllowanceCharge currentCharge : charges) {
-				VATAmount theAmount = hm.get(currentCharge.getTaxPercent());
+				VATAmount theAmount = hm.get(currentCharge.getTaxPercent().stripTrailingZeros());
 				if (theAmount == null) {
-					theAmount = new VATAmount(new BigDecimal(0), new BigDecimal(0), "S");
+					theAmount = new VATAmount(BigDecimal.ZERO, BigDecimal.ZERO, "S");
 				}
 				theAmount.setBasis(theAmount.getBasis().add(currentCharge.getTotalAmount(this)));
 				BigDecimal factor = currentCharge.getTaxPercent().divide(new BigDecimal(100));
 				theAmount.setCalculated(theAmount.getBasis().multiply(factor));
-				hm.put(currentCharge.getTaxPercent(), theAmount);
+				hm.put(currentCharge.getTaxPercent().stripTrailingZeros(), theAmount);
 			}
 		}
 		IZUGFeRDAllowanceCharge[] allowances = trans.getZFAllowances();
 		if ((allowances != null) && (allowances.length > 0)) {
 			for (IZUGFeRDAllowanceCharge currentAllowance : allowances) {
-				VATAmount theAmount = hm.get(currentAllowance.getTaxPercent());
+				VATAmount theAmount = hm.get(currentAllowance.getTaxPercent().stripTrailingZeros());
 				if (theAmount == null) {
-					theAmount = new VATAmount(new BigDecimal(0), new BigDecimal(0), "S");
+					theAmount = new VATAmount(BigDecimal.ZERO, BigDecimal.ZERO, "S");
 				}
 				theAmount.setBasis(theAmount.getBasis().subtract(currentAllowance.getTotalAmount(this)));
 				BigDecimal factor = currentAllowance.getTaxPercent().divide(new BigDecimal(100));
 				theAmount.setCalculated(theAmount.getBasis().multiply(factor));
 
-				hm.put(currentAllowance.getTaxPercent(), theAmount);
+				hm.put(currentAllowance.getTaxPercent().stripTrailingZeros(), theAmount);
 			}
 		}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -514,7 +514,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		if ((trans.getZFCharges() != null) && (trans.getZFCharges().length > 0)) {
 
 			for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
-				if (!calc.getChargesForPercent(currentTaxPercent).equals(new BigDecimal(0))) {
+				if (calc.getChargesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO)!=0) {
 
 
 					xml = xml + "	 <ram:SpecifiedTradeAllowanceCharge>\n" +
@@ -537,7 +537,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 		if ((trans.getZFAllowances() != null) && (trans.getZFAllowances().length > 0)) {
 			for (BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
-				if (!calc.getAllowancesForPercent(currentTaxPercent).equals(new BigDecimal(0))) {
+				if (calc.getAllowancesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO)!= 0) {
 					xml = xml + "	 <ram:SpecifiedTradeAllowanceCharge>\n" +
 							"        <ram:ChargeIndicator>\n" +
 							"          <udt:Indicator>false</udt:Indicator>\n" +

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -119,7 +119,7 @@ public class ZUGFeRDInvoiceImporter extends ZUGFeRDImporter {
 		}
 
 		zpp = new Invoice().setDueDate(dueDate).setDeliveryDate(deliveryDate).setIssueDate(issueDate).setSender(new TradeParty(SellerNodes)).setRecipient(new TradeParty(BuyerNodes)).setNumber(number);
-//.addItem(new Item(new Product("Testprodukt","","C62",new BigDecimal(0)),amount,new BigDecimal(1.0)))
+//.addItem(new Item(new Product("Testprodukt","","C62",BigDecimal.ZERO),amount,new BigDecimal(1.0)))
 		zpp.setOwnOrganisationName(extractString("//SellerTradeParty/Name"));
 		xpr = xpath.compile(
 				"//*[local-name()=\"IncludedSupplyChainTradeLineItem\"]");

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/BaseTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/BaseTest.java
@@ -52,7 +52,7 @@ public class BaseTest extends TestCase {
 	}
 
 	public void testCorrectDigits() {
-		assertEquals("0.00", XMLTools.nDigitFormat(new BigDecimal(0),2));
+		assertEquals("0.00", XMLTools.nDigitFormat(BigDecimal.ZERO,2));
 		assertEquals("-1.10", XMLTools.nDigitFormat(new BigDecimal("-1.10"),2));
 		assertEquals("-1.10", XMLTools.nDigitFormat(new BigDecimal("-1.1"),2));
 		assertEquals("-1.01", XMLTools.nDigitFormat(new BigDecimal("-1.01"),2));

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/UXTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/UXTest.java
@@ -48,7 +48,7 @@ public class UXTest extends TestCase {
 		try (InputStream SOURCE_PDF = this.getClass()
 				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505PDFA3.pdf"))
 		{
-			Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setOwnOrganisationName("My company").setOwnStreet("teststr").setOwnZIP("12345").setOwnLocation("teststadt").setOwnCountry("DE").setOwnTaxID("4711").setOwnVATID("0815").setRecipient(new Contact("Franz Müller", "0177123456", "fmueller@test.com", "teststr.12", "55232", "Entenhausen", "DE")).setNumber("INV/123").addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(0)), new BigDecimal(1.0), new BigDecimal(1.0)));
+			Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setOwnOrganisationName("My company").setOwnStreet("teststr").setOwnZIP("12345").setOwnLocation("teststadt").setOwnCountry("DE").setOwnTaxID("4711").setOwnVATID("0815").setRecipient(new Contact("Franz Müller", "0177123456", "fmueller@test.com", "teststr.12", "55232", "Entenhausen", "DE")).setNumber("INV/123").addItem(new Item(new Product("Testprodukt", "", "C62", BigDecimal.ZERO), new BigDecimal(1.0), new BigDecimal(1.0)));
 			new ZUGFeRDExporterFromA1().load("source.pdf").setTransaction(i).export(TARGET_PDF);
 		} catch (Exception e) {
 			fail("Exception should not be raised in testEdgeExport");

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -46,7 +46,7 @@ public class XRTest extends TestCase {
 		String amountStr = "1.00";
 		BigDecimal amount = new BigDecimal(amountStr);
 
-		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr","55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number).addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(0)), amount, new BigDecimal(1.0)));
+		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr","55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number).addItem(new Item(new Product("Testprodukt", "", "C62", BigDecimal.ZERO), amount, new BigDecimal(1.0)));
 
 		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
 		zf2p.generateXML(i);


### PR DESCRIPTION
- Use  BigDecimal.stripTrailingZeros() as key for getVATPercentMap and in consequence use compareTo... == 0 instead of equals
- Use BigDecimal.ZERO instead of new BigDecimal(0)
- These changes result in improvements in enumeration of the <ram:SpecifiedTradeAllowanceCharge> tags and the calculation of tag <ram:SpecifiedTradeSettlementHeaderMonetarySummation>. #191 