### PR TITLE
Makes the getTotalAmount() function easier to use

### DIFF
--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -116,12 +116,20 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	
 	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
+		if (percent!=null) {
+			return currentItem.getValue().multiply(getPercent().divide(new BigDecimal(100)));
+		} else if(totalAmount != null) {
+			return totalAmount;
+		} else {
+			throw new RuntimeException("percent must be set");
+		}
+	}
+
+	public BigDecimal getTotalAmount() {
 		if (totalAmount!=null) {
 			return totalAmount;
-		} else if (percent!=null) {
-			return currentItem.getValue().multiply(getPercent().divide(new BigDecimal(100)));
 		} else {
-			throw new RuntimeException("Either totalAmount or percent must be set");
+			throw new RuntimeException("totalAmount must be set");
 		}
 	}
 

--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -116,20 +116,12 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	
 	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
-		if (percent!=null) {
-			return currentItem.getValue().multiply(getPercent().divide(new BigDecimal(100)));
-		} else if(totalAmount != null) {
-			return totalAmount;
-		} else {
-			throw new RuntimeException("percent must be set");
-		}
-	}
-
-	public BigDecimal getTotalAmount() {
 		if (totalAmount!=null) {
 			return totalAmount;
+		} else if (percent!=null) {
+			return currentItem.getValue().multiply(getPercent().divide(new BigDecimal(100)));
 		} else {
-			throw new RuntimeException("totalAmount must be set");
+			throw new RuntimeException("Either totalAmount or percent must be set");
 		}
 	}
 


### PR DESCRIPTION
Makes the usage of getTotalAmount clearer because you can choose if you want the total amount of the charge of of an item with the percentage of the item.
Maybe also rename
`public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem)`
to
`public BigDecimal getItemAmount(IAbsoluteValueProvider currentItem)`
