### PR TITLE
Fix test using wrong file

### DIFF
--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -152,7 +152,7 @@ public class ZF2PushTest extends TestCase {
 		} catch (IOException e) {
 			fail("IOException should not be raised");
 		}
-		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_PDF);
+		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_ATTACHMENTSPDF);
 		Invoice i= null;
 		try {
 			i = zii.extractInvoice();


### PR DESCRIPTION
The test writes `TARGET_ATTACHMENTSPDF` but validates `TARGET_PDF`. This fails twice:

- on a clean build when reading the file because it does not (yet) exist
- on subsequent builds because the file content is not the expected content