### PR TITLE
Read missing fields for imported Invoice.

### DIFF
--- a/library/src/main/java/org/mustangproject/TradeParty.java
+++ b/library/src/main/java/org/mustangproject/TradeParty.java
@@ -203,12 +203,10 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 									if (taxChilds.item(taxChildIndex).getAttributes().getNamedItem("schemeID") != null) {
 										Node firstChild = taxChilds.item(taxChildIndex).getFirstChild();
 										if (firstChild != null) {
-											if (taxChilds.item(taxChildIndex).getAttributes()
-												.getNamedItem("schemeID").getNodeValue().equals("VA")) {
+											if (taxChilds.item(taxChildIndex).getAttributes().getNamedItem("schemeID").getNodeValue().equals("VA")) {
 												setVATID(firstChild.getNodeValue());
 											}
-											if (taxChilds.item(taxChildIndex).getAttributes()
-												.getNamedItem("schemeID").getNodeValue().equals("FC")) {
+											if (taxChilds.item(taxChildIndex).getAttributes().getNamedItem("schemeID").getNodeValue().equals("FC")) {
 												setTaxID(firstChild.getNodeValue());
 											}
 										}
@@ -298,6 +296,9 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 				NodeList itemChilds = currentItemNode.getChildNodes();
 				for (int itemChildIndex = 0; itemChildIndex < itemChilds.getLength(); itemChildIndex++) {
 					if (itemChilds.item(itemChildIndex).getLocalName() != null) {
+						if (itemChilds.item(itemChildIndex).getLocalName().equals("ID")) {
+							setID(itemChilds.item(itemChildIndex).getTextContent());
+						}
 						if (itemChilds.item(itemChildIndex).getLocalName().equals("Name")) {
 							setName(itemChilds.item(itemChildIndex).getTextContent());
 						}
@@ -358,12 +359,10 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 										if (taxChilds.item(taxChildIndex).getAttributes().getNamedItem("schemeID") != null) {
 											Node firstChild = taxChilds.item(taxChildIndex).getFirstChild();
 											if (firstChild != null) {
-												if (taxChilds.item(taxChildIndex).getAttributes()
-													.getNamedItem("schemeID").getNodeValue().equals("VA")) {
+												if (taxChilds.item(taxChildIndex).getAttributes().getNamedItem("schemeID").getNodeValue().equals("VA")) {
 													setVATID(firstChild.getNodeValue());
 												}
-												if (taxChilds.item(taxChildIndex).getAttributes()
-													.getNamedItem("schemeID").getNodeValue().equals("FC")) {
+												if (taxChilds.item(taxChildIndex).getAttributes().getNamedItem("schemeID").getNodeValue().equals("FC")) {
 													setTaxID(firstChild.getNodeValue());
 												}
 											}
@@ -630,9 +629,7 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 		if (bankDetails.isEmpty() && debitDetails.isEmpty()) {
 			return null;
 		}
-		List<IZUGFeRDTradeSettlement> tradeSettlements = Stream.concat(bankDetails.stream(), debitDetails.stream())
-			.map(IZUGFeRDTradeSettlement.class::cast)
-			.collect(Collectors.toList());
+		List<IZUGFeRDTradeSettlement> tradeSettlements = Stream.concat(bankDetails.stream(), debitDetails.stream()).map(IZUGFeRDTradeSettlement.class::cast).collect(Collectors.toList());
 
 		IZUGFeRDTradeSettlement[] result = new IZUGFeRDTradeSettlement[tradeSettlements.size()];
 		for (int i = 0; i < tradeSettlements.size(); i++) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -36,6 +36,7 @@ import org.junit.runners.MethodSorters;
 
 import junit.framework.TestCase;
 
+import org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants;
 import org.mustangproject.ZUGFeRD.model.EventTimeCodeTypeConstants;
 
 import javax.xml.xpath.XPathExpressionException;
@@ -61,7 +62,6 @@ public class ZF2PushTest extends TestCase {
 	public void testPushExport() {
 
 		// the writing part
-
 		String orgname = "Bei Spiel GmbH";
 		String number = "RE-20201121/508";
 		String priceStr = "160.00";
@@ -75,8 +75,7 @@ public class ZF2PushTest extends TestCase {
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors();
 			ze.load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
 			ze.setTransaction(new Invoice().setDueDate(sdf.parse("2020-12-12")).setIssueDate(sdf.parse("2020-11-21")).setDeliveryDate(sdf.parse("2020-11-10"))
 				.setSender(new TradeParty(orgname, "Ecke 12", "12345", "Stadthausen", "DE").addBankDetails(new BankDetails("DE88200800000970375700", "COBADEFFXXX").setAccountName("Max Mustermann")).addVATID("DE136695976"))
 				.setRecipient(new TradeParty("Theodor Est", "Bahnstr. 42", "88802", "Spielkreis", "DE")
@@ -100,19 +99,18 @@ public class ZF2PushTest extends TestCase {
 
 		assertTrue(zi.getUTF8().contains("<rsm:CrossIndustryInvoice"));
 
-		assertTrue(zi.getUTF8().contains("EUR")); //default invoice currency
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
 		assertTrue(zi.getUTF8().contains("AB321"));
 
 		// Reading ZUGFeRD
 		assertEquals("571.04", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
 	}
 
 	public void testAttachmentsExport() {
@@ -123,8 +121,7 @@ public class ZF2PushTest extends TestCase {
 		String taxID = "9990815";
 		BigDecimal price = new BigDecimal(priceStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors();
@@ -134,8 +131,12 @@ public class ZF2PushTest extends TestCase {
 			byte[] b = {12, 13};
 			ze.attachFile("one.pdf", b, "application/pdf", "Alternative");
 			ze.attachFile("two.pdf", b, "application/pdf", "Alternative");
-			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE4711").setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE"))).setNumber(number).addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)))
-
+			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE4711")
+					.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE")))
+				.setNumber(number)
+				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)))
 			);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
@@ -147,20 +148,18 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_ATTACHMENTSPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
 		assertTrue(zi.getUTF8().contains(taxID));
 
 		// Reading ZUGFeRD
 		assertEquals("1.19", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 	public void testBankTransferExport() {
@@ -171,19 +170,21 @@ public class ZF2PushTest extends TestCase {
 		String taxID = "9990815";
 		BigDecimal price = new BigDecimal(priceStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
 
 			String IBAN = "DE999888777";
 			String BIC = "COBADEFXXX";
 			BankDetails bd = new BankDetails(IBAN, BIC);
-			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addBankDetails(bd).addTaxID(taxID).addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE4711").setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE"))).setNumber(number).addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)))
-
+			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addBankDetails(bd).addTaxID(taxID).addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE4711")
+					.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE")))
+				.setNumber(number)
+				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)))
 			);
 			String theXML = new String(ze.getProvider().getXML());
 			Invoice read = new Invoice();
@@ -191,7 +192,7 @@ public class ZF2PushTest extends TestCase {
 			zii.extractInto(read);
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
 
-			//assertEquals(IBAN,read.getSender().getBankDetails().get(0).getIBAN());
+			assertEquals(IBAN, read.getSender().getBankDetails().get(0).getIBAN());
 			ze.export(TARGET_BANKPDF);
 		} catch (IOException e) {
 			fail("IOException should not be raised");
@@ -200,8 +201,6 @@ public class ZF2PushTest extends TestCase {
 		} catch (ParseException e) {
 			fail("ParseException should not be raised");
 		}
-
-
 	}
 
 	public void testItemChargesAllowancesExport() {
@@ -211,23 +210,23 @@ public class ZF2PushTest extends TestCase {
 		String amountStr = "3.00";
 		BigDecimal amount = new BigDecimal(amountStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 			//	ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr", "55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
 			//					.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)))));
 
-
-			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562"))).setNumber(number)
+			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")
+					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
+				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance(new BigDecimal("0.1"))))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50))))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(2.0)).addCharge(new Charge(new BigDecimal(1))))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)).addCharge(new Charge(new BigDecimal(1))).addAllowance(new Allowance(new BigDecimal("1"))))
-
 			);
 
 			String theXML = new String(ze.getProvider().getXML());
@@ -240,20 +239,18 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_ITEMCHARGESALLOWANCESPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
 		assertTrue(zi.getUTF8().contains("0911623562")); // fax number
 
 		// Reading ZUGFeRD
 		assertEquals("18.33", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 
@@ -264,20 +261,18 @@ public class ZF2PushTest extends TestCase {
 		String amountStr = "3.00";
 		BigDecimal amount = new BigDecimal(amountStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 			//	ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr", "55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
 			//					.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)))));
 
-
 			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addVATID("DE0815").addTaxID ("4711"))
-				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0816").setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0816")
+					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
 				.setDeliveryAddress(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0816"))
 				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)).setIntraCommunitySupply(), amount, new BigDecimal(1.0)))
@@ -296,20 +291,18 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_INTRACOMMUNITYSUPPLYPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
 		assertTrue(zi.getUTF8().contains("0911623562")); // fax number
 
 		// Reading ZUGFeRD
 		assertEquals("15.00", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 	public void testReverseChargeExport() {
@@ -319,19 +312,20 @@ public class ZF2PushTest extends TestCase {
 		String amountStr = "3.00";
 		BigDecimal amount = new BigDecimal(amountStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 
 			//	ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr", "55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
 			//					.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)))));
 
-
-			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addVATID("DE0815").addTaxID("4711")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0816").setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562"))).setNumber(number)
+			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addVATID("DE0815").addTaxID("4711"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0816")
+					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
+				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)).setReverseCharge(), amount, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)).setReverseCharge(), amount, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)).setReverseCharge(), amount, new BigDecimal(2.0)))
@@ -348,20 +342,18 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_REVERSECHARGEPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
 		assertTrue(zi.getUTF8().contains("0911623562")); // fax number
 
 		// Reading ZUGFeRD
 		assertEquals("15.00", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 	public void testChargesAllowancesExport() {
@@ -371,22 +363,21 @@ public class ZF2PushTest extends TestCase {
 		String amountStr = "3.00";
 		BigDecimal amount = new BigDecimal(amountStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
-			ze.ignorePDFAErrors()
-				.load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
+			ze.ignorePDFAErrors().load(SOURCE_PDF);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
 
-			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
+			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)))
 				.addCharge(new Charge(new BigDecimal(0.5)).setTaxPercent(new BigDecimal(19)))
 				.addAllowance(new Allowance(new BigDecimal(0.2)).setTaxPercent(new BigDecimal(19)))
-
 			);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
@@ -398,19 +389,17 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_CHARGESALLOWANCESPDF);
 
-		assertFalse(zi.getUTF8().contains("EUR"));
+		assertEquals("CHF", zi.getInvoiceCurrencyCode());
 
 		// Reading ZUGFeRD
 		assertEquals("11.07", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 	/***
@@ -421,34 +410,32 @@ public class ZF2PushTest extends TestCase {
 		String occurrenceTo = "20201005";
 		String contractID = "376zreurzu0983";
 
+		String orgID = "0009845";
 		String orgname = "Test company";
 		String number = "123";
 		String priceStr = "1.00";
 		String taxID = "9990815";
 		BigDecimal price = new BigDecimal(priceStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
-			ze.ignorePDFAErrors()
-				.load(SOURCE_PDF);
+			ze.ignorePDFAErrors().load(SOURCE_PDF);
 
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
 
 			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 			try {
-
 				SchemedID gtin = new SchemedID("0160", "2001015001325");
 				SchemedID gln = new SchemedID("0088", "4304171000002");
 				ze.setTransaction(new Invoice().setCurrency("CHF").addNote("document level 1/2").addNote("document level 2/2").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 					.setSellerOrderReferencedDocumentID("9384").setBuyerOrderReferencedDocumentID("28934")
 					.setDetailedDeliveryPeriod(new SimpleDateFormat("yyyyMMdd").parse(occurrenceFrom), new SimpleDateFormat("yyyyMMdd").parse(occurrenceTo))
-					.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).setEmail("sender@test.org").setID("0009845").addVATID("DE0815"))
+					.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).setEmail("sender@test.org").setID(orgID).addVATID("DE0815"))
 					.setDeliveryAddress(new TradeParty("just the other side of the street", "teststr.12a", "55232", "Entenhausen", "DE").addVATID("DE47110"))
 					.setContractReferencedDocument(contractID)
-					.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addGlobalID(gln).setEmail("recipient@test.org").addVATID("DE4711").setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE").setFax("++49555123456")).setAdditionalAddress("Hinterhaus 3"))
+					.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addGlobalID(gln).setEmail("recipient@test.org").addVATID("DE4711")
+						.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE").setFax("++49555123456")).setAdditionalAddress("Hinterhaus 3"))
 					.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).addReferencedLineID("xxx").addNote("item level 1/1").addAllowance(new Allowance(new BigDecimal(0.02)).setReason("item discount").setTaxPercent(new BigDecimal(16))).setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15")))
 					.addCharge(new Charge(new BigDecimal(0.5)).setReason("quick delivery charge").setTaxPercent(new BigDecimal(16)))
 					.addAllowance(new Allowance(new BigDecimal(0.2)).setReason("discount").setTaxPercent(new BigDecimal(16)))
@@ -471,14 +458,12 @@ public class ZF2PushTest extends TestCase {
 
 		assertFalse(zi.getUTF8().contains("<ram:IBANID>")); // maybe add a direct debit mandate to the class in the future then this would fail
 		assertTrue(zi.getUTF8().contains("Hinterhaus"));
-		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='BuyerTradeParty']/*[local-name()='GlobalID'][@schemeID=0088]").asString()
-			.isEqualTo("4304171000002");
-		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='SpecifiedTradeProduct']/*[local-name()='GlobalID'][@schemeID=0160]").asString()
-			.isEqualTo("2001015001325");
+		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='BuyerTradeParty']/*[local-name()='GlobalID'][@schemeID=0088]").asString().isEqualTo("4304171000002");
+		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='SpecifiedTradeProduct']/*[local-name()='GlobalID'][@schemeID=0160]").asString().isEqualTo("2001015001325");
 		assertTrue(zi.getUTF8().contains("2001015001325"));
 		assertTrue(zi.getUTF8().contains("4304171000002"));
 		assertTrue(zi.getUTF8().contains("0088"));
-		assertTrue(zi.getUTF8().contains("0009845"));
+		assertTrue(zi.getUTF8().contains(orgID));
 		assertTrue(zi.getUTF8().contains("ram:BuyerOrderReferencedDocument"));
 		assertTrue(zi.getUTF8().contains(occurrenceFrom));
 		assertTrue(zi.getUTF8().contains(occurrenceTo));
@@ -493,8 +478,7 @@ public class ZF2PushTest extends TestCase {
 		assertTrue(zi.getUTF8().contains("document level 2/2"));
 		assertTrue(zi.getUTF8().contains("++49555123456"));
 		assertTrue(zi.getUTF8().contains("Cash Discount")); // default description for cash discounts
-		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='ApplicableTradeTax']/*[local-name()='DueDateTypeCode']").asString()
-			.isEqualTo(EventTimeCodeTypeConstants.PAYMENT_DATE);
+		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='ApplicableTradeTax']/*[local-name()='DueDateTypeCode']").asString().isEqualTo(EventTimeCodeTypeConstants.PAYMENT_DATE);
 
 		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_PUSHEDGE);
 		try {
@@ -502,7 +486,7 @@ public class ZF2PushTest extends TestCase {
 
 			assertEquals("4304171000002", i.getRecipient().getGlobalID());
 			assertEquals("2001015001325", i.getZFItems()[0].getProduct().getGlobalID());
-
+			assertEquals(orgID, i.getSender().getID());
 
 		} catch (XPathExpressionException e) {
 			fail("XPathExpressionException should not be raised");
@@ -511,8 +495,6 @@ public class ZF2PushTest extends TestCase {
 			/* a parseException would also be fired if the calculated grand total does not
 			match the read grand total */
 		}
-
-
 	}
 
 	public void testAllowancesExport() {
@@ -521,20 +503,19 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		BigDecimal qty = new BigDecimal("20");
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
 
-
-			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
+			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), new BigDecimal(500.0), qty).addAllowance(new Allowance(new BigDecimal(300)).setTaxPercent(new BigDecimal(19))))
 				.addAllowance(new Allowance(new BigDecimal(600)).setTaxPercent(new BigDecimal(19)))
-
 			);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
@@ -546,19 +527,17 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_ALLOWANCESPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
 
 		// Reading ZUGFeRD
 		assertEquals("4046.00", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 	public void testRelativeChargesAllowancesExport() {
@@ -568,22 +547,21 @@ public class ZF2PushTest extends TestCase {
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
-			ze.ignorePDFAErrors()
-				.load(SOURCE_PDF);
+			ze.ignorePDFAErrors().load(SOURCE_PDF);
 
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
 
-			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
+			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, new BigDecimal(1.0)).addCharge(new Charge().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19))))
 				.addAllowance(new Allowance().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19)))
-
 			);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
@@ -595,19 +573,15 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_RELATIVECHARGESALLOWANCESPDF);
 
-		assertFalse(zi.getUTF8().contains("EUR"));
-
-		// Reading ZUGFeRD
+		assertEquals("CHF", zi.getInvoiceCurrencyCode());
 		assertEquals("6.25", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 
@@ -628,12 +602,13 @@ public class ZF2PushTest extends TestCase {
 				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
-			ze.ignorePDFAErrors()
-				.load(SOURCE_PDF);
-			ze.setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
+			ze.ignorePDFAErrors().load(SOURCE_PDF);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
 			// no due date, since we are not expecting money
-			Invoice i = new Invoice().setIssueDate(new Date()).setDetailedDeliveryPeriod(new Date(), new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815")).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0815")).setNumber(number)
+			Invoice i = new Invoice().setIssueDate(new Date()).setDetailedDeliveryPeriod(new Date(), new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0815"))
+				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, qty)).setCorrection("0815");
@@ -648,19 +623,17 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_CORRECTIONPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
-//totest: typecode 384, BuyerOrderReferencedDocument
-		// Reading ZUGFeRD
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
+		assertEquals(zi.getDocumentCode(), DocumentCodeTypeConstants.CORRECTEDINVOICE);
+		//totest: BuyerOrderReferencedDocument
 		assertEquals("-3.57", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-
-
 	}
 
 	/***
@@ -673,20 +646,20 @@ public class ZF2PushTest extends TestCase {
 
 		String orgname = "Test company";
 		String number = "123";
+		String despatchAdviceReferencedDocumentID = "DESADV-4711";
 		String priceStr = "1.00";
 		BigDecimal price = new BigDecimal(priceStr);
 		BigDecimal qty = new BigDecimal(1.0);
 		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
 			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
-			ze.ignorePDFAErrors()
-				.load(SOURCE_PDF);
-			ze.
-				setProducer("My Application")
-				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
-			Invoice i = new Invoice().setIssueDate(new Date()).setDueDate(new Date()).setDetailedDeliveryPeriod(new Date(), new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815").addBankDetails(new BankDetails("DE88200800000970375700", "COBADEFFXXX"))).setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0815")).setNumber(number)
+			ze.ignorePDFAErrors().load(SOURCE_PDF);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
+			Invoice i = new Invoice().setIssueDate(new Date()).setDueDate(new Date()).setDetailedDeliveryPeriod(new Date(), new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815").addBankDetails(new BankDetails("DE88200800000970375700", "COBADEFFXXX")))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0815"))
+				.setNumber(number).setDespatchAdviceReferencedDocumentID(despatchAdviceReferencedDocumentID)
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), price, qty)).setCreditNote();
@@ -701,20 +674,30 @@ public class ZF2PushTest extends TestCase {
 		// now check the contents (like MustangReaderTest)
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_CREDITNOTEPDF);
 
-		assertTrue(zi.getUTF8().contains("EUR"));
-//totest: typecode 384, BuyerOrderReferencedDocument
-		// Reading ZUGFeRD
+		assertEquals("EUR", zi.getInvoiceCurrencyCode());
+		assertEquals(DocumentCodeTypeConstants.CREDITNOTE, zi.getDocumentCode());
+		//totest: BuyerOrderReferencedDocument
 		assertEquals("3.57", zi.getAmount());
-		assertEquals(zi.getHolder(), orgname);
-		assertEquals(zi.getForeignReference(), number);
+		assertEquals(orgname, zi.getHolder());
+		assertEquals(number, zi.getForeignReference());
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
 
+		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_CREDITNOTEPDF);
+		try {
+			Invoice i = zii.extractInvoice();
 
+			assertEquals(despatchAdviceReferencedDocumentID, i.getDespatchAdviceReferencedDocumentID());
+
+		} catch (XPathExpressionException e) {
+			fail("XPathExpressionException should not be raised");
+		} catch (ParseException e) {
+			fail("ParseException should not be raised");
+			/* a parseException would also be fired if the calculated grand total does not
+			match the read grand total */
+		}
 	}
-
-
 }


### PR DESCRIPTION
Read missing Invoice fields
  TradeParty.ID
  ExchangedDocument.TypeCode
  ApplicableHeaderTradeDelivery.DespatchAdviceReferencedDocument.IssuerAssignedID
Everything else is reformatting, joining split lines together for, in my opinion, better readability.

Enhance ZF2PushTest to check the now filled fields.
Formatting and changing some assertEquals to set the expected value as the first parameter.
