### PR TITLE
Exclude logback.xml from final jar files

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -156,6 +156,16 @@
 				</configuration>
 			</plugin>
 			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+					<excludes>
+						<exclude>**/logback.xml</exclude>
+					</excludes>
+                </configuration>
+            </plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>3.2.1</version>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -157,6 +157,9 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
+					<excludes>
+						<exclude>**/logback.xml</exclude>
+					</excludes>
                     <archive>
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
Exclude logback.xml in library and validator. Not in CLI.

Tested that the validator continues to generate log files.