### PR TITLE
Enabling functionality via Command line, changing POM so no errors occur

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
   make IZUGFeRDExportableTradeParty name id zip location street mandatory
 - fixed a charge/allowance rounding error #212 
 - Corrected intra community supply tax exemption category code
+- removal of Tradeparty.getZip in favor of getZIP (as it's also setZIP) to avoid jackson errors
 
 2.0.3
 =======

--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 2.1.0
 =======
-
+- make  IExportableTransaction.getZFAllowances() getZFCharges() and getZFLogisticsServiceCharges() and item.getItemAllowances, item.getItemCharges optional, correct getCurrency optionality
+  make IZUGFeRDExportableTradeParty name id zip location street mandatory
 - fixed a charge/allowance rounding error #212 
 - Corrected intra community supply tax exemption category code
 

--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -20,6 +20,7 @@ package org.mustangproject.commandline;
 
 import com.sanityinc.jargs.CmdLineParser;
 import com.sanityinc.jargs.CmdLineParser.Option;
+import org.mustangproject.CII.CIIToUBL;
 import org.mustangproject.ZUGFeRD.*;
 import org.mustangproject.validator.Validator;
 import org.mustangproject.validator.ZUGFeRDValidator;
@@ -46,7 +47,7 @@ public class Main {
 	}
 
 	private static String getUsage() {
-		return "Usage: --action metrics|combine|extract|a3only|validate|visualize [-d,--directory] [-l,--listfromstdin] [-i,--ignore fileextension, PDF/A errors] | [-h,--help] \r\n"
+		return "Usage: --action metrics|combine|extract|a3only|ubl|validate|visualize [-d,--directory] [-l,--listfromstdin] [-i,--ignore fileextension, PDF/A errors] | [-h,--help] \r\n"
 				+ "        --action=metrics\n"
 				+ "          -d, --directory count ZUGFeRD files in directory to be scanned\n"
 				+ "                If it is a directory, it will recurse.\n"
@@ -85,6 +86,9 @@ public class Main {
 				+ "                [--no-notices]: refrain from reporting notices\n"
 				+ "                Additional parameters (optional - user will be prompted if not defined)\n"
 				+ "					-d, --directory to check recursively \n"
+				+ "        --action=ubl   convert UN/CEFACT 2016b CII XML to UBL XML\n"
+				+ "                [--source <filename>]: set input XML file\n"
+				+ "                [--out <filename>]: set output XML file\n"
 				+ "        --action=validateExpectInvalid  validate directory expecting negative results \n"
 				+ "                [--no-notices]: refrain from reporting notices\n"
 				+ "                Additional parameters (optional - user will be prompted if not defined)\n"
@@ -251,6 +255,38 @@ public class Main {
 		System.out.println("Written to " + outName);
 
 	}
+
+	/***
+	 * converts from CII to UBL
+	 * @param xmlName
+	 * @param outName
+	 * @throws IOException
+	 * @throws TransformerException
+	 */
+	private static void performUBL(String xmlName, String outName) throws IOException, TransformerException {
+
+		// Get params from user if not already defined
+		if (xmlName == null) {
+			xmlName = getFilenameFromUser("Factur-X XML source", "factur-x.xml", "xml", true, false);
+		} else {
+			System.out.println("Factur-X XML source set to " + xmlName);
+		}
+		if (outName == null) {
+			outName = getFilenameFromUser("UBL target", "ubl-invoice.xml", "xml", false, true);
+		} else {
+			System.out.println("UBL target to " + outName);
+		}
+
+		// Verify params
+		ensureFileExists(xmlName);
+		ensureFileNotExists(outName);
+
+		// All params are good! continue...
+		CIIToUBL c2u = new CIIToUBL();
+		c2u.convert(new File(xmlName), new File(outName));
+		System.out.println("Written to " + outName);
+
+	}
 	/***
 	 * the main function of the commandline tool...
 	 * @param args
@@ -337,6 +373,9 @@ public class Main {
 				optionsRecognized=true;
 			} else if ((action!=null)&&(action.equals("upgrade")))  {
 				performUpgrade(sourceName, outName);
+				optionsRecognized=true;
+			} else if ((action!=null)&&(action.equals("ubl")))  {
+				performUBL(sourceName, outName);
 				optionsRecognized=true;
 			} else if ((action!=null)&&(action.equals("validate"))) {
 				optionsRecognized=performValidate(sourceName, noNotices!=null&&noNotices, parser.getOptionValue(logAppendOption));

--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -94,6 +94,8 @@ public class Main {
 				+ "                Additional parameters (optional - user will be prompted if not defined)\n"
 				+ "					-d, --directory to check recursively\n"
 				+ "        --action=visualize  convert XML to HTML \n"
+				+ "                [--source <filename>]: set input XML file\n"
+				+ "                [--out <filename>]: set output HTML file\n"
 				;
 	}
 

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>com.helger</groupId>
 			<artifactId>en16931-cii2ubl</artifactId>
-			<version>1.2.5</version>
+			<version>1.3.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
 		<dependency>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -90,6 +90,12 @@
 			<artifactId>en16931-cii2ubl</artifactId>
 			<version>1.2.5</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.3</version>
+		</dependency>
 
 		<dependency>
 			<groupId>com.helger</groupId>
@@ -115,6 +121,12 @@
 			<version>9.1.1</version>
 			<scope>compile</scope>
 		</dependency>
+		<!-- API -->
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>2.3.3</version>
+		</dependency>
 
 	</dependencies>
 	<build>
@@ -124,12 +136,6 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.1</version>
 				<configuration>
-					<archive>
-						<manifest>
-							<addClasspath>true</addClasspath>
-							<mainClass>org.mustangproject.toecount.Toecount</mainClass>
-						</manifest>
-					</archive>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
@@ -145,12 +151,7 @@
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>3.2.1</version>
 				<configuration>
-					<shadedArtifactAttached>true</shadedArtifactAttached>
-					<transformers>
-						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-							<mainClass>org.mustangproject.toecount.Toecount</mainClass>
-						</transformer>
-					</transformers>
+					<shadedArtifactAttached>false</shadedArtifactAttached>
 					<minimizeJar>false</minimizeJar><!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
 					<filters>
 

--- a/library/src/main/java/org/mustangproject/TradeParty.java
+++ b/library/src/main/java/org/mustangproject/TradeParty.java
@@ -268,10 +268,6 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 		return vatID;
 	}
 
-	public String getZip() {
-		return zip;
-	}
-
 	@Override
 	public IZUGFeRDExportableContact getContact() {
 		return contact;


### PR DESCRIPTION
if `<shadedArtifactAttached>` remains `true` the following error will occur `Fehler beim Aufruf von Reflektion auf Zielklassen. Stellen Sie sicher, dass alle referenzierten Klassen im Classpath vorhanden sind: interface javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter` when running sth like `java -jar Mustang-CLI\target\Mustang-CLI-2.0.4-SNAPSHOT.jar --action ubl --source xrechnung.xml`