### PR TITLE
Remove outdated dependency to ph-commons 9.1.1 in library/pom.xml

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -117,12 +117,6 @@
 			<artifactId>xmlunit-assertj</artifactId>
 			<version>2.6.3</version>
 		</dependency>
-		<dependency>
-			<groupId>com.helger</groupId>
-			<artifactId>ph-commons</artifactId>
-			<version>9.1.1</version>
-			<scope>compile</scope>
-		</dependency>
 		<!-- API -->
 		<dependency>
 			<groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
to make UBL conversion work again with Mustang-CLI and in other programs.

ph-commons 9.1.1 is missing some classes needed by en16931-cii2ubl (1.3.0). 
So the dependency to this version in the library broke UBL conversion in all programs 
using mustang library as version 9.1.1 got always included in the jar and not the 
current version.