### PR TITLE
Update helger library

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>com.helger</groupId>
 			<artifactId>en16931-cii2ubl</artifactId>
-			<version>1.3.0</version>
+			<version>1.4.2</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
 		<dependency>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>com.helger</groupId>
 			<artifactId>en16931-cii2ubl</artifactId>
-			<version>1.4.2</version>
+			<version>1.4.10</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
 		<dependency>
@@ -122,6 +122,7 @@
 			<groupId>org.xmlunit</groupId>
 			<artifactId>xmlunit-assertj</artifactId>
 			<version>2.9.1</version>
+            <scope>test</scope>
 		</dependency>
 		<!-- API -->
 		<dependency>

--- a/library/src/main/java/org/mustangproject/CII/CIIToUBL.java
+++ b/library/src/main/java/org/mustangproject/CII/CIIToUBL.java
@@ -1,11 +1,13 @@
 package org.mustangproject.CII;
-import com.helger.commons.error.list.ErrorList;
-import com.helger.en16931.cii2ubl.CIIToUBL22Converter;
-import com.helger.ubl21.UBL21Writer;
-import com.helger.ubl22.UBL22Writer;
 
 import java.io.File;
 import java.io.Serializable;
+
+import com.helger.commons.error.list.ErrorList;
+import com.helger.en16931.cii2ubl.CIIToUBL23Converter;
+import com.helger.ubl21.UBL21Writer;
+import com.helger.ubl22.UBL22Writer;
+import com.helger.ubl23.UBL23Writer;
 
 /***
  * converts a Cross Industry Invoice XML file to a UBL XML file
@@ -18,35 +20,44 @@ public class CIIToUBL {
 	 * @param output the UBL file to write to
 	 */
    public void convert(File input, File output) {
-	   ErrorList occurred=new ErrorList();
-	   CIIToUBL22Converter cc=new CIIToUBL22Converter();
-	   Serializable aUBL = cc.convertCIItoUBL(input, occurred);
+	   final ErrorList occurred=new ErrorList();
+	   final CIIToUBL23Converter cc=new CIIToUBL23Converter();
+	   final Serializable aUBL = cc.convertCIItoUBL(input, occurred);
 	   if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.invoice_21.InvoiceType)
 	   {
 		   UBL21Writer.invoice ()
 				   .setFormattedOutput (true)
 				   .write ((oasis.names.specification.ubl.schema.xsd.invoice_21.InvoiceType) aUBL, output);
 	   }
-	   else
-	   if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_21.CreditNoteType)
+	   else	if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_21.CreditNoteType)
 	   {
 		   UBL21Writer.creditNote ()
 				   .setFormattedOutput (true)
 				   .write ((oasis.names.specification.ubl.schema.xsd.creditnote_21.CreditNoteType) aUBL, output);
 	   }
-	   else
-	   if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.invoice_22.InvoiceType)
+	   else	if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.invoice_22.InvoiceType)
 	   {
 		   UBL22Writer.invoice ()
 				   .setFormattedOutput (true)
 				   .write ((oasis.names.specification.ubl.schema.xsd.invoice_22.InvoiceType) aUBL, output);
 	   }
-	   else
-	   if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_22.CreditNoteType)
+	   else if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_22.CreditNoteType)
 	   {
 		   UBL22Writer.creditNote ()
 				   .setFormattedOutput (true)
 				   .write ((oasis.names.specification.ubl.schema.xsd.creditnote_22.CreditNoteType) aUBL, output);
+	   }
+	   else if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.invoice_23.InvoiceType)
+	   {
+		   UBL23Writer.invoice ()
+				   .setFormattedOutput (true)
+				   .write ((oasis.names.specification.ubl.schema.xsd.invoice_23.InvoiceType) aUBL, output);
+	   }
+     else if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_23.CreditNoteType)
+	   {
+		   UBL23Writer.creditNote ()
+				   .setFormattedOutput (true)
+				   .write ((oasis.names.specification.ubl.schema.xsd.creditnote_23.CreditNoteType) aUBL, output);
 	   }
    }
 

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/UBLTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/UBLTest.java
@@ -61,8 +61,8 @@ public class UBLTest extends ResourceCase {
 		try {
 			final File tempFile = File.createTempFile("ZUGFeRD-UBL-", "-test");
 			c2u.convert(input, tempFile);
-			expected = ResourceUtilities.readFile(StandardCharsets.UTF_8, expectedFile.getAbsolutePath());//.replaceAll("\r\n", "\n");
-			result = ResourceUtilities.readFile(StandardCharsets.UTF_8, tempFile.getAbsolutePath());//.replaceAll("\r\n", "\n");
+			expected = ResourceUtilities.readFile(StandardCharsets.UTF_8, expectedFile.getAbsolutePath());
+			result = ResourceUtilities.readFile(StandardCharsets.UTF_8, tempFile.getAbsolutePath());
 		} catch (final IOException e) {
 			fail("Exception should not happen: " + e.getMessage());
 		}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/UBLTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/UBLTest.java
@@ -24,22 +24,31 @@ package org.mustangproject.ZUGFeRD;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Date;
 
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
-import org.mustangproject.*;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.mustangproject.BankDetails;
 import org.mustangproject.CII.CIIToUBL;
+import org.mustangproject.Contact;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.TradeParty;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class UBLTest extends ResourceCase {
 	final String TARGET_XML = "./target/testout-1Lieferschein.xml";
 
+  public UBLTest() {
+  }
+
+  @Test
+  @Order(2)
 	public void testUBLBasic() {
 
 		// the writing part
@@ -52,21 +61,23 @@ public class UBLTest extends ResourceCase {
 		try {
 			final File tempFile = File.createTempFile("ZUGFeRD-UBL-", "-test");
 			c2u.convert(input, tempFile);
-			expected = ResourceUtilities.readFile(StandardCharsets.UTF_8, expectedFile.getAbsolutePath()).replaceAll("\r\n", "\n");
-			result = ResourceUtilities.readFile(StandardCharsets.UTF_8, tempFile.getAbsolutePath()).replaceAll("\r\n", "\n");
+			expected = ResourceUtilities.readFile(StandardCharsets.UTF_8, expectedFile.getAbsolutePath());//.replaceAll("\r\n", "\n");
+			result = ResourceUtilities.readFile(StandardCharsets.UTF_8, tempFile.getAbsolutePath());//.replaceAll("\r\n", "\n");
 		} catch (final IOException e) {
 			fail("Exception should not happen: " + e.getMessage());
 		}
 
 
 		assertNotNull(result);
-		assertEquals(expected, result);
+		Assertions.assertThat(result).isXmlEqualTo(expected);
 	}
 
+  @Test
+  @Order(1)
 	public void test1Lieferschein() {
 
-		EinLieferscheinExporter oe = new EinLieferscheinExporter();
-		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+		final EinLieferscheinExporter oe = new EinLieferscheinExporter();
+		final Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty("Test company", "teststr", "55232", "teststadt", "DE").addTaxID("DE4711").addVATID("DE0815").setContact(new Contact("Hans Test", "+49123456789", "test@example.org")).addBankDetails(new BankDetails("DE12500105170648489890", "COBADEFXXX")))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
 				.setReferenceNumber("991-01484-64")//leitweg-id
@@ -75,13 +86,13 @@ public class UBLTest extends ResourceCase {
 
 		try {
 			oe.setTransaction(i);
-			ByteArrayOutputStream baos=new ByteArrayOutputStream();
+			final ByteArrayOutputStream baos=new ByteArrayOutputStream();
 			oe.export(baos);
 
-			String theXML = baos.toString("UTF-8");
+			final String theXML = baos.toString("UTF-8");
 			assertTrue(theXML.contains("<DespatchAdvice"));
 			Files.write(Paths.get(TARGET_XML), theXML.getBytes(StandardCharsets.UTF_8));
-		} catch (IOException e) {
+		} catch (final IOException e) {
 			e.printStackTrace();
 		}
 

--- a/library/src/test/resources/ubl-conv-ubl-output-factur-x.xml
+++ b/library/src/test/resources/ubl-conv-ubl-output-factur-x.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cec="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-  <cbc:CustomizationID>urn:cen.eu:en16931:2017:extended:urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:cec="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
   <cbc:ID>RE-20201121/508</cbc:ID>
   <cbc:IssueDate>2020-11-21</cbc:IssueDate>
@@ -13,21 +15,21 @@
       <cac:PartyName>
         <cbc:Name>Bei Spiel GmbH</cbc:Name>
       </cac:PartyName>
-          <cac:PostalAddress>
+      <cac:PostalAddress>
         <cbc:StreetName>Ecke 12</cbc:StreetName>
-              <cbc:CityName>Stadthausen</cbc:CityName>
-              <cbc:PostalZone>12345</cbc:PostalZone>
-              <cac:Country>
+        <cbc:CityName>Stadthausen</cbc:CityName>
+        <cbc:PostalZone>12345</cbc:PostalZone>
+        <cac:Country>
           <cbc:IdentificationCode>DE</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
-          <cac:PartyTaxScheme>
+      <cac:PartyTaxScheme>
         <cbc:CompanyID>DE136695976</cbc:CompanyID>
-              <cac:TaxScheme>
+        <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
-          <cac:PartyLegalEntity>
+      <cac:PartyLegalEntity>
         <cbc:RegistrationName>Bei Spiel GmbH</cbc:RegistrationName>
       </cac:PartyLegalEntity>
     </cac:Party>
@@ -37,18 +39,18 @@
       <cac:PartyIdentification>
         <cbc:ID>2</cbc:ID>
       </cac:PartyIdentification>
-          <cac:PartyName>
+      <cac:PartyName>
         <cbc:Name>Theodor Est</cbc:Name>
       </cac:PartyName>
-          <cac:PostalAddress>
+      <cac:PostalAddress>
         <cbc:StreetName>Bahnstr. 42</cbc:StreetName>
-              <cbc:CityName>Spielkreis</cbc:CityName>
-              <cbc:PostalZone>88802</cbc:PostalZone>
-              <cac:Country>
+        <cbc:CityName>Spielkreis</cbc:CityName>
+        <cbc:PostalZone>88802</cbc:PostalZone>
+        <cac:Country>
           <cbc:IdentificationCode>DE</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
-          <cac:PartyLegalEntity>
+      <cac:PartyLegalEntity>
         <cbc:RegistrationName>Theodor Est</cbc:RegistrationName>
       </cac:PartyLegalEntity>
     </cac:Party>
@@ -61,24 +63,24 @@
   </cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="EUR">75.04</cbc:TaxAmount>
-      <cac:TaxSubtotal>
+    <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="EUR">160.00</cbc:TaxableAmount>
-          <cbc:TaxAmount currencyID="EUR">11.20</cbc:TaxAmount>
-          <cac:TaxCategory>
+      <cbc:TaxAmount currencyID="EUR">11.20</cbc:TaxAmount>
+      <cac:TaxCategory>
         <cbc:ID>S</cbc:ID>
-              <cbc:Percent>7.00</cbc:Percent>
-              <cac:TaxScheme>
+        <cbc:Percent>7.00</cbc:Percent>
+        <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:TaxCategory>
     </cac:TaxSubtotal>
-      <cac:TaxSubtotal>
+    <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="EUR">336.00</cbc:TaxableAmount>
-          <cbc:TaxAmount currencyID="EUR">63.84</cbc:TaxAmount>
-          <cac:TaxCategory>
+      <cbc:TaxAmount currencyID="EUR">63.84</cbc:TaxAmount>
+      <cac:TaxCategory>
         <cbc:ID>S</cbc:ID>
-              <cbc:Percent>19.00</cbc:Percent>
-              <cac:TaxScheme>
+        <cbc:Percent>19.00</cbc:Percent>
+        <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:TaxCategory>
@@ -86,71 +88,71 @@
   </cac:TaxTotal>
   <cac:LegalMonetaryTotal>
     <cbc:LineExtensionAmount currencyID="EUR">496.00</cbc:LineExtensionAmount>
-      <cbc:TaxExclusiveAmount currencyID="EUR">496.00</cbc:TaxExclusiveAmount>
-      <cbc:TaxInclusiveAmount currencyID="EUR">571.04</cbc:TaxInclusiveAmount>
-      <cbc:AllowanceTotalAmount currencyID="EUR">0.00</cbc:AllowanceTotalAmount>
-      <cbc:ChargeTotalAmount currencyID="EUR">0.00</cbc:ChargeTotalAmount>
-      <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-      <cbc:PayableAmount currencyID="EUR">571.04</cbc:PayableAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">496.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">571.04</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="EUR">0.00</cbc:AllowanceTotalAmount>
+    <cbc:ChargeTotalAmount currencyID="EUR">0.00</cbc:ChargeTotalAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">571.04</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
-      <cbc:InvoicedQuantity unitCode="HUR">1.0000</cbc:InvoicedQuantity>
-      <cbc:LineExtensionAmount currencyID="EUR">160.00</cbc:LineExtensionAmount>
-      <cac:Item>
+    <cbc:InvoicedQuantity unitCode="HUR">1.0000</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">160.00</cbc:LineExtensionAmount>
+    <cac:Item>
       <cbc:Description>Of a sample invoice</cbc:Description>
-          <cbc:Name>Design (hours)</cbc:Name>
-          <cac:ClassifiedTaxCategory>
+      <cbc:Name>Design (hours)</cbc:Name>
+      <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-              <cbc:Percent>7.00</cbc:Percent>
-              <cac:TaxScheme>
+        <cbc:Percent>7.00</cbc:Percent>
+        <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
-      <cac:Price>
+    <cac:Price>
       <cbc:PriceAmount currencyID="EUR">160.0000</cbc:PriceAmount>
-          <cbc:BaseQuantity unitCode="HUR">1.0000</cbc:BaseQuantity>
+      <cbc:BaseQuantity unitCode="HUR">1.0000</cbc:BaseQuantity>
     </cac:Price>
   </cac:InvoiceLine>
   <cac:InvoiceLine>
     <cbc:ID>2</cbc:ID>
-      <cbc:InvoicedQuantity unitCode="H87">400.0000</cbc:InvoicedQuantity>
-      <cbc:LineExtensionAmount currencyID="EUR">316.00</cbc:LineExtensionAmount>
-      <cac:Item>
+    <cbc:InvoicedQuantity unitCode="H87">400.0000</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">316.00</cbc:LineExtensionAmount>
+    <cac:Item>
       <cbc:Description>various colors, ~2000ml</cbc:Description>
-          <cbc:Name>Ballons</cbc:Name>
-          <cac:ClassifiedTaxCategory>
+      <cbc:Name>Ballons</cbc:Name>
+      <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-              <cbc:Percent>19.00</cbc:Percent>
-              <cac:TaxScheme>
+        <cbc:Percent>19.00</cbc:Percent>
+        <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
-      <cac:Price>
+    <cac:Price>
       <cbc:PriceAmount currencyID="EUR">0.7900</cbc:PriceAmount>
-          <cbc:BaseQuantity unitCode="H87">1.0000</cbc:BaseQuantity>
+      <cbc:BaseQuantity unitCode="H87">1.0000</cbc:BaseQuantity>
     </cac:Price>
   </cac:InvoiceLine>
   <cac:InvoiceLine>
     <cbc:ID>3</cbc:ID>
-      <cbc:InvoicedQuantity unitCode="LTR">800.0000</cbc:InvoicedQuantity>
-      <cbc:LineExtensionAmount currencyID="EUR">20.00</cbc:LineExtensionAmount>
-      <cac:Item>
+    <cbc:InvoicedQuantity unitCode="LTR">800.0000</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">20.00</cbc:LineExtensionAmount>
+    <cac:Item>
       <cbc:Description></cbc:Description>
-          <cbc:Name>Hot air „heiße Luft“ (litres)</cbc:Name>
-          <cac:ClassifiedTaxCategory>
+      <cbc:Name>Hot air „heiße Luft“ (litres)</cbc:Name>
+      <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-              <cbc:Percent>19.00</cbc:Percent>
-              <cac:TaxScheme>
+        <cbc:Percent>19.00</cbc:Percent>
+        <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
-      <cac:Price>
+    <cac:Price>
       <cbc:PriceAmount currencyID="EUR">0.0250</cbc:PriceAmount>
-          <cbc:BaseQuantity unitCode="LTR">1.0000</cbc:BaseQuantity>
+      <cbc:BaseQuantity unitCode="LTR">1.0000</cbc:BaseQuantity>
     </cac:Price>
   </cac:InvoiceLine>
 </Invoice>

--- a/library/src/test/resources/ubl-conv-ubl-output-factur-x.xml
+++ b/library/src/test/resources/ubl-conv-ubl-output-factur-x.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
          xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
          xmlns:cec="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>

--- a/library/src/test/resources/ubl-conv-ubl-output-factur-x.xml
+++ b/library/src/test/resources/ubl-conv-ubl-output-factur-x.xml
@@ -58,28 +58,39 @@
   <cac:Delivery>
     <cbc:ActualDeliveryDate>2020-11-10</cbc:ActualDeliveryDate>
   </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="Bank transfer">42</cbc:PaymentMeansCode>
+    <cbc:PaymentID>RE-20201121/508</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>DE88200800000970375700</cbc:ID>
+      <cbc:Name>Max Mustermann</cbc:Name>
+      <cac:FinancialInstitutionBranch>
+        <cbc:ID>COBADEFFXXX</cbc:ID>
+      </cac:FinancialInstitutionBranch>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
   <cac:PaymentTerms>
     <cbc:Note>Zahlbar ohne Abzug bis 12.12.2020</cbc:Note>
   </cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="EUR">75.04</cbc:TaxAmount>
     <cac:TaxSubtotal>
-      <cbc:TaxableAmount currencyID="EUR">160.00</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="EUR">11.20</cbc:TaxAmount>
+      <cbc:TaxableAmount currencyID="EUR">160</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">11.2</cbc:TaxAmount>
       <cac:TaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>7.00</cbc:Percent>
+        <cbc:Percent>7</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:TaxCategory>
     </cac:TaxSubtotal>
     <cac:TaxSubtotal>
-      <cbc:TaxableAmount currencyID="EUR">336.00</cbc:TaxableAmount>
+      <cbc:TaxableAmount currencyID="EUR">336</cbc:TaxableAmount>
       <cbc:TaxAmount currencyID="EUR">63.84</cbc:TaxAmount>
       <cac:TaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>19.00</cbc:Percent>
+        <cbc:Percent>19</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
@@ -87,72 +98,71 @@
     </cac:TaxSubtotal>
   </cac:TaxTotal>
   <cac:LegalMonetaryTotal>
-    <cbc:LineExtensionAmount currencyID="EUR">496.00</cbc:LineExtensionAmount>
-    <cbc:TaxExclusiveAmount currencyID="EUR">496.00</cbc:TaxExclusiveAmount>
+    <cbc:LineExtensionAmount currencyID="EUR">496</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">496</cbc:TaxExclusiveAmount>
     <cbc:TaxInclusiveAmount currencyID="EUR">571.04</cbc:TaxInclusiveAmount>
-    <cbc:AllowanceTotalAmount currencyID="EUR">0.00</cbc:AllowanceTotalAmount>
-    <cbc:ChargeTotalAmount currencyID="EUR">0.00</cbc:ChargeTotalAmount>
-    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:AllowanceTotalAmount currencyID="EUR">0</cbc:AllowanceTotalAmount>
+    <cbc:ChargeTotalAmount currencyID="EUR">0</cbc:ChargeTotalAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0</cbc:PrepaidAmount>
     <cbc:PayableAmount currencyID="EUR">571.04</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
-    <cbc:InvoicedQuantity unitCode="HUR">1.0000</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="EUR">160.00</cbc:LineExtensionAmount>
+    <cbc:InvoicedQuantity unitCode="HUR">1</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">160</cbc:LineExtensionAmount>
     <cac:Item>
       <cbc:Description>Of a sample invoice</cbc:Description>
       <cbc:Name>Design (hours)</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>7.00</cbc:Percent>
+        <cbc:Percent>7</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
     <cac:Price>
-      <cbc:PriceAmount currencyID="EUR">160.0000</cbc:PriceAmount>
-      <cbc:BaseQuantity unitCode="HUR">1.0000</cbc:BaseQuantity>
+      <cbc:PriceAmount currencyID="EUR">160</cbc:PriceAmount>
+      <cbc:BaseQuantity unitCode="HUR">1</cbc:BaseQuantity>
     </cac:Price>
   </cac:InvoiceLine>
   <cac:InvoiceLine>
     <cbc:ID>2</cbc:ID>
-    <cbc:InvoicedQuantity unitCode="H87">400.0000</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="EUR">316.00</cbc:LineExtensionAmount>
+    <cbc:InvoicedQuantity unitCode="H87">400</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">316</cbc:LineExtensionAmount>
     <cac:Item>
       <cbc:Description>various colors, ~2000ml</cbc:Description>
       <cbc:Name>Ballons</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>19.00</cbc:Percent>
+        <cbc:Percent>19</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
     <cac:Price>
-      <cbc:PriceAmount currencyID="EUR">0.7900</cbc:PriceAmount>
-      <cbc:BaseQuantity unitCode="H87">1.0000</cbc:BaseQuantity>
+      <cbc:PriceAmount currencyID="EUR">0.79</cbc:PriceAmount>
+      <cbc:BaseQuantity unitCode="H87">1</cbc:BaseQuantity>
     </cac:Price>
   </cac:InvoiceLine>
   <cac:InvoiceLine>
     <cbc:ID>3</cbc:ID>
-    <cbc:InvoicedQuantity unitCode="LTR">800.0000</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="EUR">20.00</cbc:LineExtensionAmount>
+    <cbc:InvoicedQuantity unitCode="LTR">800</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">20</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description></cbc:Description>
       <cbc:Name>Hot air „heiße Luft“ (litres)</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>19.00</cbc:Percent>
+        <cbc:Percent>19</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
     <cac:Price>
-      <cbc:PriceAmount currencyID="EUR">0.0250</cbc:PriceAmount>
-      <cbc:BaseQuantity unitCode="LTR">1.0000</cbc:BaseQuantity>
+      <cbc:PriceAmount currencyID="EUR">0.025</cbc:PriceAmount>
+      <cbc:BaseQuantity unitCode="LTR">1</cbc:BaseQuantity>
     </cac:Price>
   </cac:InvoiceLine>
 </Invoice>


### PR DESCRIPTION
There is already version 2.0.1. Unfortunately the update results in many compatibility test failures and ClassNotFoundExceptions with to transitive dependencies. Therefore the step to 1.4.10 is sufficient for now.

Now without test failures.