### PR TITLE
Enhance Charges/Allowances with reasonCode.

### DIFF
--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -27,6 +27,10 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	 */
 	protected String reason;
 	/**
+	 * Code from list UNTDID 5189
+	 */
+	protected String reasonCode;
+	/**
 	 * the category ID why this charge has been applied
 	 */
 	protected String categoryCode;
@@ -95,6 +99,22 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 
 
 	@Override
+	public String getReasonCode() {
+		return reasonCode;
+	}
+
+	/***
+	 * Reason code for the charge
+	 * @param reasonCode from list UNTDID 5189
+	 * @return fluid setter
+	 */
+	public Charge setReasonCode(String reasonCode) {
+		this.reasonCode = reasonCode;
+		return this;
+	}
+
+	
+	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
 		if (totalAmount!=null) {
 			return totalAmount;
@@ -137,7 +157,7 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 
 
 	/***
-	 * machine readable reason for this allowance/charge
+	 * the category ID why this has been applied
 	 * @param categoryCode usually S
 	 * @return fluid setter
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -45,6 +45,12 @@ public interface IZUGFeRDAllowanceCharge {
 	String getReason();
 
 	/***
+	 * get the code for the allowance/charge
+	 * @return the code
+	 */
+	String getReasonCode();
+
+	/***
 	 * get the applicable tax percentage for the allowance/charge
 	 * @return the percentage
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -141,7 +141,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 		if (party.getLegalOrganisation() != null) {
 			xml += "<ram:SpecifiedLegalOrganization> ";
-			xml += "  <ram:ID schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemeID()) + "\">" + XMLTools.encodeXML(party.getLegalOrganisation().getID()) + "</ram:ID>";
+			xml += "<ram:ID schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemeID()) + "\">" + XMLTools.encodeXML(party.getLegalOrganisation().getID()) + "</ram:ID>";
 			xml += "</ram:SpecifiedLegalOrganization>";
 		}
 
@@ -244,10 +244,16 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			// only in extended profile
 			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
 		}
+		String reasonCode = "";
+		if ((allowance.getReasonCode() != null) && (profile == Profiles.getByName("XRechnung"))) {
+			// only in XRechnung profile
+			reasonCode = "<ram:ReasonCode>" + allowance.getReasonCode() + "</ram:ReasonCode>";
+		}
 		final String allowanceChargeStr = "<ram:AppliedTradeAllowanceCharge><ram:ChargeIndicator><udt:Indicator>" +
 			chargeIndicator + "</udt:Indicator></ram:ChargeIndicator>" + percentage +
 			"<ram:ActualAmount>" + priceFormat(allowance.getTotalAmount(item)) + "</ram:ActualAmount>" +
 			reason +
+			reasonCode +
 			"</ram:AppliedTradeAllowanceCharge>";
 		return allowanceChargeStr;
 	}
@@ -269,10 +275,21 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			chargeIndicator = "true";
 		}
 
+		String reason = "";
+		if ((allowance.getReason() != null) && (profile == Profiles.getByName("Extended"))) {
+			// only in extended profile
+			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
+		}
+		String reasonCode = "";
+		if ((allowance.getReasonCode() != null) && (profile == Profiles.getByName("XRechnung"))) {
+			// only in XRechnung profile
+			reasonCode = "<ram:ReasonCode>" + allowance.getReasonCode() + "</ram:ReasonCode>";
+		}
 		final String itemTotalAllowanceChargeStr = "<ram:SpecifiedTradeAllowanceCharge><ram:ChargeIndicator><udt:Indicator>" +
 			chargeIndicator + "</udt:Indicator></ram:ChargeIndicator>" + percentage +
 			"<ram:ActualAmount>" + currencyFormat(allowance.getTotalAmount(item)) + "</ram:ActualAmount>" +
-			"<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>" +
+			reason +
+			reasonCode +
 			"</ram:SpecifiedTradeAllowanceCharge>";
 		return itemTotalAllowanceChargeStr;
 	}
@@ -325,9 +342,9 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		//
 
 		if (getProfile() == Profiles.getByName("XRechnung")) {
-			xml += "  <ram:BusinessProcessSpecifiedDocumentContextParameter>\n"
-				+ "    <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>\n"
-				+ "  </ram:BusinessProcessSpecifiedDocumentContextParameter>\n";
+			xml += "<ram:BusinessProcessSpecifiedDocumentContextParameter>\n"
+				+ "<ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>\n"
+				+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>\n";
 		}
 		xml +=
 			"<ram:GuidelineSpecifiedDocumentContextParameter>"
@@ -336,7 +353,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				+ "</rsm:ExchangedDocumentContext>"
 				+ "<rsm:ExchangedDocument>"
 				+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>"
-				// + " <ram:Name>RECHNUNG</ram:Name>"
+				// + "<ram:Name>RECHNUNG</ram:Name>"
 				// + "<ram:TypeCode>380</ram:TypeCode>"
 				+ "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
 				+ "<ram:IssueDateTime>"
@@ -436,11 +453,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 						+ "<ram:BasisQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit())
 						+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
 						+ allowanceChargeStr
-						// + " <AppliedTradeAllowanceCharge>"
-						// + " <ChargeIndicator>false</ChargeIndicator>"
-						// + " <ActualAmount currencyID=\"EUR\">0.6667</ActualAmount>"
-						// + " <Reason>Rabatt</Reason>"
-						// + " </AppliedTradeAllowanceCharge>"
+						// + "<AppliedTradeAllowanceCharge>"
+						// + "<ChargeIndicator>false</ChargeIndicator>"
+						// + "<ActualAmount currencyID=\"EUR\">0.6667</ActualAmount>"
+						// + "<Reason>Rabatt</Reason>"
+						// + "</AppliedTradeAllowanceCharge>"
 						+ "</ram:GrossPriceProductTradePrice>";
 				}
 
@@ -499,53 +516,53 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			+ getTradePartyAsXML(trans.getSender(), true, false)
 			+ "</ram:SellerTradeParty>"
 			+ "<ram:BuyerTradeParty>";
-		// + " <ID>GE2020211</ID>"
-		// + " <GlobalID schemeID=\"0088\">4000001987658</GlobalID>"
+		// + "<ID>GE2020211</ID>"
+		// + "<GlobalID schemeID=\"0088\">4000001987658</GlobalID>"
 
 		xml += getTradePartyAsXML(trans.getRecipient(), false, false);
 		xml += "</ram:BuyerTradeParty>";
 
 		if (trans.getSellerOrderReferencedDocumentID() != null) {
-			xml += "   <ram:SellerOrderReferencedDocument>"
-				+ "       <ram:IssuerAssignedID>"
+			xml += "<ram:SellerOrderReferencedDocument>"
+				+ "<ram:IssuerAssignedID>"
 				+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-				+ "   </ram:SellerOrderReferencedDocument>";
+				+ "</ram:SellerOrderReferencedDocument>";
 		}
 		if (trans.getBuyerOrderReferencedDocumentID() != null) {
-			xml += "   <ram:BuyerOrderReferencedDocument>"
-				+ "       <ram:IssuerAssignedID>"
+			xml += "<ram:BuyerOrderReferencedDocument>"
+				+ "<ram:IssuerAssignedID>"
 				+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-				+ "   </ram:BuyerOrderReferencedDocument>";
+				+ "</ram:BuyerOrderReferencedDocument>";
 		}
 		if (trans.getContractReferencedDocument() != null) {
-			xml += "   <ram:ContractReferencedDocument>"
-				+ "       <ram:IssuerAssignedID>"
+			xml += "<ram:ContractReferencedDocument>"
+				+ "<ram:IssuerAssignedID>"
 				+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
-				+ "    </ram:ContractReferencedDocument>";
+				+ "</ram:ContractReferencedDocument>";
 		}
 
 		// Additional Documents of XRechnung (Rechnungsbegruendende Unterlagen - BG-24 XRechnung)
 		if (trans.getAdditionalReferencedDocuments() != null) {
 			for (final FileAttachment f : trans.getAdditionalReferencedDocuments()) {
 				final String documentContent = new String(Base64.getEncoder().encodeToString(f.getData()));
-				xml += "  <ram:AdditionalReferencedDocument>"
-					+ "    <ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
-					+ "    <ram:TypeCode>916</ram:TypeCode>"
-					+ "    <ram:Name>" + f.getDescription() + "</ram:Name>"
-					+ "    <ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
-					+ "      filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
-					+ "  </ram:AdditionalReferencedDocument>";
+				xml += "<ram:AdditionalReferencedDocument>"
+					+ "<ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
+					+ "<ram:TypeCode>916</ram:TypeCode>"
+					+ "<ram:Name>" + f.getDescription() + "</ram:Name>"
+					+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
+					+ "filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
+					+ "</ram:AdditionalReferencedDocument>";
 			}
 		}
 
 		if (trans.getSpecifiedProcuringProjectID() != null) {
-			xml += "   <ram:SpecifiedProcuringProject>"
-				+ "       <ram:ID>"
+			xml += "<ram:SpecifiedProcuringProject>"
+				+ "<ram:ID>"
 				+ XMLTools.encodeXML(trans.getSpecifiedProcuringProjectID()) + "</ram:ID>";
 			if (trans.getSpecifiedProcuringProjectName() != null) {
-				xml += "       <ram:Name >" + XMLTools.encodeXML(trans.getSpecifiedProcuringProjectName()) + "</ram:Name>";
+				xml += "<ram:Name>" + XMLTools.encodeXML(trans.getSpecifiedProcuringProjectName()) + "</ram:Name>";
 			}
-			xml += "    </ram:SpecifiedProcuringProject>";
+			xml += "</ram:SpecifiedProcuringProject>";
 		}
 		xml += "</ram:ApplicableHeaderTradeAgreement>";
 		xml += "<ram:ApplicableHeaderTradeDelivery>";
@@ -562,7 +579,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				+ "<ram:OccurrenceDateTime>";
 			xml += DATE.udtFormat(trans.getDeliveryDate());
 			xml += "</ram:OccurrenceDateTime>";
-			xml += "            </ram:ActualDeliverySupplyChainEvent>";
+			xml += "</ram:ActualDeliverySupplyChainEvent>";
 
 		}
 		/*
@@ -581,9 +598,9 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		xml += "</ram:ApplicableHeaderTradeDelivery>";
 		xml += "<ram:ApplicableHeaderTradeSettlement>";
 		if ((trans.getNumber() != null) && (getProfile() != Profiles.getByName("Minimum"))) {
-			xml += "            <ram:PaymentReference>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:PaymentReference>";
+			xml += "<ram:PaymentReference>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:PaymentReference>";
 		}
-		xml += "            <ram:InvoiceCurrencyCode>" + trans.getCurrency() + "</ram:InvoiceCurrencyCode>";
+		xml += "<ram:InvoiceCurrencyCode>" + trans.getCurrency() + "</ram:InvoiceCurrencyCode>";
 
 		if (trans.getTradeSettlementPayment() != null) {
 			for (final IZUGFeRDTradeSettlementPayment payment : trans.getTradeSettlementPayment()) {
@@ -645,40 +662,87 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		}
 
 		if ((trans.getZFCharges() != null) && (trans.getZFCharges().length > 0)) {
-
-			for (final BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
-				if (calc.getChargesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO) != 0) {
-					xml += " <ram:SpecifiedTradeAllowanceCharge>" +
+			if (profile == Profiles.getByName("XRechnung")) {
+				for(IZUGFeRDAllowanceCharge charge : trans.getZFCharges()) {
+					xml += "<ram:SpecifiedTradeAllowanceCharge>" +
 						"<ram:ChargeIndicator>" +
 						"<udt:Indicator>true</udt:Indicator>" +
 						"</ram:ChargeIndicator>" +
-						"<ram:ActualAmount>" + currencyFormat(calc.getChargesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
-						"<ram:Reason>" + XMLTools.encodeXML(calc.getChargeReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
-						"<ram:CategoryTradeTax>" +
+						"<ram:ActualAmount>" + currencyFormat(charge.getTotalAmount(calc)) + "</ram:ActualAmount>";
+					if (charge.getReason() != null) {
+						xml += "<ram:Reason>" + XMLTools.encodeXML(charge.getReason()) + "</ram:Reason>";
+					}
+					if (charge.getReasonCode() != null) {
+						xml += "<ram:ReasonCode>" + charge.getReasonCode() + "</ram:ReasonCode>";
+					}
+					xml += "<ram:CategoryTradeTax>" +
 						"<ram:TypeCode>VAT</ram:TypeCode>" +
-						"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
-						"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
-						"</ram:CategoryTradeTax>" +
-						"</ram:SpecifiedTradeAllowanceCharge>	";
+						"<ram:CategoryCode>" + charge.getCategoryCode() + "</ram:CategoryCode>";
+					if (charge.getTaxPercent() != null) {
+						xml += "<ram:RateApplicablePercent>" + vatFormat(charge.getTaxPercent()) + "</ram:RateApplicablePercent>";
+					}
+					xml += "</ram:CategoryTradeTax>" +
+						"</ram:SpecifiedTradeAllowanceCharge>";
+				}
+			} else {
+				for (final BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
+					if (calc.getChargesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO) != 0) {
+						xml += "<ram:SpecifiedTradeAllowanceCharge>" +
+							"<ram:ChargeIndicator>" +
+							"<udt:Indicator>true</udt:Indicator>" +
+							"</ram:ChargeIndicator>" +
+							"<ram:ActualAmount>" + currencyFormat(calc.getChargesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
+							"<ram:Reason>" + XMLTools.encodeXML(calc.getChargeReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
+							"<ram:CategoryTradeTax>" +
+							"<ram:TypeCode>VAT</ram:TypeCode>" +
+							"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
+							"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
+							"</ram:CategoryTradeTax>" +
+							"</ram:SpecifiedTradeAllowanceCharge>";
+					}
 				}
 			}
 		}
 
 		if ((trans.getZFAllowances() != null) && (trans.getZFAllowances().length > 0)) {
-			for (final BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
-				if (calc.getAllowancesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO) != 0) {
+			if (profile == Profiles.getByName("XRechnung")) {
+				for(IZUGFeRDAllowanceCharge allowance : trans.getZFAllowances()) {
 					xml += "<ram:SpecifiedTradeAllowanceCharge>" +
 						"<ram:ChargeIndicator>" +
 						"<udt:Indicator>false</udt:Indicator>" +
 						"</ram:ChargeIndicator>" +
-						"<ram:ActualAmount>" + currencyFormat(calc.getAllowancesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
-						"<ram:Reason>" + XMLTools.encodeXML(calc.getAllowanceReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
-						"<ram:CategoryTradeTax>" +
+						"<ram:ActualAmount>" + currencyFormat(allowance.getTotalAmount(calc)) + "</ram:ActualAmount>";
+					if (allowance.getReason() != null) {
+						xml += "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
+					}
+					if (allowance.getReasonCode() != null) {
+						xml += "<ram:ReasonCode>" + allowance.getReasonCode() + "</ram:ReasonCode>";
+					}
+					xml += "<ram:CategoryTradeTax>" +
 						"<ram:TypeCode>VAT</ram:TypeCode>" +
-						"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
-						"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
-						"</ram:CategoryTradeTax>" +
-						"</ram:SpecifiedTradeAllowanceCharge>	";
+						"<ram:CategoryCode>" + allowance.getCategoryCode() + "</ram:CategoryCode>";
+					if (allowance.getTaxPercent() != null) {
+						xml += "<ram:RateApplicablePercent>" + vatFormat(allowance.getTaxPercent()) + "</ram:RateApplicablePercent>";
+					}
+					xml += "</ram:CategoryTradeTax>" +
+						"</ram:SpecifiedTradeAllowanceCharge>";
+				}
+			} else {
+				for (final BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
+					if (calc.getAllowancesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO) != 0) {
+						xml += "<ram:SpecifiedTradeAllowanceCharge>" +
+							"<ram:ChargeIndicator>" +
+							"<udt:Indicator>false</udt:Indicator>" +
+							"</ram:ChargeIndicator>" +
+							"<ram:ActualAmount>" + currencyFormat(calc.getAllowancesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
+							"<ram:Reason>" + XMLTools.encodeXML(calc.getAllowanceReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
+							"<ram:CategoryTradeTax>" +
+							"<ram:TypeCode>VAT</ram:TypeCode>" +
+							"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
+							"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
+							"</ram:CategoryTradeTax>" +
+							"</ram:SpecifiedTradeAllowanceCharge>";
+					}
 				}
 			}
 		}
@@ -736,31 +800,31 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		// //
 		// currencyID=\"EUR\"
 		if (getProfile() != Profiles.getByName("Minimum")) {
-			xml += "             <ram:TotalPrepaidAmount>" + currencyFormat(calc.getTotalPrepaid()) + "</ram:TotalPrepaidAmount>";
+			xml += "<ram:TotalPrepaidAmount>" + currencyFormat(calc.getTotalPrepaid()) + "</ram:TotalPrepaidAmount>";
 		}
 		xml += "<ram:DuePayableAmount>" + currencyFormat(calc.getGrandTotal().subtract(calc.getTotalPrepaid())) + "</ram:DuePayableAmount>"
 			+ "</ram:SpecifiedTradeSettlementHeaderMonetarySummation>";
 		if (trans.getInvoiceReferencedDocumentID() != null) {
-			xml += "   <ram:InvoiceReferencedDocument>"
-				+ "       <ram:IssuerAssignedID>"
+			xml += "<ram:InvoiceReferencedDocument>"
+				+ "<ram:IssuerAssignedID>"
 				+ XMLTools.encodeXML(trans.getInvoiceReferencedDocumentID()) + "</ram:IssuerAssignedID>";
 			if (trans.getInvoiceReferencedIssueDate() != null) {
 				xml += "<ram:FormattedIssueDateTime>"
 					+ DATE.qdtFormat(trans.getInvoiceReferencedIssueDate())
 					+ "</ram:FormattedIssueDateTime>";
 			}
-			xml += "   </ram:InvoiceReferencedDocument>";
+			xml += "</ram:InvoiceReferencedDocument>";
 		}
 
 		xml += "</ram:ApplicableHeaderTradeSettlement>";
-		// + " <IncludedSupplyChainTradeLineItem>\n"
-		// + " <AssociatedDocumentLineDocument>\n"
-		// + " <IncludedNote>\n"
-		// + " <Content>Wir erlauben uns Ihnen folgende Positionen aus der Lieferung Nr.
+		// + "<IncludedSupplyChainTradeLineItem>\n"
+		// + "<AssociatedDocumentLineDocument>\n"
+		// + "<IncludedNote>\n"
+		// + "<Content>Wir erlauben uns Ihnen folgende Positionen aus der Lieferung Nr.
 		// 2013-51112 in Rechnung zu stellen:</Content>\n"
-		// + " </IncludedNote>\n"
-		// + " </AssociatedDocumentLineDocument>\n"
-		// + " </IncludedSupplyChainTradeLineItem>\n";
+		// + "</IncludedNote>\n"
+		// + "</AssociatedDocumentLineDocument>\n"
+		// + "</IncludedSupplyChainTradeLineItem>\n";
 
 		xml += "</rsm:SupplyChainTradeTransaction>"
 			+ "</rsm:CrossIndustryInvoice>";

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -357,6 +357,7 @@ public class ZUGFeRDInvoiceImporter extends ZUGFeRDImporter {
 				boolean isCharge = true;
 				String chargeAmount = null;
 				String reason = null;
+				String reasonCode = null;
 				String taxPercent = null;
 				for (int chargeChildIndex = 0; chargeChildIndex < chargeNodeChilds.getLength(); chargeChildIndex++) {
 					String chargeChildName = chargeNodeChilds.item(chargeChildIndex).getLocalName();
@@ -377,6 +378,8 @@ public class ZUGFeRDInvoiceImporter extends ZUGFeRDImporter {
 							chargeAmount = chargeNodeChilds.item(chargeChildIndex).getTextContent();
 						} else if (chargeChildName.equals("Reason")) {
 							reason = chargeNodeChilds.item(chargeChildIndex).getTextContent();
+						} else if (chargeChildName.equals("ReasonCode")) {
+							reasonCode = chargeNodeChilds.item(chargeChildIndex).getTextContent();
 						} else if (chargeChildName.equals("CategoryTradeTax")) {
 							NodeList taxChilds = chargeNodeChilds.item(chargeChildIndex).getChildNodes();
 							for (int taxChildIndex = 0; taxChildIndex < taxChilds.getLength(); taxChildIndex++) {
@@ -395,15 +398,20 @@ public class ZUGFeRDInvoiceImporter extends ZUGFeRDImporter {
 					if (reason != null) {
 						c.setReason(reason);
 					}
+					if (reasonCode != null) {
+						c.setReasonCode(reasonCode);
+					}
 					if (taxPercent != null) {
 						c.setTaxPercent(new BigDecimal(taxPercent));
 					}
-
 					zpp.addCharge(c);
 				} else {
 					Allowance a = new Allowance(new BigDecimal(chargeAmount));
 					if (reason != null) {
 						a.setReason(reason);
+					}
+					if (reasonCode != null) {
+						a.setReasonCode(reasonCode);
 					}
 					if (taxPercent != null) {
 						a.setTaxPercent(new BigDecimal(taxPercent));

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 	private BigDecimal totalAmount;
 	private String reason;
+	private String reasonCode;
 	private BigDecimal taxPercent;
 	boolean isCharge=true;
 
@@ -34,6 +35,11 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 	@Override
 	public String getReason() {
 		return reason;
+	}
+
+	@Override
+	public String getReasonCode() {
+		return reasonCode;
 	}
 
 	@Override
@@ -58,6 +64,11 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 
 	public IZUGFeRDAllowanceChargeImpl setReason(String reason) {
 		this.reason = reason;
+		return this;
+	}
+
+	public IZUGFeRDAllowanceChargeImpl setReasonCode(String reasonCode) {
+		this.reasonCode = reasonCode;
 		return this;
 	}
 


### PR DESCRIPTION
Added field reasonCode to IZUGFeRDAllowanceCharge, used for Charges and Allowances.
ZUGFeRDInvoiceImporter: read the value during import.
ZUGFeRD2PullProvider:
Export Allowances and Charges one by one, not aggregated by taxPercent, but only for profile XRechnung for now.
Don't know if this is also allowed for other profiles also.
Added reasonCode also on item level.
Removed some obsolete spaces in xml-Fragments.