### PR TITLE
activate shade-plugin only for module CLI; fixes ClassNotFoundExcepti…

### DIFF
--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -37,6 +37,11 @@
         -->
       </dependency>
       <dependency>
+         <groupId>com.helger</groupId>
+         <artifactId>en16931-cii2ubl</artifactId>
+         <version>1.3.0</version>
+      </dependency>
+      <dependency>
          <!-- for commandline options -->
          <groupId>com.sanityinc</groupId>
          <artifactId>jargs</artifactId>
@@ -144,24 +149,6 @@
                         <exclude>META-INF/*.DSA</exclude>
                         <exclude>META-INF/*.RSA</exclude>
                      </excludes>
-                  </filter>
-                  <filter>
-                     <artifact>log4j:log4j</artifact>
-                     <includes>
-                        <include>**</include>
-                     </includes>
-                  </filter>
-                  <filter>
-                     <artifact>commons-logging:commons-logging</artifact>
-                     <includes>
-                        <include>**</include>
-                     </includes>
-                  </filter>
-                  <filter>
-                     <artifact>com.sun.xml.bind:jaxb-impl</artifact>
-                     <includes>
-                        <include>**</include>
-                     </includes>
                   </filter>
                </filters>
             </configuration>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -149,55 +149,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.1</version>
-				<configuration>
-					<shadedArtifactAttached>false</shadedArtifactAttached>
-					<minimizeJar>false</minimizeJar><!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
-					<filters>
-
-						<filter>
-							<artifact>*:*</artifact>
-							<excludes>
-								<exclude>META-INF/*.SF</exclude>
-								<exclude>META-INF/*.DSA</exclude>
-								<exclude>META-INF/*.RSA</exclude>
-							</excludes>
-						</filter>
-						<filter>
-							<artifact>log4j:log4j</artifact>
-							<includes>
-								<include>**</include>
-							</includes>
-						</filter>
-						<filter>
-							<artifact>commons-logging:commons-logging</artifact>
-							<includes>
-								<include>**</include>
-							</includes>
-						</filter>
-					</filters>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<artifactSet>
-								<excludes>
-									<!--exclude>classworlds:classworlds</exclude> <exclude>junit:junit</exclude>
-                                        <exclude>jmock:*</exclude> <exclude>*:xml-apis</exclude> <exclude>org.apache.maven:lib:tests</exclude>
-                                        <exclude>log4j:log4j:jar:</exclude -->
-								</excludes>
-							</artifactSet>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>templating-maven-plugin</artifactId>
 				<version>1.0.0</version>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -166,56 +166,6 @@
             </plugin>
             <!-- /ZUV -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <minimizeJar>false</minimizeJar>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>log4j:log4j</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
-                            <artifact>commons-logging:commons-logging</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
-                            <artifact>com.sun.xml.bind:jaxb-impl</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <excludes />
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>


### PR DESCRIPTION
1. fixes the ClassNotFoundException mentioned in #214; see comment in #185
2. I activated the shade-plugin only for module CLI, because in my opinion you don't really need shaded jars for library and validator. If you use library/validator in your own project (like me), Maven/Gradle will pull in the other jars transitively.

