### PR TITLE
handle read from empty file

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -24,6 +24,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -114,10 +115,14 @@ public class ZUGFeRDImporter {
 		BufferedInputStream pdfStream=new BufferedInputStream(inStream);
 		byte[] pad = new byte[4];
 		pdfStream.mark(0);
-		pdfStream.read(pad);
+		int readBytes = pdfStream.read(pad);
+		if(readBytes < 4) {
+			// 3 bytes or fewer could not be a valide file.
+			throw new IOException("tried to read from empty file");
+		}
 		pdfStream.reset();
 		byte[] pdfSignature = { '%', 'P', 'D', 'F' };
-		if (pad.equals(pdfSignature)) { // we have a pdf
+		if (Arrays.equals(pad, pdfSignature)) { // we have a pdf
 
 
 		try (PDDocument doc = PDDocument.load(pdfStream)) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/EmptyPdfTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/EmptyPdfTest.java
@@ -1,0 +1,18 @@
+package org.mustangproject.ZUGFeRD;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+
+public class EmptyPdfTest extends TestCase {
+
+	public void testEmptyPdfFile() {
+		try {
+			new ZUGFeRDImporter("src/test/resources/emptyFile.pdf");
+			fail("read empty pdf file");
+		} catch (ZUGFeRDExportException e) {
+			assertEquals("java.io.IOException: tried to read from empty file", e.getMessage());
+		}
+
+	}
+}


### PR DESCRIPTION
I added a check if the file to read from is empty if yes a error is reported. In addition I use `Arrays.equals` to check if the first 4 bytes match a PDF-file.