### PR TITLE
Proposed changes of namespace and meta-data for Delivery-X

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA1.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA1.java
@@ -40,11 +40,15 @@ public class DXExporterFromA1 extends DXExporterFromA3 implements IZUGFeRDExport
 	}
 	/***
 	 * internal helper function: get namespace for order-x
-	 * @param ver the order-x version
+	 * @param ver the delivery-x version
 	 * @return the URN of the namespace
 	 */
 	public String getNamespaceForVersion(int ver) {
-		return "urn:facturx:pdfa:CrossIndustryDocument:despatchadvice:1p0#";
+		// As of late 2022 the Delivery-X standard is not yet published. See specification:
+		// Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022
+		// Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
+		// http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html
+		return "urn:factur-x:pdfa:CrossIndustryDocument:despatchadvice:1p0#";
 	}
 	/***
 	 * internal helper: returns the namespace prefix for the given order-x version number

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA3.java
@@ -334,6 +334,12 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 */
 	public DXExporterFromA3 setXML(byte[] zugferdData) throws IOException {
 		CustomXMLProvider cus = new CustomXMLProvider();
+		// As of late 2022 the Delivery-X standard is not yet published. See specification:
+		// Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022
+		// Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
+		// http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html
+		cus.setProfile(Profiles.getByName(EStandard.despatchadvice, "PILOT", 1));
+
 		cus.setXML(zugferdData);
 		this.setXMLProvider(cus);
 		prepare();
@@ -425,14 +431,18 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	protected void addXMP(XMPMetadata metadata) {
 
 		if (attachZUGFeRDHeaders) {
+			// As of late 2022 the Delivery-X standard is not yet published. See specification:
+			// Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022
+			// Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
+			// http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html
 			XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, 1, true, xmlProvider.getProfile(),
-					"urn:facturx:pdfa:CrossIndustryDocument:despatchadvice:1p0#", "fx",
-					"cida.xml");
+					"urn:factur-x:pdfa:CrossIndustryDocument:despatchadvice:1p0#", "fx",
+					"cida.xml", "1.0");
 			zf.setType(this.despatchAdviceDocumentType);
 
 			metadata.addSchema(zf);
 			// also add the schema extensions...
-			XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, 1, attachZUGFeRDHeaders, EStandard.orderx);
+			XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, 1, attachZUGFeRDHeaders, EStandard.despatchadvice);
 			pdfaex.setZUGFeRDVersion(1);
 			metadata.addSchema(pdfaex);
 		}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaPDFAExtensions.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaPDFAExtensions.java
@@ -139,6 +139,16 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 				addProperty(newSeq, "Version", "Text", "external", "The actual version of the Order-X XML schema");
 				addProperty(newSeq, "ConformanceLevel", "Text", "external",
 								    "The selected Order-X profile completeness");
+			} else if ((eStandard != null) && (eStandard == EStandard.despatchadvice))
+			{
+				// As of late 2022 the Delivery-X standard is not yet published. See specification:
+				// Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022
+				// Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
+				// http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html
+				addProperty(newSeq, "DocumentFileName", "Text", "external", "Name of the embedded XML despatch advice file");
+				addProperty(newSeq, "DocumentType",     "Text", "external", "DESPATCHADVICE");
+				addProperty(newSeq, "Version",          "Text", "external", "The actual version of the despatch advice dataset");
+				addProperty(newSeq, "ConformanceLevel", "Text", "external", "The conformance level of the despatch advice dataset");
 			} else
 			{
 				addProperty(newSeq, "DocumentFileName", "Text", "external", "name of the embedded XML invoice file");


### PR DESCRIPTION
As of late 2022 the Delivery-X standard is not yet published. See specification:
Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022 
Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html

Seeburger intends to deliver this as an early-access implementation, subject to change (when the standard is made official).