### PR TITLE
refactor(ZUGFeRDVisualizer): improve PDF visualization performance

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -226,13 +226,6 @@ public class ZUGFeRDVisualizer {
 		}
 
 		FileInputStream fis = new FileInputStream(xmlFilename);
-		try {
-			// TODO why are we reading the whole file here and discarding the content?
-			new String(Files.readAllBytes(Paths.get(xmlFilename)), StandardCharsets.UTF_8);
-		} catch (IOException e2) {
-			LOGGER.error("Failed to read file", e2);
-		}
-
 		ByteArrayOutputStream iaos = new ByteArrayOutputStream();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -276,12 +269,11 @@ public class ZUGFeRDVisualizer {
 
 		String result = null;
 
-		ZUGFeRDVisualizer zvi = new ZUGFeRDVisualizer();
 			/* remove file endings so that tests can also pass after checking
 			   out from git with arbitrary options (which may include CSRF changes)
 			 */
 		try {
-			result = zvi.toFOP(CIIinputFile.getAbsolutePath());
+			result = this.toFOP(CIIinputFile.getAbsolutePath());
 		} catch (FileNotFoundException | TransformerException e) {
 			LOGGER.error("Failed to apply FOP", e);
 		}


### PR DESCRIPTION
Verwendet in `ZUGFeRDVisualizer.toPDF` die bereits instanziierte `ZUGFeRDVisualizer`-Klasse, statt eine neue Instanz zu erzeugen. Hierdurch müssen die in [ZUGFeRDVisualizer.java#L97-L101](https://github.com/matmen/mustangproject/blob/e2ff39e10f0341392af3accab202c666a83d04c7/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java#L97-L101) definierten Variablen nicht erneut eingelesen bzw. die XSLT-Templates nicht neu geparsed werden. In meinen Benchmarks (10 Iterationen Warmup, 100 Iterationen Test) kann das ca. 80% Rechenleistung (wall time, vorher ~840ms/op, danach ~160ms/op) einsparen, sofern eine "globale" Instanz wiederverwendet wird.
Außerdem wird ein m.M.n. ungenutzes Dateilesen entfernt.

Bislang konnte ich bei meinen Tests noch keine side-effects erkennen.