### PR TITLE
Fix ClassCastException in CLI (Main.java).

### DIFF
--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -722,9 +722,6 @@ public class Main {
 					((ZUGFeRDExporterFromPDFA) ze).ignorePDFAErrors();
 				}
 			}
-			for (FileAttachment attachment : attachments) {
-				((ZUGFeRDExporterFromA3) ze).attachFile(attachment.getFilename(), attachment.getData(), attachment.getMimetype(), attachment.getRelation());
-			}
 
 			ze.load(pdfName);
 			ze.setProducer("Mustang-cli")
@@ -736,6 +733,14 @@ public class Main {
 			}
 
 			ze.setXML(Files.readAllBytes(Paths.get(xmlName)));
+
+			for (FileAttachment attachment : attachments) {
+				if (((ZUGFeRDExporterFromPDFA) ze).getExporter() instanceof ZUGFeRDExporterFromA3 ) {
+					((ZUGFeRDExporterFromA3) ((ZUGFeRDExporterFromPDFA) ze).getExporter()).attachFile(attachment.getFilename(), attachment.getData(), attachment.getMimetype(), attachment.getRelation());
+				} else {
+					System.err.println("IZUGFeRDExporter ze is not of type 'ZUGFeRDExporterFromA3'");
+				}
+			}
 
 			ze.export(outName);
 			System.out.println("Written to " + outName);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
@@ -72,7 +72,7 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 
 
 	}
-	protected IZUGFeRDExporter getExporter() {
+	public IZUGFeRDExporter getExporter() {
 		if (theExporter==null) {
 			throw new RuntimeException("In ZUGFeRDExporterFromPDFA, source must always be loaded before other operations are performed.");
 		}


### PR DESCRIPTION
Related to #448 .

Moved adding of Attachments after loading the pdf-file. Only at this point it's clear, of which type the source pdf is.
Check if exporter class is really of type ZUGFeRDExporterFromA3, else (ZUGFeRDExporterFromA1) print an error message.
At least with a source pdf of PDF/A-3A it works.
Class ZUGFeRDExporterFromA1 does not support Attachments, because in PDF/A-1 (ISO 19005-01) version 1.4 (2005) Attachments are NOT allowed.

```
java -jar Mustang-CLI-2.13.0-SNAPSHOT.jar --action combine --source Rechnung.pdf --source-xml CII-XRechnung-4711-0815-xml.xml --out ZF_Rechnung.pdf --format zf --version 2 --profile E  --attachments "CII-XRechnung-4711-0815-xml.pdf"

SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
Source PDF set to Rechnung.pdf
ZUGFeRD XML set to CII-XRechnung-4711-0815-xml.xml
Output PDF set to ZF_Rechnung.pdf
Format set to zf
Version set to 2
Profile set to E
Written to ZF_Rechnung.pdf
```
