### PR TITLE
Enabling Maven builds for push and pull requests in Github Cloud

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,6 @@ jobs:
       with:
         distribution: 'adopt' # for latest JDKs use temurin https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
         java-version: '8'
-        cache: 'maven'
+        cache: 'maven' #cache/restore any dependencies to improve the workflow execution time
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,22 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# For setup-java see: https://github.com/actions/setup-java#Usage 
+
+name: Java CI with Maven
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3 # the log states the default ~/.m2/toolchains.xml is being created pointing to the JDK
+      with:
+        distribution: 'adopt' # for latest JDKs use temurin https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
+        java-version: '8'
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -13,9 +13,9 @@
    <version>2.5.8-SNAPSHOT</version>
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
-      <maven.compiler.source>1.8</maven.compiler.source>
-      <maven.compiler.target>1.8</maven.compiler.target>
+      <maven.compiler.compilerVersion>8</maven.compiler.compilerVersion>
+      <maven.compiler.source>8</maven.compiler.source>
+      <maven.compiler.target>8</maven.compiler.target>
    </properties>
    <dependencies>
       <dependency>
@@ -101,8 +101,8 @@
             <configuration>
                <toolchains>
                   <jdk>
-                     <version>1.8</version>
-                     <vendor>openjdk</vendor>
+                     <version>8</version>
+                     <vendor>adopt</vendor>
                   </jdk>
                </toolchains>
             </configuration>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -45,9 +45,9 @@
 		<github.global.server>github</github.global.server>
 		<additionalparam>-Xdoclint:none</additionalparam>
 		<!-- Skip error check for javadoc -->
-		<maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.compilerVersion>8</maven.compiler.compilerVersion>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 		<maven.deploy.skip>true</maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
 
 	</properties>
@@ -138,8 +138,8 @@
 					<!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven
                         mvn clean compile assembly:single -->
 					<!-- or whatever version you use -->
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>8</source>
+					<target>8</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -156,8 +156,8 @@
 				<configuration>
 					<toolchains>
 						<jdk>
-							<version>1.8</version>
-							<vendor>openjdk</vendor>
+							<version>8</version>
+							<vendor>adopt</vendor>
 						</jdk>
 					</toolchains>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -192,8 +192,8 @@
                         <configuration>
                             <toolchains>
                                 <jdk>
-                                    <version>1.8</version>
-                                    <vendor>openjdk</vendor>
+                                    <version>8</version>
+                                    <vendor>adopt</vendor>
                                 </jdk>
                             </toolchains>
                         </configuration>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -29,9 +29,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>false
         </maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
-        <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.compilerVersion>8</maven.compiler.compilerVersion>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
 
     </properties>
     <dependencies>
@@ -156,8 +156,8 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <version>1.8</version>
-                            <vendor>openjdk</vendor>
+                            <version>8</version>
+                            <vendor>adopt</vendor>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -173,8 +173,8 @@
                     <!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven
                              mvn clean compile assembly:single -->
                     <!-- or whatever version you use -->
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <!-- /ZUV -->


### PR DESCRIPTION
Hi Jochen,

as I have local test/build problems with Mustang on Linux and Windows with your recent commits, I thought it might make sense to pre-date your Xmas present and provide a black Friday pull request to you! :-)

This new Yaml file .github/workflows/maven.yml will trigger a build and tests using GitHub/Microsoft Cloud whenever a push is being made or a pull request is being offered to this project! \o/
I have chosen Ubuntu as the build platform and JDK 8 but you might add a matrix with multiple JDKs and platforms, see

- https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
- https://github.com/actions/setup-java#Usage 

Of course, it is a trojan horse as **before you can accept/merge my pull request**...

1. You have to fix your build :-) - some months ago I struggled with ODF Toolkit as well a multi-pom project to get access to the test files of each sub-project independent from the starting directory you might have the same problem here.
AFAIR different plugin versions and platforms provided different behaviour, my workaround was to provide a system variable for tunnelling the Maven build directory variable in the pom.xml for the surefire test plugin:
https://github.com/tdf/odftoolkit/blob/odf-codegen/generator/schema2template/pom.xml#L102
to the Java test:
https://github.com/tdf/odftoolkit/blob/odf-codegen/generator/schema2template/src/test/java/schema2template/grammar/ConstantsBuildEnv.java#L30
If you have a different problem, we might as well have a joint tea break. But running out of time to provide a further patch fixing build...

2. Add to your ~/.m2/toolchains.xml with ```<version>8</version>``` and  ```<vendor>adopt</vendor>``` , e.g. for Windows just copy your ```<version>1.8</version>``` and  ```<vendor>openjdk</vendor>``` so it still runs with old versions! :-)
```xml
<?xml version="1.0" encoding="UTF-8"?>
<toolchains>
  <!-- JDK toolchains -->
  <toolchain>
    <type>jdk</type>
    <provides>
      <version>1.8</version>
      <vendor>openjdk</vendor>
    </provides>
    <configuration>
      <jdkHome>C:\Program Files\Java\jdk1.8.0_341</jdkHome>
    </configuration>
  </toolchain>
  <toolchain>
    <type>jdk</type>
    <provides>
      <version>8</version>
      <vendor>adopt</vendor>
    </provides>
    <configuration>
      <jdkHome>C:\Program Files\Java\jdk1.8.0_341</jdkHome>
    </configuration>
  </toolchain>
```
It took a while till I got the GitHub actions for JDK 8 with Maven Toolchain running!
https://github.com/svanteschubert/mustangproject/actions
I simply did not recognise that "JDK 1.8" and "openjdk" was defined in all pom.xml.
Note: The JDK download in the cloud does not work with version "1.8" so I had to rename it to "8" (toolchains.xml example is wrong since JDK 5 a single digit is being used!").
I fixed it in all pom.xml

Now the build is 'only' failing with tests that do not run successfully:
```
Results :

Failed tests:   testXRImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest)

Tests in error: 
  testZF1Import(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-MustangGnuaccountingBeispielRE-20171118_506zf1.pdf
  testItemAllowancesChargesImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-ZF2PushItemChargesAllowances.pdf
  testAllowancesChargesImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-ZF2PushChargesAllowances.pdf
  testInvoiceImport(org.mustangproject.ZUGFeRD.ZF2ZInvoiceImporterTest): java.nio.file.NoSuchFileException: ./target/testout-ZF2new.pdf

Tests run: 55, Failures: 1, Errors: 4, Skipped: 0
```
see https://github.com/svanteschubert/mustangproject/actions/runs/3548389021/jobs/5959540915#step:4:1832
