### PR TITLE
Allow setting Contact for recipient TradeParty in XRechnung

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -129,7 +129,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		}
 		xml += "	<ram:Name>" + XMLTools.encodeXML(party.getName()) + "</ram:Name>\n";
 
-		if ((party.getContact() != null) && (isSender || profile == Profiles.getByName("Extended"))) {
+		if ((party.getContact() != null) && (isSender || profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung"))) {
 			xml = xml + "<ram:DefinedTradeContact>\n" + "     <ram:PersonName>" + XMLTools.encodeXML(party.getContact().getName())
 					+ "</ram:PersonName>\n";
 			if (party.getContact().getPhone() != null) {


### PR DESCRIPTION
This adds support for setting a Contact for the recipient (buyer) TradeParty while using the XRechnung profile in accordance with the format specifications. I've tested this in all relevant combinations and validated the results with the Mustang validator without errors.

Please tell me if anything else is required to get this merged, since I didn't find any contribution guidelines.