### PR TITLE
Module dependency update

### DIFF
--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -39,9 +39,15 @@
          <version>0.3.0</version>
       </dependency>
       <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <version>4.13.1</version>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <version>5.9.1</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.vintage</groupId>
+         <artifactId>junit-vintage-engine</artifactId>
+         <version>5.9.1</version>
          <scope>test</scope>
       </dependency>
 <!-- for directory validation: -->

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -86,11 +86,17 @@
 			<version>2.1.3</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.9.1</version>
 			<scope>test</scope>
-		</dependency>
+		 </dependency>
+		 <dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.9.1</version>
+			<scope>test</scope>
+		 </dependency>
 
 		<!-- CII to UBL conversion -->
 		<dependency>

--- a/library/src/test/resources/junit-platform.properties
+++ b/library/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/library/src/test/resources/junit-platform.properties
+++ b/library/src/test/resources/junit-platform.properties
@@ -1,2 +1,2 @@
 # ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$ClassName

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -35,6 +35,11 @@
 
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>library</artifactId>
+            <version>2.5.8-SNAPSHOT</version>
+        </dependency>
         <!-- for java9 -->
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -113,11 +113,17 @@
             <version>0.3.0</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.1</version>
             <scope>test</scope>
-        </dependency>
+         </dependency>
+         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+         </dependency>
     </dependencies>
     <build>
         <pluginManagement>

--- a/validator/src/test/resources/junit-platform.properties
+++ b/validator/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/validator/src/test/resources/junit-platform.properties
+++ b/validator/src/test/resources/junit-platform.properties
@@ -1,2 +1,2 @@
 # ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$ClassName


### PR DESCRIPTION
Hello Jochen,

as discussed, the easiest workaround for the following problem is to run "mvn package" or "mvn install" twice without a "mvn clean". 

First, I have added a dependency in the pom.xml of the validation module to the library module. So library will always be called before validation.
Second, as the library module requires executing the JUnit tests in alphabetical order, I have updated the JUnit dependency from 4 to 5 as this is possible in JUnit4 adding by adding a property JUnit file under test resources.
See https://stackoverflow.com/questions/57624495/junit-test-class-order

NOTE: You might want to consider migrating from 4 to 5 API - https://blog.jetbrains.com/idea/2020/08/migrating-from-junit-4-to-junit-5/  -> The clean JUnit 5 way would be exchanging the new two API and vintage Junit dependency with one to the engine - https://oss.sonatype.org/content/groups/public/org/junit/jupiter/junit-jupiter-engine/

Unfortunately, this ordering seems to work only for windows atm on my machines, you might want to test it yourself.

But there is still a problem with or without the new test class ordering working (I added the ordering to the validator module as well) there are now build/test problems in the validator module calling the Schematron/JAXB of Philip Helger. You might want to look into this as you are more familiar with your library than I am.

But at least we are now passing the library module, and getting closer.. :-)

Good luck, Jochen!
Svante