### PR TITLE
Re-Added getValidationContext to ZUGFeRD Validator

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
@@ -430,4 +430,8 @@ public class ZUGFeRDValidator {
 		}
 	}
 
+	public ValidationContext getValidationContext() {
+		return context;
+	}
+
 }


### PR DESCRIPTION
I'm not sure if it was an intended change to remove the Getter I added but with the ZUGFeRD validator no longer implementing the Validator Interface it'd still be nice to be able to get the context to easily get the ResultItems during processing.