### PR TITLE
Add LegalOrganisation.TradingBusinessName and DefinedTradeContact als…

### DIFF
--- a/library/src/main/java/org/mustangproject/LegalOrganisation.java
+++ b/library/src/main/java/org/mustangproject/LegalOrganisation.java
@@ -2,6 +2,8 @@ package org.mustangproject;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.mustangproject.ZUGFeRD.*;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /***
  * A organisation, i.e. usually a company
@@ -9,35 +11,68 @@ import org.mustangproject.ZUGFeRD.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LegalOrganisation implements IZUGFeRDLegalOrganisation {
 
-	protected String ID = null;
-	protected String SchemeID = null;
+	protected SchemedID schemedID = null;
+	protected String tradingBusinessName = null;
 
 	public LegalOrganisation() {
 	}
 
 	public LegalOrganisation(String ID, String scheme) {
-		this.ID=ID;
-		this.SchemeID=scheme;
+		this.schemedID = new SchemedID(ID, scheme);
+	}
+
+	public LegalOrganisation(SchemedID schemedID, String tradingBusinessName) {
+		this.schemedID = schemedID;
+		this.tradingBusinessName=tradingBusinessName;
+	}
+
+	/***
+	 * XML parsing constructor
+	 * @param nodes the nodelist returned e.g. from xpath
+	 */
+	public LegalOrganisation(NodeList nodes) {
+		if (nodes.getLength() > 0) {
+		/*
+			will parse sth like
+			<ram:SpecifiedLegalOrganization>  
+				<ram:ID schemeID="0002">4711</ram:ID>
+				<ram:TradingBusinessName>Test GmbH &amp; Co.KG</ram:TradingBusinessName>
+			</ram:SpecifiedLegalOrganization>
+		 */
+			for (int nodeIndex = 0; nodeIndex < nodes.getLength(); nodeIndex++) {
+				Node currentItemNode = nodes.item(nodeIndex);
+				if (currentItemNode.getLocalName() != null) {
+					if (currentItemNode.getLocalName().equals("GlobalID")) {
+						if (currentItemNode.getAttributes().getNamedItem("schemeID") != null) {
+							SchemedID gid = new SchemedID().setScheme(currentItemNode.getAttributes().getNamedItem("schemeID").getNodeValue()).setId(currentItemNode.getTextContent());
+							this.setSchemedID(gid);
+						}
+					}
+					if (currentItemNode.getLocalName().equals("TradingBusinessName")) {
+					    setTradingBusinessName(currentItemNode.getFirstChild().getNodeValue());
+					}
+				}
+			}
+		}
 	}
 
 	@Override
-	public String getID() {
-		return ID;
+	public SchemedID getSchemedID() {
+		return this.schemedID;
 	}
 
 	@Override
-	public String getSchemeID() {
-		return SchemeID;
+	public String getTradingBusinessName() {
+		return this.tradingBusinessName;
 	}
 
-	public LegalOrganisation setID(String id) {
-		this.ID=id;
+	public LegalOrganisation setSchemedID(SchemedID schemedID) {
+		this.schemedID = schemedID;
 		return this;
 	}
 
-	public LegalOrganisation setSchemeID(String scheme) {
-		SchemeID=scheme;
+	public LegalOrganisation setTradingBusinessName(String tradingBusinessName) {
+		this.tradingBusinessName = tradingBusinessName;
 		return this;
 	}
-
 }

--- a/library/src/main/java/org/mustangproject/TradeParty.java
+++ b/library/src/main/java/org/mustangproject/TradeParty.java
@@ -308,6 +308,10 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 								addGlobalID(gid);
 							}
 						}
+						if (itemChilds.item(itemChildIndex).getLocalName().equals("SpecifiedLegalOrganization")) {
+							NodeList organization = itemChilds.item(itemChildIndex).getChildNodes();
+							setLegalOrganisation(new LegalOrganisation(organization));
+						}
 						if (itemChilds.item(itemChildIndex).getLocalName().equals("DefinedTradeContact")) {
 							NodeList contact = itemChilds.item(itemChildIndex).getChildNodes();
 							setContact(new Contact(contact));

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDLegalOrganisation.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDLegalOrganisation.java
@@ -18,17 +18,19 @@
  *********************************************************************** */
 package org.mustangproject.ZUGFeRD;
 
-public interface IZUGFeRDLegalOrganisation   {
+import org.mustangproject.SchemedID;
 
-	/***
-	 *
-	 * @return the ID of the legal organisation
-	 */
-	public String getID();
+public interface IZUGFeRDLegalOrganisation   {
 
 	/**
 	 *
-	 * @return the scheme attribute of the legal organization=the type of the identification, e.g. 0002=Siren
+	 * @return the scheme attribute of the legal organization=the type of the identification, e.g. 0002=Siren, and its value
 	 */
-	public String getSchemeID();
+	public SchemedID getSchemedID();
+
+	/***
+	 *
+	 * @return the TradingBusinessName of the legal organisation
+	 */
+	public String getTradingBusinessName();
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -139,13 +139,18 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		}
 		xml += "<ram:Name>" + XMLTools.encodeXML(party.getName()) + "</ram:Name>";
 
-		if (party.getLegalOrganisation() != null) {
+		if (party.getLegalOrganisation() != null && (profile == Profiles.getByName("EN16931") || profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung"))) {
 			xml += "<ram:SpecifiedLegalOrganization> ";
-			xml += "<ram:ID schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemeID()) + "\">" + XMLTools.encodeXML(party.getLegalOrganisation().getID()) + "</ram:ID>";
+			if (party.getLegalOrganisation().getSchemedID() != null) {
+				xml += "<ram:ID schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getScheme()) + "\">" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getID()) + "</ram:ID>";
+			}
+			if (party.getLegalOrganisation().getTradingBusinessName() != null) {
+				xml += "<ram:TradingBusinessName>" + XMLTools.encodeXML(party.getLegalOrganisation().getTradingBusinessName()) + "</ram:TradingBusinessName>";
+			}
 			xml += "</ram:SpecifiedLegalOrganization>";
 		}
 
-		if ((party.getContact() != null) && (isSender || profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung"))) {
+		if ((party.getContact() != null) && (isSender || profile == Profiles.getByName("EN16931") || profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung"))) {
 			xml += "<ram:DefinedTradeContact>";
 			if (party.getContact().getName() != null) {
 				xml += "<ram:PersonName>" + XMLTools.encodeXML(party.getContact().getName())

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ProfilesMinimumBasicWLTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ProfilesMinimumBasicWLTest.java
@@ -36,7 +36,8 @@ import java.util.Date;
  */
 public class ProfilesMinimumBasicWLTest extends TestCase {
 
-	final String TARGET_PDF_FX_MINIMUM = "./target/testout-Minimum.pdf";
+	final String TARGET_PDF_FX_MINIMUM_INV = "./target/testout-Minimum-INV.pdf";
+	final String TARGET_PDF_FX_MINIMUM_CN = "./target/testout-Minimum-CN.pdf";
 
 	public void testMinimumCreditNote() {
 		String ownNumber = "NUMFACTURE";
@@ -67,7 +68,7 @@ public class ProfilesMinimumBasicWLTest extends TestCase {
 					.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), new BigDecimal(123), new BigDecimal(1)))
 					.setCreditNote();
 			ze.setTransaction(i);
-			ze.export(TARGET_PDF_FX_MINIMUM);
+			ze.export(TARGET_PDF_FX_MINIMUM_CN);
 
 			// check for pdf-a schema extension
 //			assertFalse(pdfContent.indexOf("<zf:ConformanceLevel>EN 16931</zf:ConformanceLevel>") == -1);
@@ -79,7 +80,7 @@ public class ProfilesMinimumBasicWLTest extends TestCase {
 		}
 
 		// now check the contents (like MustangReaderTest)
-		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF_FX_MINIMUM);
+		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF_FX_MINIMUM_CN);
 
 		// Reading ZUGFeRD
 		assertEquals("146.37",zi.getAmount());
@@ -121,7 +122,7 @@ public class ProfilesMinimumBasicWLTest extends TestCase {
 					.setNumber(ownNumber).setTotalPrepaidAmount(new BigDecimal("1"))
 					.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), new BigDecimal(123), new BigDecimal(1)));
 			ze.setTransaction(i);
-			ze.export(TARGET_PDF_FX_MINIMUM);
+			ze.export(TARGET_PDF_FX_MINIMUM_INV);
 
 			// check for pdf-a schema extension
 //			assertFalse(pdfContent.indexOf("<zf:ConformanceLevel>EN 16931</zf:ConformanceLevel>") == -1);
@@ -133,7 +134,7 @@ public class ProfilesMinimumBasicWLTest extends TestCase {
 		}
 
 		// now check the contents (like MustangReaderTest)
-		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF_FX_MINIMUM);
+		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF_FX_MINIMUM_INV);
 
 		// Reading ZUGFeRD
 		assertEquals("145.37",zi.getAmount());

--- a/validator/src/test/java/org/mustangproject/validator/LibraryTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/LibraryTest.java
@@ -244,8 +244,31 @@ public class LibraryTest extends ResourceCase {
 				.isEqualTo(0);
 	}
 
-	public void testMinimumProfileValidity() {
-		File tempFile = new File("../library/target/testout-Minimum.pdf");
+	public void testMinimumProfileValidityInvoice() {
+		File tempFile = new File("../library/target/testout-Minimum-INV.pdf");
+		ZUGFeRDValidator zfv = new ZUGFeRDValidator();
+
+		String res = zfv.validate(tempFile.getAbsolutePath());
+
+		assertThat(res).valueByXPath("count(//error)")
+				.asInt()
+				.isEqualTo(0);
+		assertThat(res).valueByXPath("/validation/summary/@status")
+				.asString()
+				.isEqualTo("valid");// expect to be valid because XR notices are, well, only notices
+		assertThat(res).valueByXPath("/validation/xml/summary/@status")
+				.asString()
+				.isEqualTo("valid");
+		/** end of errors due to version mismatch*/
+
+
+		assertThat(res).valueByXPath("count(//notice)")
+				.asInt()
+				.isEqualTo(0);
+	}
+
+	public void testMinimumProfileValidityCreditNote() {
+		File tempFile = new File("../library/target/testout-Minimum-CN.pdf");
 		ZUGFeRDValidator zfv = new ZUGFeRDValidator();
 
 		String res = zfv.validate(tempFile.getAbsolutePath());


### PR DESCRIPTION
…o for Recipient.

Related to #447.

Changes:
- IZUGFeRDLegalOrganisation: remove separate String fields in favour of SchemedID class, add tradingBusinessName
- LegalOrganisation: change separate String fields to SchemedID class, add tradingBusinessName, add two new constructors
- TradeParty: read SpecifiedLegalOrganization during import from xml
- ProfilesMinimumBasicWLTest: write output to different files, Invoice and CreditNote
- LibraryTest: check both files created with ProfilesMinimumBasicWLTest

Due to the changes for importing the LegalOrganisation also now, the LibraryTest failed then.
LegalOrganisation is now only written for profiles EN16931, Extended or XRechnung, so not for Minimum.

Added EN16931 to the profiles valid for writing DefinedTradeContact element.