### PR TITLE
ZUGFeRDVisualizer.toPDF(): generate PDF/A-3b.

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -332,7 +332,7 @@ public class ZUGFeRDVisualizer {
 
 		FOUserAgent userAgent = fopFactory.newFOUserAgent();
 
-		userAgent.getRendererOptions().put("pdf-a-mode", "PDF/A-1b");
+		userAgent.getRendererOptions().put("pdf-a-mode", "PDF/A-3b");
 
 // Step 2: Set up output stream.
 // Note: Using BufferedOutputStream for performance reasons (helpful with FileOutputStreams).


### PR DESCRIPTION
PDF/A-1b doesn't support embedded files, but when converting e.g. an XRechnung with an attached document, the visualizer tries (and fails) to attach it to the generated PDF.

This diff just changes the PDF generation to PDF/1-3b.