### PR TITLE
Missing closing tag in BankDetails when there's no BIC number

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
@@ -78,10 +78,10 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 					+ "<ram:BICID>" + XMLTools.encodeXML(getOwnBIC()) + "</ram:BICID>"
 					// + " <ram:Name>"+trans.getOwnBankName()+"</ram:Name>"
 					//
-					+ "</ram:PayeeSpecifiedCreditorFinancialInstitution>"
-					+ "</ram:SpecifiedTradeSettlementPaymentMeans>";
+					+ "</ram:PayeeSpecifiedCreditorFinancialInstitution>";
 
 		}
+		xml+= "</ram:SpecifiedTradeSettlementPaymentMeans>";
 		return xml;
 	}
 	


### PR DESCRIPTION
Hi, just noticed the `ram:SpecifiedTradeSettlementPaymentMeans` is missing its closing tag when the seller's BankDetails BIC number is left empty :-)