### PR TITLE
Fix logging implementation missing in CLI

### DIFF
--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -35,6 +35,12 @@
             <version>1.8.0</version>
         </dependency>
 
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.12</version>
+		</dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>


### PR DESCRIPTION
Fixes #434 

No logging implementation was included in the shaded jar resulting in the mentioned error message and missing log outputs.