### PR TITLE
Some general improvements for the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,31 @@ Mustangproject
 
 Source code repository for the [Mustang project](http://www.mustangproject.org/) open source java PDF invoice metadata library in ZUGFeRD format.
 
-License
+Build
 -----
 
-Subject to the Apache license http://www.apache.org/licenses/LICENSE-2.0.html
+These are the recommended dependencies for the project: 
 
-Running
------
+ - OpenJDK 21.0.2 2024-01-16
+ - Apache Maven 3.9.6
 
-This project requires Maven to run. Build project with "mvn clean install". This will build the project, test it and install the artifacts to local cache. After that the mustang jar can be used.
+You can build the project with: 
 
-More information in [the mustang documentation](https://github.com/ZUGFeRD/mustangproject/blob/master/doc/ZugferdDev.en.pdf?raw=true).
+```shell
+mvn clean install
+``` 
+
+This will run the tests, build the project artefacts, and install the artifacts to the local 
+cache. After that the mustang JAR can be used.
+
+More information on how to develop **on** mustang: 
+ 
+ - [Developer documentation](https://github.com/ZUGFeRD/mustangproject/blob/master/doc/development_documentation.md)
 
 Usage
 -----
 
-If you setup a Maven project, you can grab the artifacts using
+If you set up a Maven project, you can reference the mustang artifact like this:
 
 ```xml
 <dependency>
@@ -29,8 +38,19 @@ If you setup a Maven project, you can grab the artifacts using
 </dependency>
 ```
 
+Further docs on how to develop **with** mustang: 
+
+ - [ZugferdDev.en.pdf](https://github.com/ZUGFeRD/mustangproject/blob/master/doc/ZugferdDev.en.pdf?raw=true): the English mustang user documentation.
+ - [ZugferdDev.de.pdf](https://github.com/ZUGFeRD/mustangproject/blob/master/doc/ZugferdDev.de.pdf?raw=true): the German mustang user documentation.
+ - [Usage examples](https://www.mustangproject.org/use/): Read and write electronic invoices.
+ - [Mustang classes](https://www.mustangproject.org/invoice-class/): Using the mustang classes.
+
 Contact
 -----
 
 Developer: Jochen Stärk. For questions please contact Jochen at jstaerk [at] usegroup.de 
 
+License
+-----
+
+Subject to the [Apache-2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).


### PR DESCRIPTION
Here some changes to the README: 

- I moved the license section to the bottom, because that's the best practice. GitHub is anyway parsing the license information directly from the pom.xml file and displays the license SPDX identifier on the right upper corner. That's why the license section is anyway somehow redundant on the README. 
- Using the SPDX identifier for the license. 
- Added a list of the most important dependencies before the build. 
- Code highlighted `mvn clean install` because it's an important one. 
- Added further links to docs. 

I hope that's fine with you. Or do you wish any adjustments? 