### PR TITLE
Multiple changes to do with XRechnung and OrderX

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaPDFAExtensions.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaPDFAExtensions.java
@@ -31,6 +31,7 @@ import org.apache.xmpbox.XMPMetadata;
 import org.apache.xmpbox.XmpConstants;
 import org.apache.xmpbox.schema.PDFAExtensionSchema;
 import org.apache.xmpbox.type.*;
+import org.mustangproject.EStandard;
 
 /**
  * Additionally to adding a RDF namespace with a indication which file
@@ -52,7 +53,7 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 	public final String prefix_pdfaProperty = "pdfaProperty";
 	public String namespace = null;
 	public String prefix = null;
-	
+
 	protected IZUGFeRDExporter exporter;
 
 
@@ -90,20 +91,21 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 	}
 
 	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion) {
-		super(metadata);
-		exporter=ze;
-		setZUGFeRDVersion(ZFVersion);
-		attachExtensions(metadata, true);
+		this(ze, metadata, ZFVersion, true);
 	}
 
 	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion, boolean withZF) {
+		this(ze, metadata, ZFVersion, withZF, null);
+	}
+
+	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion, boolean withZF, EStandard eStandard) {
 		super(metadata);
 		exporter=ze;
 		setZUGFeRDVersion(ZFVersion);
-		attachExtensions(metadata, withZF);
+		attachExtensions(metadata, withZF, eStandard);
 	}
 
-	public void attachExtensions(XMPMetadata metadata, boolean withZF) {
+	public void attachExtensions(XMPMetadata metadata, boolean withZF, EStandard eStandard) {
 
 		addNamespace(xmlns_pdfaSchema, prefix_pdfaSchema);
 		addNamespace(xmlns_pdfaProperty, prefix_pdfaProperty);
@@ -130,11 +132,21 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 					PDFASchemaType.PROPERTY, Cardinality.Seq);
 			li.addProperty(newSeq);
 
-			addProperty(newSeq, "DocumentFileName", "Text", "external", "name of the embedded XML invoice file");
-			addProperty(newSeq, "DocumentType", "Text", "external", "INVOICE");
-			addProperty(newSeq, "Version", "Text", "external", "The actual version of the ZUGFeRD XML schema");
-			addProperty(newSeq, "ConformanceLevel", "Text", "external",
-					"The selected ZUGFeRD profile completeness");
+			if ((eStandard != null) && (eStandard == EStandard.orderx))
+			{
+				addProperty(newSeq, "DocumentFileName", "Text", "external", "Name of the embedded XML Order (or related) file");
+				addProperty(newSeq, "DocumentType", "Text", "external", "ORDER, ORDER_RESPONSE, or ORDER_CHANGE");
+				addProperty(newSeq, "Version", "Text", "external", "The actual version of the Order-X XML schema");
+				addProperty(newSeq, "ConformanceLevel", "Text", "external",
+								    "The selected Order-X profile completeness");
+			} else
+			{
+				addProperty(newSeq, "DocumentFileName", "Text", "external", "name of the embedded XML invoice file");
+				addProperty(newSeq, "DocumentType", "Text", "external", "INVOICE");
+				addProperty(newSeq, "Version", "Text", "external", "The actual version of the ZUGFeRD XML schema");
+				addProperty(newSeq, "ConformanceLevel", "Text", "external",
+								    "The selected ZUGFeRD profile completeness");
+			}
 		}
 	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaZugferd.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaZugferd.java
@@ -33,6 +33,7 @@ public class XMPSchemaZugferd extends XMPSchema {
 
 	/***
 	 * This is what needs to be added to the RDF metadata - basically the name of the embedded Zugferd file
+	 *
 	 * @param metadata the xmp to be added to
 	 * @param zfVersion which ZF version to use (2 for FX)
 	 * @param isFacturX whether to export as Factur-X
@@ -41,7 +42,26 @@ public class XMPSchemaZugferd extends XMPSchema {
 	 * @param prefix the xml namespace prefix for the XMP, zf for ZUGFeRD, fx for Factur-X
 	 * @param filename the filename of the invoice
 	 */
-	public XMPSchemaZugferd(XMPMetadata metadata, int zfVersion, boolean isFacturX, Profile conformanceLevel, String URN, String prefix, String filename) {
+	public XMPSchemaZugferd(XMPMetadata metadata, int zfVersion, boolean isFacturX, Profile conformanceLevel,
+			                String URN, String prefix, String filename) {
+		this(metadata, zfVersion, isFacturX, conformanceLevel, URN, prefix, filename, null);
+	}
+
+
+	/***
+	 * This is what needs to be added to the RDF metadata - basically the name of the embedded Zugferd file
+	 *
+	 * @param metadata the xmp to be added to
+	 * @param zfVersion which ZF version to use (2 for FX)
+	 * @param isFacturX whether to export as Factur-X
+	 * @param conformanceLevel e.g.  conformanceLevel.EN16931
+	 * @param URN the xml URI for the XMP
+	 * @param prefix the xml namespace prefix for the XMP, zf for ZUGFeRD, fx for Factur-X
+	 * @param filename the filename of the invoice
+	 * @param version meta-data version to set. May be null, and then it is set automatically
+	 */
+	public XMPSchemaZugferd(XMPMetadata metadata, int zfVersion, boolean isFacturX, Profile conformanceLevel,
+			                String URN, String prefix, String filename, String version) {
 		super(metadata, URN, prefix, "ZUGFeRD Schema");
 
 		setAboutAsSimple("");
@@ -50,14 +70,17 @@ public class XMPSchemaZugferd extends XMPSchema {
 		setTextPropertyValue("ConformanceLevel", conformanceLevelValue);
 		setTextPropertyValue("DocumentType", "INVOICE");
 		setTextPropertyValue("DocumentFileName", filename);
-		String version="1.0";
-		if ((zfVersion==2)&&(!isFacturX)) {
-			version="2p0";
+
+		if (version == null) {
+		    version = "1.0";
+		    if ((zfVersion==2)&&(!isFacturX)) {
+				version="2p0";
+			}
 		}
 		setTextPropertyValue("Version", version);
 	}
 
-	/***
+    /***
 	 * Specify a custom XMP metadata document type
 	 * @param type INVOICE or ORDER
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
@@ -115,6 +115,11 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	protected int ZFVersion = DefaultZUGFeRDVersion;
 	private boolean attachZUGFeRDHeaders = true;
+	
+	
+	// Specific metaData version in case of XRechnung. We need it to be settable
+	// by the caller if necessary.
+	protected String XRechnungVersion = null; // Default XRechnung as of late 2021 is 2p0
 
 	/**
 	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on the
@@ -220,6 +225,20 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		isFacturX = true;
 		return this;
 	}
+	
+	
+	/**
+	 * Sets a specific XRechnung version from outside. This version needs to be present in the
+	 * meta-data as well. The caller may wish to generate a specific version of XRechnung
+	 * depending on the time period etc.
+	 *
+	 * @param XRechnungVersion the XRechnung version
+	 */
+    public void setXRechnungSpecificVersion(String XRechnungVersion)
+    {
+    	this.XRechnungVersion = XRechnungVersion;
+    }
+	
 
 	/***
 	 * Generate ZF2.0/2.1 files with filename zugferd-invoice.xml instead of factur-x.xml
@@ -300,6 +319,24 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 			close();
 		}
 	}
+
+
+	/**
+	 * Embeds an external file (generic - any type allowed) in the PDF.
+	 * The embedding is done in the default PDF document.
+	 *
+	 * @param filename     name of the file that will become attachment name in the PDF
+	 * @param relationship how the file relates to the content, e.g. "Alternative"
+	 * @param description  Human-readable description of the file content
+	 * @param subType      type of the data e.g. could be "text/xml" - mime like
+	 * @param data         the binary data of the file/attachment
+	 * @throws java.io.IOException if anything is wrong with filename
+	 */
+	public void PDFAttachGenericFile(String filename, String relationship, String description,
+									 String subType, byte[] data) throws IOException {
+		PDFAttachGenericFile(this.doc, filename, relationship, description, subType, data);
+	}
+
 
 	/**
 	 * Embeds an external file (generic - any type allowed) in the PDF.
@@ -467,10 +504,19 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 */
 	protected void addXMP(XMPMetadata metadata) {
 
+    	String metaDataVersion = null; // default will be used
+
+    	// The XRechnung version may be settable from outside.
+    	if ((this.XRechnungVersion != null) && (this.profile != null) &&
+    		this.profile.getName().equalsIgnoreCase(Profiles.getByName("XRECHNUNG").getName()))
+    	{
+    		metaDataVersion = this.XRechnungVersion;
+    	}
+
 		if (attachZUGFeRDHeaders) {
 			XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, ZFVersion, isFacturX, xmlProvider.getProfile(),
 					getNamespaceForVersion(ZFVersion), getPrefixForVersion(ZFVersion),
-					getFilenameForVersion(ZFVersion, xmlProvider.getProfile()));
+					getFilenameForVersion(ZFVersion, xmlProvider.getProfile()), metaDataVersion);
 
 			metadata.addSchema(zf);
 		}
@@ -480,8 +526,9 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		metadata.addSchema(pdfaex);
 	}
 
-	protected void removeCidSet(PDDocumentCatalog catalog, PDDocument doc) {
-
+	private void removeCidSet(PDDocumentCatalog catalog, PDDocument doc)
+	    throws IOException
+	{
 		// https://github.com/ZUGFeRD/mustangproject/issues/249
 
 		COSName cidSet = COSName.getPDFName("CIDSet");
@@ -507,7 +554,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 							}
 						}
 					} catch (IOException e) {
-						e.printStackTrace();
+						throw e;
 					}
 					// do stuff with the font
 				}
@@ -567,7 +614,21 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		prepareDocument();
 		xmlProvider.generateXML(trans);
 		String filename = getFilenameForVersion(ZFVersion, xmlProvider.getProfile());
-		PDFAttachGenericFile(doc, filename, "Alternative",
+
+        String relationship = "Alternative";
+        // ZUGFeRD 2.1.1 Technical Supplement | Part A | 2.2.2. Data Relationship
+        // See documentation ZUGFeRD211_EN/Documentation/ZUGFeRD-2.1.1 - Specification_TA_Part-A.pdf
+        // https://www.ferd-net.de/standards/zugferd-2.1.1/index.html
+        if (ZFVersion >= 2)
+        {
+        	if (this.profile.getName().equalsIgnoreCase(Profiles.getByName("MINIMUM").getName()) ||
+        		this.profile.getName().equalsIgnoreCase(Profiles.getByName("BASICWL").getName()))
+        	{
+        		relationship = "Data";
+        	}
+        }
+
+		PDFAttachGenericFile(doc, filename, relationship,
 				"Invoice metadata conforming to ZUGFeRD standard (http://www.ferd-net.de/front_content.php?idcat=231&lang=4)",
 				"text/xml", xmlProvider.getXML());
 
@@ -582,14 +643,16 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 * Reads the XMPMetadata from the PDDocument, if it exists.
 	 * Otherwise creates XMPMetadata.
 	 */
-	protected XMPMetadata getXmpMetadata() {
+	protected XMPMetadata getXmpMetadata()
+	    throws IOException
+	{
 		PDMetadata meta = doc.getDocumentCatalog().getMetadata();
-		if (meta != null) {
+		if ((meta != null) && (meta.getLength() > 0)) {
 			try {
 				DomXmpParser xmpParser = new DomXmpParser();
 				return xmpParser.parse(meta.toByteArray());
-			} catch (XmpParsingException | IOException e) {
-				// TODO use logging or handle the error somehow
+			} catch (XmpParsingException e) {
+				throw new IOException(e);
 			}
 		}
 		return XMPMetadata.createXMPMetadata();
@@ -723,7 +786,9 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	/**
 	 * Adds an OutputIntent and the sRGB color profile if no OutputIntent exist
 	 */
-	protected void addSRGBOutputIntend() {
+	protected void addSRGBOutputIntend()
+	    throws IOException
+	{
 		if (!doc.getDocumentCatalog().getOutputIntents().isEmpty()) {
 			return;
 		}
@@ -739,7 +804,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 				doc.getDocumentCatalog().addOutputIntent(intent);
 			}
 		} catch (IOException e) {
-			// TODO use logging or handle the error somehow
+			throw e;
 		}
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
@@ -115,8 +115,8 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	protected int ZFVersion = DefaultZUGFeRDVersion;
 	private boolean attachZUGFeRDHeaders = true;
-	
-	
+
+
 	// Specific metaData version in case of XRechnung. We need it to be settable
 	// by the caller if necessary.
 	protected String XRechnungVersion = null; // Default XRechnung as of late 2021 is 2p0
@@ -225,8 +225,8 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		isFacturX = true;
 		return this;
 	}
-	
-	
+
+
 	/**
 	 * Sets a specific XRechnung version from outside. This version needs to be present in the
 	 * meta-data as well. The caller may wish to generate a specific version of XRechnung
@@ -238,7 +238,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
     {
     	this.XRechnungVersion = XRechnungVersion;
     }
-	
+
 
 	/***
 	 * Generate ZF2.0/2.1 files with filename zugferd-invoice.xml instead of factur-x.xml
@@ -619,7 +619,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
         // ZUGFeRD 2.1.1 Technical Supplement | Part A | 2.2.2. Data Relationship
         // See documentation ZUGFeRD211_EN/Documentation/ZUGFeRD-2.1.1 - Specification_TA_Part-A.pdf
         // https://www.ferd-net.de/standards/zugferd-2.1.1/index.html
-        if (ZFVersion >= 2)
+        if ((this.profile != null) && (ZFVersion >= 2))
         {
         	if (this.profile.getName().equalsIgnoreCase(Profiles.getByName("MINIMUM").getName()) ||
         		this.profile.getName().equalsIgnoreCase(Profiles.getByName("BASICWL").getName()))


### PR DESCRIPTION
This represents a set of changes proposed from the Seeburger fork:
1. Allowing the XRechnung version to be explicitly set in the PDF meta-data (must match the version in the attached XML).
2. Change/fix for data relationship in case of MINIMUM and BASICWL profile. See documentation ZUGFeRD211_EN/Documentation/ZUGFeRD-2.1.1 - Specification_TA_Part-A.pdf
3. OrderX document type setting and slight meta-data improvements
4. Error handling improvements (exceptions not suppressed, throwing RutnimeException instead of error)

Maven build with the PR branch (including unit tests) works.

---------------------------------------------
BTW: I have seen one problem with the Mustang build. If the maven clean target is executed, the build overall fails. So
```
mvn clean package install  # will fail
mvn package install # will work ...
```
Example log:
```
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ git branch
* master
  seeburger
  temp_branch_for_upstream_PRs_02_2022
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ git log -5
commit 3f80c1daaf285fd17c1e2e49608c182696d6261c (HEAD -> master, origin/master)
Author: jstaerk <jstaerk@usegroup.de>
Date:   Thu Jan 27 08:51:02 2022 +0100

    distinguish if a validation was done on XML or PDF
    
    (cherry picked from commit cd7edc31e694fc49f1e16789c0e9795bce2c754d)

commit f255e5b8648afed4be4b603d04b7d7bfa4ce891b
Merge: 263bdf6 717bd87
Author: jstaerk <jstaerk@usegroup.de>
Date:   Thu Jan 13 13:41:44 2022 +0100

    Merge branch 'master' of github.com:ZUGFeRD/mustangproject

commit 717bd87268cfdf0aacfeeff47578a66e0c7a0f94
Author: Jochen Staerk <jstaerk@usegroup.de>
Date:   Thu Jan 13 12:09:03 2022 +0100

    Update README.md

commit 263bdf6f315f928bb81271a2eb39962682423aaa
Author: jstaerk <jstaerk@usegroup.de>
Date:   Thu Jan 13 11:34:18 2022 +0100

    [maven-release-plugin] prepare for next development iteration

commit 8069b503e0a43e9d98e0be8bb03434842eed674c
Author: jstaerk <jstaerk@usegroup.de>
Date:   Thu Jan 13 11:34:17 2022 +0100

    [maven-release-plugin] prepare release core-2.4.0
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ mvn clean package install 
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 4 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 4 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Mustang                                                            [pom]
[INFO] Library to write, read and validate e-invoices (Factur-X, ZUGFeRD and to a limited extend XRechnung/CII). [jar]
[INFO] Library to validate e-invoices (ZUGFeRD, Factur-X and Xrechnung)   [jar]
[INFO] e-invoices commandline tool, allowing to create(embed), split and validate Factur-X/ZUGFeRD files. Validation should also work for XRechnung/CII. [jar]
[INFO] 
[INFO] ----------------------< org.mustangproject:core >-----------------------
[INFO] Building Mustang 2.4.1-SNAPSHOT                                    [1/4]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ core ---
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ core ---
[INFO] Installing /home/ivan/Projects/MustangOrderX/PDFA3/pom.xml to /home/ivan/.m2/repository/org/mustangproject/core/2.4.1-SNAPSHOT/core-2.4.1-SNAPSHOT.pom
[INFO] 
[INFO] ---------------------< org.mustangproject:library >---------------------
[INFO] Building Library to write, read and validate e-invoices (Factur-X, ZUGFeRD and to a limited extend XRechnung/CII). 2.4.1-SNAPSHOT [2/4]
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for org.glassfish.jaxb:jaxb-runtime:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[WARNING] The POM for org.glassfish.jaxb:jaxb-core:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ library ---
[INFO] Deleting /home/ivan/Projects/MustangOrderX/PDFA3/library/target
[INFO] 
[INFO] --- templating-maven-plugin:1.0.0:filter-sources (filtering-java-templates) @ library ---
[INFO] Coping files with filtering to temporary directory.
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] Copied 1 files to output directory: /home/ivan/Projects/MustangOrderX/PDFA3/library/target/generated-sources/java-templates
[INFO] Source directory: /home/ivan/Projects/MustangOrderX/PDFA3/library/target/generated-sources/java-templates added.
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ library ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 8 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.6.1:compile (default-compile) @ library ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 61 source files to /home/ivan/Projects/MustangOrderX/PDFA3/library/target/classes
[INFO] /home/ivan/Projects/MustangOrderX/PDFA3/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java: Some input files use or override a deprecated API.
[INFO] /home/ivan/Projects/MustangOrderX/PDFA3/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ library ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 21 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.6.1:testCompile (default-testCompile) @ library ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 25 source files to /home/ivan/Projects/MustangOrderX/PDFA3/library/target/test-classes
[INFO] /home/ivan/Projects/MustangOrderX/PDFA3/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java: Some input files use or override a deprecated API.
[INFO] /home/ivan/Projects/MustangOrderX/PDFA3/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ library ---
[INFO] Surefire report directory: /home/ivan/Projects/MustangOrderX/PDFA3/library/target/surefire-reports

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.mustangproject.ZUGFeRD.XRTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.302 sec
Running org.mustangproject.ZUGFeRD.BaseTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec
Running org.mustangproject.ZUGFeRD.CalculationTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 sec
Running org.mustangproject.ZUGFeRD.UXTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec
Running org.mustangproject.ZUGFeRD.MustangReaderWriterTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.195 sec
Running org.mustangproject.ZUGFeRD.VisualizationTest
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Warning at char 27 in xsl:value-of/@select on line 1985 column 166 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at xsl:for-each on line 2083 column 78 
  SXWN9009: An empty xsl:for-each instruction has no effect
Warning at char 6 in xsl:value-of/@select on line 1010 column 126 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 6 in xsl:value-of/@select on line 1927 column 119 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 27 in xsl:value-of/@select on line 1985 column 166 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 6 in xsl:value-of/@select on line 1010 column 126 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 6 in xsl:value-of/@select on line 1927 column 119 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning at char 27 in xsl:value-of/@select on line 1985 column 166 
  SXWN9000: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty
Warning 
  XTDE0540: Ambiguous rule match for
  /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction[1]/ram:ApplicableHeaderTradeSettlement[1]/ram:SpecifiedTradeSettlementPaymentMeans[1]/ram:PayeeSpecifiedCreditorFinancialInstitution[1]/ram:BICID[1]
Matches both "document-node()/element(Q{urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100}CrossIndustryInvoice)/element(Q{urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100}SupplyChainTradeTransaction)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}ApplicableHeaderTradeSettlement)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}SpecifiedTradeSettlementPaymentMeans)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}PayeeSpecifiedCreditorFinancialInstitution)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}BICID)" on line 1205 of 
and "document-node()/el
Warning 
  XTDE0540: Ambiguous rule match for
  /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction[1]/ram:ApplicableHeaderTradeSettlement[1]/ram:SpecifiedTradeSettlementPaymentMeans[1]/ram:PayeeSpecifiedCreditorFinancialInstitution[1]/ram:BICID[1]
Matches both "document-node()/element(Q{urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100}CrossIndustryInvoice)/element(Q{urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100}SupplyChainTradeTransaction)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}ApplicableHeaderTradeSettlement)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}SpecifiedTradeSettlementPaymentMeans)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}PayeeSpecifiedCreditorFinancialInstitution)/element(Q{urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100}BICID)" on line 1205 of 
and "document-node()/el
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.246 sec
Running org.mustangproject.ZUGFeRD.MustangReaderWriterCustomXMLTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.185 sec
Running org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest
Jan 31, 2022 2:21:03 PM org.mustangproject.ZUGFeRD.ZUGFeRDImporter <init>
SEVERE: null
java.nio.file.NoSuchFileException: ./target/testout-ZF2PushItemChargesAllowances.pdf
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:83)
	at org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter.<init>(ZUGFeRDInvoiceImporter.java:30)
	at org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest.testItemAllowancesChargesImport(ZF2ZInvoiceImporterTest.java:100)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

Jan 31, 2022 2:21:03 PM org.mustangproject.ZUGFeRD.ZUGFeRDImporter <init>
SEVERE: null
java.nio.file.NoSuchFileException: ./target/testout-ZF2PushChargesAllowances.pdf
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:83)
	at org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter.<init>(ZUGFeRDInvoiceImporter.java:30)
	at org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest.testAllowancesChargesImport(ZF2ZInvoiceImporterTest.java:116)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

Jan 31, 2022 2:21:03 PM org.mustangproject.ZUGFeRD.ZUGFeRDImporter <init>
SEVERE: null
java.nio.file.NoSuchFileException: ./target/testout-ZF2new.pdf
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:83)
	at org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter.<init>(ZUGFeRDInvoiceImporter.java:30)
	at org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest.testInvoiceImport(ZF2ZInvoiceImporterTest.java:53)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

Tests run: 3, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 0.022 sec <<< FAILURE!
testItemAllowancesChargesImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest)  Time elapsed: 0.012 sec  <<< ERROR!
org.mustangproject.ZUGFeRD.ZUGFeRDExportException: java.nio.file.NoSuchFileException: ./target/testout-ZF2PushItemChargesAllowances.pdf
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:87)
	at org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter.<init>(ZUGFeRDInvoiceImporter.java:30)
	at org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest.testItemAllowancesChargesImport(ZF2ZInvoiceImporterTest.java:100)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
Caused by: java.nio.file.NoSuchFileException: ./target/testout-ZF2PushItemChargesAllowances.pdf
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:83)
	... 27 more

testAllowancesChargesImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest)  Time elapsed: 0.005 sec  <<< ERROR!
org.mustangproject.ZUGFeRD.ZUGFeRDExportException: java.nio.file.NoSuchFileException: ./target/testout-ZF2PushChargesAllowances.pdf
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:87)
	at org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter.<init>(ZUGFeRDInvoiceImporter.java:30)
	at org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest.testAllowancesChargesImport(ZF2ZInvoiceImporterTest.java:116)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
Caused by: java.nio.file.NoSuchFileException: ./target/testout-ZF2PushChargesAllowances.pdf
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:83)
	... 27 more

testInvoiceImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest)  Time elapsed: 0.002 sec  <<< ERROR!
org.mustangproject.ZUGFeRD.ZUGFeRDExportException: java.nio.file.NoSuchFileException: ./target/testout-ZF2new.pdf
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:87)
	at org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter.<init>(ZUGFeRDInvoiceImporter.java:30)
	at org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest.testInvoiceImport(ZF2ZInvoiceImporterTest.java:53)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
Caused by: java.nio.file.NoSuchFileException: ./target/testout-ZF2new.pdf
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.mustangproject.ZUGFeRD.ZUGFeRDImporter.<init>(ZUGFeRDImporter.java:83)
	... 27 more

Running org.mustangproject.ZUGFeRD.UBLTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.531 sec
Running org.mustangproject.ZUGFeRD.OXTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 sec
Running org.mustangproject.ZUGFeRD.DeSerializationTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.16 sec
Running org.mustangproject.ZUGFeRD.ZF2EdgeTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.085 sec
Running org.mustangproject.ZUGFeRD.BackwardCompatibilityTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.181 sec
Running org.mustangproject.ZUGFeRD.ZF2PushTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.382 sec
Running org.mustangproject.ZUGFeRD.MustangReaderWriterEdgeTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.118 sec
Running org.mustangproject.ZUGFeRD.ZF2Test
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.077 sec

Results :

Tests in error: 
  testItemAllowancesChargesImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-ZF2PushItemChargesAllowances.pdf
  testAllowancesChargesImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-ZF2PushChargesAllowances.pdf
  testInvoiceImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-ZF2new.pdf

Tests run: 46, Failures: 0, Errors: 3, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Mustang 2.4.1-SNAPSHOT:
[INFO] 
[INFO] Mustang ............................................ SUCCESS [  0.143 s]
[INFO] Library to write, read and validate e-invoices (Factur-X, ZUGFeRD and to a limited extend XRechnung/CII). FAILURE [  9.065 s]
[INFO] Library to validate e-invoices (ZUGFeRD, Factur-X and Xrechnung) SKIPPED
[INFO] e-invoices commandline tool, allowing to create(embed), split and validate Factur-X/ZUGFeRD files. Validation should also work for XRechnung/CII. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  9.780 s
[INFO] Finished at: 2022-01-31T14:21:06+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project library: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/ivan/Projects/MustangOrderX/PDFA3/library/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :library
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ 
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ 
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ 
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ 
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ 
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ 
ivan@ivan-vb:~/Projects/MustangOrderX/PDFA3$ mvn package install #will work ...


```