### PR TITLE
changed additional references by line from String to List and implemented it on Item

### DIFF
--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -465,6 +465,29 @@ public class Item implements IZUGFeRDExportableItem {
 		return referencedDocuments.toArray(new IReferencedDocument[0]);
 	}
 
+
+	/***
+	 * adds item level references along with their typecodes and issuerassignedIDs (contract ID, cost centre, ...) 
+	 * @param doc the ReferencedDocument to add
+	 * @return fluent setter
+	 */
+	public Item addAdditionalReference(ReferencedDocument doc) {
+		if (referencedDocuments == null) {
+			referencedDocuments = new ArrayList<>();
+		}
+		referencedDocuments.add(doc);
+		return this;
+	}
+
+	@Override
+	public IReferencedDocument[] getAdditionalReferences() {
+		if (referencedDocuments == null) {
+			return null;
+		}
+		return referencedDocuments.toArray(new IReferencedDocument[0]);
+	}
+	
+	
 	/***
 	 * specify a item level delivery period
 	 * (apart from the document level delivery period, and the document level

--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -64,7 +64,7 @@ public class Item implements IZUGFeRDExportableItem {
 		String referencedLineID = null;
 
 		ArrayList<ReferencedDocument> rdocs = null;
-		ArrayList<ReferencedDocument> additionalReferences = null;
+		ArrayList<ReferencedDocument> addRefs = null;
 
 		// nodes.item(i).getTextContent())) {
 
@@ -272,10 +272,10 @@ public class Item implements IZUGFeRDExportableItem {
 
 							ReferencedDocument rd = new ReferencedDocument(IssuerAssignedID, TypeCode,
 								ReferenceTypeCode);
-							if (additionalReferences == null) {
-								additionalReferences = new ArrayList<>();
+							if (addRefs == null) {
+								addRefs = new ArrayList<>();
 							}
-							additionalReferences.add(rd);
+							addRefs.add(rd);
 
 						}
 						
@@ -305,8 +305,8 @@ public class Item implements IZUGFeRDExportableItem {
 				addReferencedDocument(rdoc);
 			}
 		}
-		if (additionalReferences != null) {
-			for (ReferencedDocument rdoc : additionalReferences) {
+		if (addRefs != null) {
+			for (ReferencedDocument rdoc : addRefs) {
 				addAdditionalReference(rdoc);
 			}
 		}

--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -26,6 +26,7 @@ public class Item implements IZUGFeRDExportableItem {
 	protected Product product;
 	protected ArrayList<String> notes = null;
 	protected ArrayList<ReferencedDocument> referencedDocuments = null;
+	protected ArrayList<ReferencedDocument> additionalReference = null;
 	protected ArrayList<IZUGFeRDAllowanceCharge> Allowances = new ArrayList<>(),
 		Charges = new ArrayList<>();
 
@@ -248,6 +249,35 @@ public class Item implements IZUGFeRDExportableItem {
 								}
 							}
 						}
+						
+						if (tradeSettlementName.equals("AdditionalReferencedDocument")) {
+							String IssuerAssignedID = "";
+							String TypeCode = "";
+							String ReferenceTypeCode = "";
+
+							NodeList refDocChilds = tradeSettlementChilds.item(tradeSettlementChildIndex).getChildNodes();
+							for (int refDocIndex = 0; refDocIndex < refDocChilds.getLength(); refDocIndex++) {
+								String localName = refDocChilds.item(refDocIndex).getLocalName();
+								if ((localName != null) && (localName.equals("IssuerAssignedID"))) {
+									IssuerAssignedID = refDocChilds.item(refDocIndex).getTextContent();
+								}
+								if ((localName != null) && (localName.equals("TypeCode"))) {
+									TypeCode = refDocChilds.item(refDocIndex).getTextContent();
+								}
+								if ((localName != null) && (localName.equals("ReferenceTypeCode"))) {
+									ReferenceTypeCode = refDocChilds.item(refDocIndex).getTextContent();
+								}
+							}
+
+							ReferencedDocument rd = new ReferencedDocument(IssuerAssignedID, TypeCode,
+								ReferenceTypeCode);
+							if (rdocs == null) {
+								rdocs = new ArrayList<>();
+							}
+							rdocs.add(rd);
+
+						}
+						
 					}
 				}
 			}
@@ -472,19 +502,19 @@ public class Item implements IZUGFeRDExportableItem {
 	 * @return fluent setter
 	 */
 	public Item addAdditionalReference(ReferencedDocument doc) {
-		if (referencedDocuments == null) {
-			referencedDocuments = new ArrayList<>();
+		if (additionalReference == null) {
+			additionalReference = new ArrayList<>();
 		}
-		referencedDocuments.add(doc);
+		additionalReference.add(doc);
 		return this;
 	}
 
 	@Override
 	public IReferencedDocument[] getAdditionalReferences() {
-		if (referencedDocuments == null) {
+		if (additionalReference == null) {
 			return null;
 		}
-		return referencedDocuments.toArray(new IReferencedDocument[0]);
+		return additionalReference.toArray(new IReferencedDocument[0]);
 	}
 	
 	

--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -64,6 +64,7 @@ public class Item implements IZUGFeRDExportableItem {
 		String referencedLineID = null;
 
 		ArrayList<ReferencedDocument> rdocs = null;
+		ArrayList<ReferencedDocument> additionalReferences = null;
 
 		// nodes.item(i).getTextContent())) {
 
@@ -271,10 +272,10 @@ public class Item implements IZUGFeRDExportableItem {
 
 							ReferencedDocument rd = new ReferencedDocument(IssuerAssignedID, TypeCode,
 								ReferenceTypeCode);
-							if (rdocs == null) {
-								rdocs = new ArrayList<>();
+							if (additionalReferences == null) {
+								additionalReferences = new ArrayList<>();
 							}
-							rdocs.add(rd);
+							additionalReferences.add(rd);
 
 						}
 						
@@ -302,6 +303,11 @@ public class Item implements IZUGFeRDExportableItem {
 		if (rdocs != null) {
 			for (ReferencedDocument rdoc : rdocs) {
 				addReferencedDocument(rdoc);
+			}
+		}
+		if (additionalReferences != null) {
+			for (ReferencedDocument rdoc : additionalReferences) {
+				addAdditionalReference(rdoc);
 			}
 		}
 		addReferencedLineID( referencedLineID );

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
@@ -91,6 +91,16 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	}
 
 	/***
+	 * the ID of an additionally referenced document for this item
+	 * @deprecated use {@link #getAdditionalReferences()} instead.
+	 * @return the id as string
+	 */
+	@Deprecated
+	default String getAdditionalReferencedDocumentID() {
+		return null;
+	}
+
+	/***
 	 * allows to specify multiple references (billing information)
 	 * @return the referenced documents
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
@@ -91,10 +91,10 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	}
 
 	/***
-	 * the ID of an additionally referenced document for this item
-	 * @return the id as string
+	 * allows to specify multiple references (billing information)
+	 * @return the referenced documents
 	 */
-	default String getAdditionalReferencedDocumentID() {
+	default IReferencedDocument[] getAdditionalReferences() {
 		return null;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
@@ -387,8 +387,8 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 					+ "<ram:LineTotalAmount currencyID=\"" + trans.getCurrency() + "\">" + currencyFormat(lc.getItemTotalNetAmount())
 					+ "</ram:LineTotalAmount>"
 					+ "</ram:SpecifiedTradeSettlementMonetarySummation>";
-			if (currentItem.getAdditionalReferencedDocumentID() != null) {
-				xml += "<ram:AdditionalReferencedDocument><ram:ID>" + currentItem.getAdditionalReferencedDocumentID() + "</ram:ID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
+			if (currentItem.getAdditionalReferences() != null) {
+				xml += "<ram:AdditionalReferencedDocument><ram:ID>" + currentItem.getAdditionalReferences()[0].getIssuerAssignedID() + "</ram:ID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
 
 			}
 			xml += "</ram:SpecifiedSupplyChainTradeSettlement>"

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
@@ -389,7 +389,8 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 					+ "</ram:SpecifiedTradeSettlementMonetarySummation>";
 			if (currentItem.getAdditionalReferences() != null) {
 				xml += "<ram:AdditionalReferencedDocument><ram:ID>" + currentItem.getAdditionalReferences()[0].getIssuerAssignedID() + "</ram:ID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
-
+			} else if (currentItem.getAdditionalReferencedDocumentID() != null) {
+				xml += "<ram:AdditionalReferencedDocument><ram:ID>" + currentItem.getAdditionalReferencedDocumentID() + "</ram:ID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
 			}
 			xml += "</ram:SpecifiedSupplyChainTradeSettlement>"
 					+ "<ram:SpecifiedTradeProduct>";

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -511,6 +511,8 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 							"<ram:ReferenceTypeCode>" + XMLTools.encodeXML(currentReference.getReferenceTypeCode()) + "</ram:ReferenceTypeCode>" +
 							"</ram:AdditionalReferencedDocument>";
 					}
+				} else if (currentItem.getAdditionalReferencedDocumentID() != null) {
+					xml += "<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>" + currentItem.getAdditionalReferencedDocumentID() + "</ram:IssuerAssignedID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
 				}
 				xml += "</ram:SpecifiedLineTradeSettlement>"
 					+ "</ram:IncludedSupplyChainTradeLineItem>";

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -503,9 +503,14 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "<ram:LineTotalAmount>" + currencyFormat(lc.getItemTotalNetAmount())
 					+ "</ram:LineTotalAmount>" // currencyID=\"EUR\"
 					+ "</ram:SpecifiedTradeSettlementLineMonetarySummation>";
-				if (currentItem.getAdditionalReferencedDocumentID() != null) {
-					xml += "<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>" + currentItem.getAdditionalReferencedDocumentID() + "</ram:IssuerAssignedID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
-
+				if (currentItem.getAdditionalReferences() != null) {
+					for (final IReferencedDocument currentReference : currentItem.getAdditionalReferences()) {
+						xml += "<ram:AdditionalReferencedDocument>" +
+							"<ram:IssuerAssignedID>" + XMLTools.encodeXML(currentReference.getIssuerAssignedID()) + "</ram:IssuerAssignedID>" +
+							"<ram:TypeCode>130</ram:TypeCode>" +
+							"<ram:ReferenceTypeCode>" + XMLTools.encodeXML(currentReference.getReferenceTypeCode()) + "</ram:ReferenceTypeCode>" +
+							"</ram:AdditionalReferencedDocument>";
+					}
 				}
 				xml += "</ram:SpecifiedLineTradeSettlement>"
 					+ "</ram:IncludedSupplyChainTradeLineItem>";


### PR DESCRIPTION
Wir stehen vor der Herausforderung Sammelrechnungen abbilden zu müssen. Hierzu ist es erforderlich je Rechnungsposition eine Liste von Details (u.a. Vertragsnummer) zu hinterlegen, damit der Rechnungsempfänger die Position korrekt zuordnen kann.
Nach eingehender Betrachtung der ZUGFeRD Dokumentation sind wir zu dem Schluss gekommen, dass die positionsbezogenen Referenzen in BT-128 zu hinterlegen sind. Dies entspricht dem Pfad CrossIndustryInvoice / SupplyChainTradeTransaction / IncludedSupplyChainTradeLineItem / SpecifiedLineTradeSettlement / AdditionalReferencedDocument, welcher in ZF2 als Liste mehrerer Referenzen vorgesehen ist.
Bisher ist von mustangproject hierfür nur ein String vorgesehen gewesen (IZUGFeRDExportableItem.getAdditionalReferencedDocumentID), welcher allerdings nur im Interface existiert und nicht implementiert ist. Die Funktionalität Item.addReferencedDocument() halten wir für unseren Anwendungsfall für die falsche Stelle, da diese Werte unter ~ / IncludedSupplyChainTradeLineItem / SpecifiedLineTradeAgreement eingefügt werden und keinem BusinessTerm zugeordnet sind.
Ich habe nun am Item die vorhandene Methode ersetzt, durch die Möglichkeit eine Liste zu erfassen. Für ZF1 wird nur das erste Element ausgelesen und dessen ID gesetzt. Der Import wurde ebenfalls angepasst.

Eventuell kann hiermit auch issue #250 geschlossen werden.