### PR TITLE
Re-Formatted and re-organized POMs

### DIFF
--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -1,215 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mustangproject</groupId>
         <artifactId>core</artifactId>
         <version>2.13.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
     <artifactId>Mustang-CLI</artifactId>
-    <name>e-invoices commandline tool, allowing to create(embed), split and validate Factur-X/ZUGFeRD files. Validation
-        should also work for XRechnung/CII.
-    </name>
     <packaging>jar</packaging>
+    <name>E-Invoice commandline tool</name>
+    
+    <description>
+    	E-invoices commandline tool, allowing to create(embed), split and validate Factur-X/ZUGFeRD files. Validation
+        should also work for XRechnung/CII.
+    </description>
+    
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.mustangproject</groupId>
             <artifactId>validator</artifactId>
-            <version>2.13.0-SNAPSHOT</version>
-            <!-- prototypes of new mustangproject versions can be installed by referring to them and installed to the local repo from a jar file with
-           mvn install:install-file -Dfile=mustang-1.5.4-SNAPSHOT.jar -DgroupId=org.mustangproject.ZUGFeRD -DartifactId=mustang -Dversion=1.5.4 -Dpackaging=jar -DgeneratePom=true
-           -->
+            <version>${project.version}</version>
         </dependency>
+        
         <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
-        <dependency><!-- apache commons cli to parse command line -->
+        <dependency>
+            <!-- apache commons cli to parse command line -->
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.8.0</version>
+            <version>${dep.commons-cli.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- for directory validation: -->
-        <dependency>
-            <groupId>org.xmlunit</groupId>
+	        <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.10.0</version>
+			<scope>compile</scope>
         </dependency>
+
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj</artifactId>
-            <version>2.10.0</version>
+            <scope>compile</scope>
         </dependency>
-
-        <!-- /directory validation: -->
 
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.2</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
         </dependency>
-
 
     </dependencies>
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <!-- mvn help:effective-pom will otherwise tell it just defaults
-                             to 2.3.2 - which does not release in the maven repo, and neither shows any
-                             error message :-( -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
             </plugin>
-            <!-- allow getImplementationVersion for the pom.xml -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-
-                    </archive>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>org.mustangproject.commandline.Main</mainClass>
                         </transformer>
                     </transformers>
-                    <minimizeJar>false</minimizeJar>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>LICENSE</exclude>
-                                <exclude>NOTICE</exclude>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>commons-logging:commons-logging</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                    </filters>
                 </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <excludes/>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile> <!-- enforce building binaries with Java 1.8 for Maven Central, otherwise using them e.g. as jar will
-           throw a version exception, triggered automatically on mvn release:release (hopefully) and requires an according
-           ~/.m2/toolchains.xml file, @see doc/development_documentation.md -->
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>toolchain</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <version>11</version>
-                                    <vendor>adopt</vendor>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <name>Jochen Stärk</name>
-            <email>jstaerk@usegroup.de</email>
-            <roles>
-                <role>architect</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
 </project>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -1,178 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mustangproject</groupId>
         <artifactId>core</artifactId>
         <version>2.13.0-SNAPSHOT</version>
     </parent>
-
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>library</artifactId>
     <packaging>jar</packaging>
-    <name>Library to write, read and validate e-invoices (Factur-X, ZUGFeRD, Order-X, XRechnung/CII)</name>
-    <description>FOSS Java library to read, write and validate european electronic invoices and orders in the UN/CEFACT
+    
+    <name>Mustang Library to r/w e-invoices</name>
+    
+    <description>
+    	FOSS Java library to read, write and validate european electronic invoices and orders in the UN/CEFACT
         Cross Industry Invoice based formats Factur-X/ZUGFeRD, XRechnung and Order-X in your invoice PDFs.
     </description>
-    <url>http://www.mustangproject.org/</url>
-    <scm>
-        <connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
-        <developerConnection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</developerConnection>
-        <url>https://github.com/ZUGFeRD/mustangproject</url>
-        <tag>core-2.3.2</tag>
-    </scm>
-    <repositories>
-        <repository><!-- for jargs -->
-            <id>sonatype-oss-public</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <distributionManagement>
-        <repository>
-            <id>internal.repo</id>
-            <name>Temporary Staging Repository</name>
-            <url>file://${project.build.directory}/mvn-repo</url>
-        </repository>
-    </distributionManagement>
+    
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <github.global.server>github</github.global.server>
-        <additionalparam>-Xdoclint:none</additionalparam>
-        <!-- Skip error check for javadoc -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.deploy.skip>true</maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
-
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
         </dependency>
+        
         <!-- https://mvnrepository.com/artifact/net.sf.saxon/Saxon-HE -->
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>12.4</version>
-        </dependency><!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+            <version>${dep.saxon-he.version}</version>
+        </dependency>
+        
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>${dep.jackson.version}</version>
         </dependency>
+        
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/fop -->
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>fop</artifactId>
-            <version>2.9</version>
+            <version>${dep.apache.fop.version}</version>
             <exclusions>
-              <exclusion>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-              </exclusion>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.2</version>
+            <version>${dep.jakarta.xml-bind.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>
-            <version>2.0.2</version>
+            <version>${dep.angus.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>preflight</artifactId>
-            <version>3.0.2</version>
+            <version>${dep.pdfbox.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>3.0.2</version>
+            <version>${dep.pdfbox.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>2.1.4</version>
+            <version>${dep.dom4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
-        </dependency>
-
+        
         <!-- CII to UBL conversion -->
         <dependency>
             <groupId>com.helger</groupId>
             <artifactId>en16931-cii2ubl</artifactId>
-            <version>2.2.4</version>
+            <version>${dep.en16931-cii2ubl.version}</version>
         </dependency>
+        
         <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.5</version>
+            <version>${dep.jaxb-runtime.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <excludes>
                         <exclude>**/logback.xml</exclude>
@@ -204,26 +169,19 @@
                     </archive>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.3</version>
                 <configuration>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <minimizeJar>false</minimizeJar><!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
+                    <minimizeJar>false</minimizeJar>
+                    <!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
                     <filters>
                         <filter>
                             <artifact>*:*</artifact>
@@ -243,100 +201,19 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <phase>package</phase>
                         <configuration>
                             <artifactSet>
-                                <excludes>
-                                </excludes>
+                                <excludes></excludes>
                             </artifactSet>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>templating-maven-plugin</artifactId>
-                <version>1.0.0</version>
-                <executions>
-                    <execution>
-                        <id>filtering-java-templates</id>
-                        <goals>
-                            <goal>filter-sources</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>
         </plugins>
     </build>
 
-
-    <profiles>
-        <profile> <!-- enforce building binaries with Java 1.8 for Maven Central, otherwise using them e.g. as jar will throw a version exception-->
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>toolchain</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <version>11</version>
-                                    <vendor>adopt</vendor>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-    <mailingLists>
-        <mailingList>
-            <name>User List</name>
-            <archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
-        </mailingList>
-    </mailingLists>
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <name>Jochen Stärk</name>
-            <email>jstaerk@usegroup.de</email>
-            <roles>
-                <role>architect</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <name>Alexander Schmidt</name>
-            <email>schmidt.alexander@mail.de</email>
-            <roles>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,126 +7,44 @@
     <packaging>pom</packaging>
     <name>Mustang</name>
 
+    <description>
+    	The Mustang project is a java library to read and write ZUGFeRD
+        meta data inside your invoice PDFs
+    </description>
+        
+    <url>http://www.mustangproject.org/</url>
+    
     <modules>
         <module>library</module>
         <module>validator</module>
         <module>Mustang-CLI</module>
     </modules>
-
-    <description>The Mustang project is a java library to read and write ZUGFeRD meta data inside your invoice PDFs
-    </description>
-    <url>http://www.mustangproject.org/</url>
-    <scm>
-        <connection>scm:git:git://github.com/dexecutor/dependent-tasks-executor.git</connection>
-        <developerConnection>scm:git:git@github.com:dexecutor/dexecutor.git</developerConnection>
-        <url>https://github.com/dexecutor/dependent-tasks-executor</url>
-      <tag>core-2.3.2</tag>
-  </scm>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin><!-- mvn help:effective-pom will otherwise tell it just defaults
-						to 2.3.2 - which does not release in the maven repo, and neither shows any
-						error message :-( -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                    <configuration>
-                        <localCheckout>true</localCheckout>
-                        <pushChanges>false</pushChanges>
-                        <mavenExecutorId>forked-path</mavenExecutorId>
-                        <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
-                    </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.scm</groupId>
-                            <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.9.5</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-
-                    <excludePackageNames>org.mustangproject.ZUGFeRD.model.*</excludePackageNames>
-
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0-M1</version>
-                <configuration>
-                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.1</version>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                    </execution>
-                </executions>
-            </plugin>
-
-        </plugins>
-    </build>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
         <additionalparam>-Xdoclint:none</additionalparam>
-        <!-- Skip error check for javadoc -->
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <maven.deploy.skip>true</maven.deploy.skip><!-- prevent this to be deployed to maven central as "core",
-        we only want submodules, see also https://stackoverflow.com/questions/7446599/how-to-deploy-only-the-sub-modules-using-maven-deploy-->
+        
+        <dep.slf4j.version>2.0.13</dep.slf4j.version>
+        <dep.saxon-he.version>12.4</dep.saxon-he.version>
+        <dep.jackson.version>2.17.1</dep.jackson.version>
+        <dep.apache.fop.version>2.9</dep.apache.fop.version>
+        <dep.jakarta.xml-bind.version>4.0.2</dep.jakarta.xml-bind.version>
+        <dep.angus.version>2.0.2</dep.angus.version>
+        <dep.pdfbox.version>3.0.2</dep.pdfbox.version>
+        <dep.dom4j.version>2.1.4</dep.dom4j.version>
+        <dep.en16931-cii2ubl.version>2.2.4</dep.en16931-cii2ubl.version>
+        <dep.jaxb-runtime.version>4.0.5</dep.jaxb-runtime.version>
+        <dep.junit5.version>5.10.2</dep.junit5.version>
+        <dep.xmlunit.version>2.10.0</dep.xmlunit.version>
+        
+        <dep.commons-cli.version>1.9.0</dep.commons-cli.version>
+        <dep.verapdf.validation-model-jakarta.version>1.26.1</dep.verapdf.validation-model-jakarta.version>
+        <dep.ph-schematron-xslt.version>8.0.0</dep.ph-schematron-xslt.version>
     </properties>
-
-    <mailingLists>
-        <mailingList>
-            <name>User List</name>
-            <archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
-        </mailingList>
-    </mailingLists>
+    
     <licenses>
         <license>
             <name>Apache-2.0</name>
@@ -135,6 +53,7 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
+    
     <developers>
         <developer>
             <name>Jochen Stärk</name>
@@ -152,11 +71,267 @@
             </roles>
         </developer>
     </developers>
+
+    <mailingLists>
+        <mailingList>
+            <name>User List</name>
+            <archive>https://groups.google.com/forum/?hl=de#!forum/mustangproject</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+        <connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
+        <developerConnection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</developerConnection>
+        <url>https://github.com/ZUGFeRD/mustangproject</url>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+	            <plugin>
+    	            <groupId>org.apache.maven.plugins</groupId>
+        	        <artifactId>maven-compiler-plugin</artifactId>
+        	        <version>3.13.0</version>
+                    <executions>
+                        <execution>
+                            <id>compile</id>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>${maven.compiler.source}</release>
+                            </configuration>
+                        </execution>
+                    </executions>
+	            </plugin>
+            
+            	<plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+        	        <artifactId>maven-resources-plugin</artifactId>
+	                <version>3.3.1</version>
+            	</plugin>
+            	
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <configuration>
+                        <localCheckout>true</localCheckout>
+                        <pushChanges>false</pushChanges>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-provider-gitexe</artifactId>
+                            <version>2.1.0</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                
+                <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-javadoc-plugin</artifactId>
+	                <version>3.8.0</version>
+	                <configuration>
+	                    <excludePackageNames>org.mustangproject.ZUGFeRD.model.*</excludePackageNames>
+	                </configuration>
+            	</plugin>
+            	
+	            <plugin>
+	                <artifactId>maven-deploy-plugin</artifactId>
+	                <version>3.1.2</version>
+	                <configuration>
+	                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+	                </configuration>
+	            </plugin>
+	            
+	            <plugin>
+	                <groupId>org.sonatype.plugins</groupId>
+	                <artifactId>nexus-staging-maven-plugin</artifactId>
+	                <version>1.7.0</version>
+	                <extensions>true</extensions>
+	                <configuration>
+	                    <serverId>ossrh</serverId>
+	                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+	                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+	                </configuration>
+	            </plugin>
+	            
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-surefire-plugin</artifactId>
+	                <version>3.3.1</version>
+	                <configuration>
+	                	<runOrder>alphabetical</runOrder>
+	                </configuration>
+	            </plugin>
+
+				<plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-source-plugin</artifactId>
+	                <version>3.3.1</version>
+	                <executions>
+	                    <execution>
+                            <id>attach-sources</id>
+	                        <goals>
+    	                        <goal>jar-no-fork</goal>
+        	                </goals>
+	                    </execution>
+	                </executions>
+	            </plugin>
+	            
+				<plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-jar-plugin</artifactId>
+    	            <version>3.4.2</version>
+                    <configuration>
+	                    <archive>
+	                        <manifest>
+	                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+	                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+	                        </manifest>
+	                    </archive>
+	                </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>test-jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+				</plugin>
+				
+	            <plugin>
+    	            <groupId>org.apache.maven.plugins</groupId>
+        	        <artifactId>maven-shade-plugin</artifactId>
+            	    <version>3.5.3</version>
+            	    <configuration>
+	                    <minimizeJar>false</minimizeJar>
+	                    <filters>
+	                        <filter>
+	                            <artifact>*:*</artifact>
+	                            <excludes>
+	                                <exclude>LICENSE</exclude>
+	                                <exclude>NOTICE</exclude>
+	                                <exclude>META-INF/*.SF</exclude>
+	                                <exclude>META-INF/*.DSA</exclude>
+	                                <exclude>META-INF/*.RSA</exclude>
+	                            </excludes>
+	                        </filter>
+	                        <filter>
+	                            <artifact>commons-logging:commons-logging</artifact>
+	                            <includes>
+	                                <include>**</include>
+	                            </includes>
+	                        </filter>
+	                    </filters>
+	                </configuration>
+	                <executions>
+	                    <execution>
+	                        <goals>
+	                            <goal>shade</goal>
+	                        </goals>
+	                        <phase>package</phase>
+	                        <configuration>
+	                            <artifactSet>
+	                                <excludes></excludes>
+	                            </artifactSet>
+	                        </configuration>
+	                    </execution>
+	                </executions>
+				</plugin>
+
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>templating-maven-plugin</artifactId>
+					<version>3.0.0</version>
+					<executions>
+						<execution>
+							<id>filtering-java-templates</id>
+							<goals>
+								<goal>filter-sources</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+            </plugins>
+        </pluginManagement>
+        
+        <plugins>
+        	<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+        	</plugin>
+        </plugins>
+    </build>
+    
+    <dependencyManagement>
+		<dependencies>
+	        <dependency>
+	            <groupId>org.slf4j</groupId>
+    	    	<artifactId>slf4j-api</artifactId>
+        		<version>${dep.slf4j.version}</version>
+	        </dependency>
+		
+	        <dependency>
+	            <groupId>jakarta.xml.bind</groupId>
+	            <artifactId>jakarta.xml.bind-api</artifactId>
+	            <version>${dep.jakarta.xml-bind.version}</version>
+	        </dependency>
+
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-api</artifactId>
+				<version>${dep.junit5.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.junit.vintage</groupId>
+				<artifactId>junit-vintage-engine</artifactId>
+				<version>${dep.junit5.version}</version>
+				<scope>test</scope>
+			</dependency>
+			
+	        <dependency>
+	            <groupId>org.xmlunit</groupId>
+	            <artifactId>xmlunit-core</artifactId>
+	            <version>${dep.xmlunit.version}</version>
+	            <scope>test</scope>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.xmlunit</groupId>
+	            <artifactId>xmlunit-assertj</artifactId>
+	            <version>${dep.xmlunit.version}</version>
+	            <scope>test</scope>
+	        </dependency>
+
+	        <dependency>
+	            <groupId>org.slf4j</groupId>
+	            <artifactId>slf4j-simple</artifactId>
+	            <version>${dep.slf4j.version}</version>
+	            <scope>test</scope>
+	        </dependency>
+
+		</dependencies>
+    </dependencyManagement>
+    
     <profiles>
-
-
-        <!-- GPG Signature on release -->
-
+		<!-- GPG Signature on release -->
         <profile>
             <id>release-sign-artifacts</id>
             <activation>
@@ -170,7 +345,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -180,26 +355,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>toolchain</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <version>11</version>
-                                    <vendor>adopt</vendor>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -1,33 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mustangproject</groupId>
         <artifactId>core</artifactId>
         <version>2.13.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+    
     <artifactId>validator</artifactId>
-    <name>Library to validate e-invoices (ZUGFeRD, Factur-X and Xrechnung)</name>
-
     <packaging>jar</packaging>
-    <repositories>
-        <repository>
-            <!-- for jargs -->
-            <id>sonatype-oss-public</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+    
+    <name>E-Invoices Validator</name>
+	
+	<description>
+		Library to validate e-invoices (ZUGFeRD, Factur-X and Xrechnung
+	</description>
+	
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.deploy.skip>false</maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
@@ -35,155 +24,82 @@
             <artifactId>library</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.2</version>
         </dependency>
 
-        <!-- Verapdf plugin <dependency> <groupId>org.verapdf</groupId> <artifactId>core</artifactId>
-              <version>1.6.2</version> </dependency> -->
-        <!-- embedded verapdf -->
         <dependency>
             <groupId>org.verapdf</groupId>
             <artifactId>validation-model-jakarta</artifactId>
-            <version>1.26.1</version>
+            <version>${dep.verapdf.validation-model-jakarta.version}</version>
         </dependency>
+        
         <!-- https://mvnrepository.com/artifact/com.helger/ph-schematron -->
         <dependency>
             <groupId>com.helger.schematron</groupId>
             <artifactId>ph-schematron-xslt</artifactId>
-            <version>8.0.0</version>
+            <version>${dep.ph-schematron-xslt.version}</version>
         </dependency>
+        
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.9</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <!-- mvn help:effective-pom will otherwise tell it just defaults
-                             to 2.3.2 - which does not release in the maven repo, and neither shows any
-                             error message :-( -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <runOrder>alphabetical</runOrder>
-                </configuration>
             </plugin>
-            <!-- allow getImplementationVersion for the pom.xml -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/logback.xml</exclude>
-                    </excludes>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
-            <!-- /ZUV -->
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
-                <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <minimizeJar>false</minimizeJar>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>LICENSE</exclude>
-                                <exclude>NOTICE</exclude>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>commons-logging:commons-logging</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <excludes />
-                            </artifactSet>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>copy-zf-schematron-xml-dependencies</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
+                        <phase>compile</phase>
 
                         <configuration>
                             <outputDirectory>${basedir}/src/main/resources/xslt/ZF_221/</outputDirectory>
@@ -201,62 +117,11 @@
             </plugin>
         </plugins>
     </build>
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
-    <developers>
-        <developer>
-            <name>Jochen Stärk</name>
-            <email>jstaerk@usegroup.de</email>
-            <roles>
-                <role>architect</role>
-                <role>developer</role>
-            </roles>
-        </developer>
-    </developers>
     <profiles>
-        <profile> <!-- enforce building binaries with Java 1.8 for Maven Central, otherwise using them e.g. as jar will
-        throw a version exception, triggered automatically on mvn release:release (hopefully) and requires an according
-        ~/.m2/toolchains.xml file, @see doc/development_documentation.md -->
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-toolchains-plugin</artifactId>
-                        <version>3.1.0</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>toolchain</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <toolchains>
-                                <jdk>
-                                    <version>11</version>
-                                    <vendor>adopt</vendor>
-                                </jdk>
-                            </toolchains>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile> <!-- build the intermediate XSLT files from schematron takes 30min+ and is only required if there actually is a change in the schematron,
-         -> invoke manually with commandline -P generateXSLTFromSchematron on demand -->
+        <profile>
+            <!-- build the intermediate XSLT files from schematron takes 30min+ and is only
+            	 required if there actually is a change in the schematron,
+         		invoke manually with commandline -P generateXSLTFromSchematron on demand -->
             <id>generateXSLTFromSchematron</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
@@ -266,7 +131,7 @@
                     <plugin>
                         <groupId>com.helger.maven</groupId>
                         <artifactId>ph-schematron-maven-plugin</artifactId>
-                        <version>8.0.0</version>
+                        <version>${dep.ph-schematron-xslt.version}</version>
                         <configuration>
                             <schematronDirectory>${basedir}/src/main/resources/schematron</schematronDirectory>
                             <xsltDirectory>${basedir}/src/main/resources/xslt</xsltDirectory>


### PR DESCRIPTION
This PR includes a refactoring of the project POMs.

- Formatted all POMs using Maven sortpom Plugin
- Removed duplicated configuration (will be inherited from the parent POM)
- Moved all plugins to plugin management with a base (default) configuration
- Use plugins in modules by referencing them, added additional configuration if needed
- Updated plugin versions
- Add test-jar to created jars on build (I wonder why Maven Central did not complain about that)
- Moved common dependencies to dependency-management
- Added properties for all used dependency versions
  - this allows defining the versions only once and at a well defined position

I build everything locally and also did `release:prepare` and `release:perform`. 
The created artifacts looks good to me. POM seems to be complete (not missing dependencies).  
I don't know how exactly your build-chain works, but usually the maven-deploy plugin should deploy to Maven Central, while it will only deploy to some local directories with the current configuration (like before).

One more thing I've noticed: The surefire plugin is configured to run the tests in a specified order. That is really awkward. Tests should never rely on each other, every test class should be able to perform the required actions without any knowledge of other tests. E.g. this setup will not work when running tests in an IDE, because some resources would be missing when another test was not executed explicitly before.

I did not change that behavior even though I was thinking about it, but that would at least be stuff for another PR and also would require refactoring in test setup.

If you need further assistance with this, let me know.