### PR TITLE
Use typecode 58 (SEPA) in SpecifiedTradeSettlementPaymentMeans

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
@@ -68,8 +68,8 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 		}
 
 		String xml = "			<ram:SpecifiedTradeSettlementPaymentMeans>\n"
-				+ "				<ram:TypeCode>42</ram:TypeCode>\n"
-				+ "				<ram:Information>Bank transfer</ram:Information>\n"
+				+ "				<ram:TypeCode>58</ram:TypeCode>\n"
+				+ "				<ram:Information>SEPA credit transfer</ram:Information>\n"
 				+ "				<ram:PayeePartyCreditorFinancialAccount>\n"
 				+ "					<ram:IBANID>" + XMLTools.encodeXML(getOwnIBAN()) + "</ram:IBANID>\n";
 		xml+= accountNameStr;


### PR DESCRIPTION
as old code 42 is for the more generic "payment to bank account" while
the ZUGFeRD specification and EN16931-1 recommend to clearly distinguish
between SEPA transfers and non SEPA transfers and we are only supporting
SEPA payment data right now.