### PR TITLE
Set ignoreInputErrors flag before loading PDFs

### DIFF
--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -642,14 +642,15 @@ public class Main {
 			}
 
 			// All params are good! continue...
-			ZUGFeRDExporterFromA1 ze = (ZUGFeRDExporterFromA1) new ZUGFeRDExporterFromA1().setProducer("Mustang-cli")
+			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1().setProducer("Mustang-cli")
 					.setZUGFeRDVersion(zfIntVersion)
-					.setCreator(System.getProperty("user.name")).setProfile(zfConformanceLevelProfile)
-					.load(pdfName);
+					.setCreator(System.getProperty("user.name")).setProfile(zfConformanceLevelProfile);
+
 			if (ignoreInputErrors) {
 				ze.ignorePDFAErrors();
-
 			}
+
+			ze = ze.load(pdfName);
 
 			if (!format.equals("fx")) {
 				ze.disableFacturX();


### PR DESCRIPTION
I noticed that PDF files are still checked for PDF/A conformity even though the  `-i` was set. This fix makes the flag work as it should (at least from my expectations).