### PR TITLE
Fix validator dependencies

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -40,6 +40,22 @@
             <artifactId>library</artifactId>
             <version>2.14.0-SNAPSHOT</version>
         </dependency>
+		<dependency>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
+			<version>2.1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.16.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.pdfbox</groupId>
+			<artifactId>pdfbox</artifactId>
+			<version>3.0.2</version>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>


### PR DESCRIPTION
Without these dependencies the `validator` project cannot be build. The build still fails due to a validation error in a test, though.

```
[INFO] --- compiler:2.3.2:compile (default-compile) @ validator ---
[INFO] Compiling 10 source files to /Users/jan/git/mustangproject/validator/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[23,28] error: package org.apache.commons.io does not exist
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[24,16] error: package org.dom4j does not exist
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[25,16] error: package org.dom4j does not exist
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[26,19] error: package org.dom4j.io does not exist
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[27,19] error: package org.dom4j.io does not exist
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[112,14] error: cannot find symbol
[ERROR]  class ZUGFeRDValidator
/Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[285,2] error: cannot find symbol
[ERROR]  class ZUGFeRDValidator
/Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[285,24] error: cannot find symbol
[ERROR]  class ZUGFeRDValidator
/Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[287,11] error: package org.dom4j does not exist
[ERROR] /Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[289,14] error: cannot find symbol
[ERROR]  class ZUGFeRDValidator
/Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[290,11] error: cannot find symbol
[ERROR]  class ZUGFeRDValidator
/Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[293,2] error: cannot find symbol
[ERROR]  class ZUGFeRDValidator
/Users/jan/git/mustangproject/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java:[293,25] error: cannot find symbol
[INFO] 13 errors 
```