### PR TITLE
Add missing encodeXML to node payment terms description

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
@@ -35,7 +35,6 @@ import java.util.logging.Logger;
 
 import org.mustangproject.EStandard;
 import org.mustangproject.FileAttachment;
-import org.mustangproject.TradeParty;
 import org.mustangproject.XMLTools;
 
 public class OXPullProvider extends ZUGFeRD2PullProvider implements IXMLProvider {
@@ -57,7 +56,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider implements IXMLProvider
 		final String exemptionReason = "";
 
 		if (trans.getPaymentTermDescription() != null) {
-			paymentTermsDescription = trans.getPaymentTermDescription();
+      paymentTermsDescription = XMLTools.encodeXML(trans.getPaymentTermDescription());
 		}
 
 		if ((paymentTermsDescription == null) && (trans.getDocumentCode() != CORRECTEDINVOICE)/* && (trans.getDocumentCode() != DocumentCodeTypeConstants.CREDITNOTE)*/) {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -265,7 +265,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		String exemptionReason = "";
 
 		if (trans.getPaymentTermDescription() != null) {
-			paymentTermsDescription = trans.getPaymentTermDescription();
+      paymentTermsDescription = XMLTools.encodeXML(trans.getPaymentTermDescription());
 		}
 
 		if ((paymentTermsDescription == null) && (trans.getDocumentCode() != CORRECTEDINVOICE)/* && (trans.getDocumentCode() != DocumentCodeTypeConstants.CREDITNOTE)*/) {
@@ -746,7 +746,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		String paymentTermsXml = "<ram:SpecifiedTradePaymentTerms>";
 
 		final IZUGFeRDPaymentDiscountTerms discountTerms = paymentTerms.getDiscountTerms();
-		Date dueDate = paymentTerms.getDueDate();
+		final Date dueDate = paymentTerms.getDueDate();
 		if (dueDate != null && discountTerms != null && discountTerms.getBaseDate() != null) {
 			throw new IllegalStateException(
 					"if paymentTerms.dueDate is specified, paymentTerms.discountTerms.baseDate has not to be specified");


### PR DESCRIPTION
Someone always manages to insert a "&" in that node too ;-)