### PR TITLE
Fix build warnings from editing and building.

### DIFF
--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -7,16 +7,13 @@
         <version>2.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.mustangproject</groupId>
     <artifactId>Mustang-CLI</artifactId>
     <name>e-invoices commandline tool, allowing to create(embed), split and validate Factur-X/ZUGFeRD files. Validation
         should also work for XRechnung/CII.
     </name>
     <packaging>jar</packaging>
-    <version>2.12.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
@@ -111,18 +108,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>org.mustangproject.commandline.main</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven
-                             mvn clean compile assembly:single -->
-                    <!-- or whatever version you use -->
                     <source>11</source>
                     <target>11</target>
                 </configuration>
@@ -151,19 +136,7 @@
                             </excludes>
                         </filter>
                         <filter>
-                            <artifact>log4j:log4j</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
                             <artifact>commons-logging:commons-logging</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
-                            <artifact>com.sun.xml.bind:jaxb-impl</artifact>
                             <includes>
                                 <include>**</include>
                             </includes>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -8,9 +8,7 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.mustangproject</groupId>
     <artifactId>library</artifactId>
-    <version>2.12.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Library to write, read and validate e-invoices (Factur-X, ZUGFeRD, Order-X, XRechnung/CII)</name>
     <description>FOSS Java library to read, write and validate european electronic invoices and orders in the UN/CEFACT
@@ -47,11 +45,9 @@
         <github.global.server>github</github.global.server>
         <additionalparam>-Xdoclint:none</additionalparam>
         <!-- Skip error check for javadoc -->
-        <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <maven.deploy.skip>true
-        </maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
+        <maven.deploy.skip>true</maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
 
     </properties>
     <dependencies>
@@ -170,12 +166,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven
-                        mvn clean compile assembly:single -->
-                    <!-- or whatever version you use -->
                     <source>11</source>
                     <target>11</target>
                 </configuration>
@@ -234,10 +224,8 @@
                 <version>3.5.3</version>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <minimizeJar>false
-                    </minimizeJar><!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
+                    <minimizeJar>false</minimizeJar><!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
                     <filters>
-
                         <filter>
                             <artifact>*:*</artifact>
                             <excludes>
@@ -245,12 +233,6 @@
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
                             </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>log4j:log4j</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
                         </filter>
                         <filter>
                             <artifact>commons-logging:commons-logging</artifact>
@@ -269,9 +251,6 @@
                         <configuration>
                             <artifactSet>
                                 <excludes>
-                                    <!--exclude>classworlds:classworlds</exclude> <exclude>junit:junit</exclude>
-                                        <exclude>jmock:*</exclude> <exclude>*:xml-apis</exclude> <exclude>org.apache.maven:lib:tests</exclude>
-                                        <exclude>log4j:log4j:jar:</exclude -->
                                 </excludes>
                             </artifactSet>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,7 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <configuration>
-                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo
-                    </altDeploymentRepository>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
                 </configuration>
             </plugin>
 
@@ -82,6 +81,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.3.1</version>
                 <configuration>
                     <runOrder>alphabetical</runOrder>
                 </configuration>
@@ -90,9 +90,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
-                <configuration>
-                    <encoding>UTF-8</encoding>
-                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>
@@ -118,7 +115,6 @@
         <github.global.server>github</github.global.server>
         <additionalparam>-Xdoclint:none</additionalparam>
         <!-- Skip error check for javadoc -->
-        <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.deploy.skip>true</maven.deploy.skip><!-- prevent this to be deployed to maven central as "core",

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -6,12 +6,10 @@
         <version>2.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.mustangproject</groupId>
     <artifactId>validator</artifactId>
     <name>Library to validate e-invoices (ZUGFeRD, Factur-X and Xrechnung)</name>
 
     <packaging>jar</packaging>
-    <version>2.12.0-SNAPSHOT</version>
     <repositories>
         <repository>
             <!-- for jargs -->
@@ -27,18 +25,15 @@
     </repositories>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.deploy.skip>false
-        </maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
-        <maven.compiler.compilerVersion>11</maven.compiler.compilerVersion>
+        <maven.deploy.skip>false</maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-
     </properties>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>library</artifactId>
-            <version>2.12.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
@@ -134,12 +129,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <!-- http://stackoverflow.com/questions/574594/how-can-i-create-an-executable-jar-with-dependencies-using-maven
-                             mvn clean compile assembly:single -->
-                    <!-- or whatever version you use -->
                     <source>11</source>
                     <target>11</target>
                 </configuration>
@@ -164,19 +153,7 @@
                             </excludes>
                         </filter>
                         <filter>
-                            <artifact>log4j:log4j</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
                             <artifact>commons-logging:commons-logging</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
-                            <artifact>com.sun.xml.bind:jaxb-impl</artifact>
                             <includes>
                                 <include>**</include>
                             </includes>


### PR DESCRIPTION
Change pom.xml files to get rid of warnings when editing them in Eclipse and running maven install.

**From Eclipse:**
```
Description	Resource	Path	Location	Type
Invalid plugin configuration: encoding	pom.xml	/core	line 95	Language Servers

Description	Resource	Path	Location	Type
GroupId is duplicate of parent groupId	pom.xml	/library	line 11	Language Servers
Invalid plugin configuration: descriptorRefs	pom.xml	/library	line 173	Language Servers
Version is duplicate of parent version	pom.xml	/library	line 13	Language Servers

Description	Resource	Path	Location	Type
GroupId is duplicate of parent groupId	pom.xml	/validator	line 9	Language Servers
Invalid plugin configuration: descriptorRefs	pom.xml	/validator	line 137	Language Servers
Version is duplicate of parent version	pom.xml	/validator	line 14	Language Servers

Description	Resource	Path	Location	Type
GroupId is duplicate of parent groupId	pom.xml	/Mustang-CLI	line 10	Language Servers
Invalid plugin configuration: archive	pom.xml	/Mustang-CLI	line 114	Language Servers
Invalid plugin configuration: descriptorRefs	pom.xml	/Mustang-CLI	line 120	Language Servers
Version is duplicate of parent version	pom.xml	/Mustang-CLI	line 16	Language Servers
```

**$ mvn clean install**
```
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mustangproject:library:jar:2.12.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 161, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mustangproject:validator:jar:2.12.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 108, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mustangproject:Mustang-CLI:jar:2.12.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 87, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.mustangproject:core:pom:2.12.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 82, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.

[WARNING]  Parameter 'compilerVersion' (user property 'maven.compiler.compilerVersion') is deprecated: This parameter is no longer evaluated by the underlying compilers, instead the actual version of the javac binary is automatically retrieved.

[INFO] No artifact matching filter log4j:log4j
[INFO] No artifact matching filter com.sun.xml.bind:jaxb-impl

```