### PR TITLE
Fix UnsupportedOperationException in buildNotes

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -864,8 +864,9 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 	}
 
 	protected String buildNotes(IExportableTransaction exportableTransaction) {
-		final List<IncludedNote> includedNotes = Optional.ofNullable(exportableTransaction.getNotesWithSubjectCode())
-			.orElse(new ArrayList<>());
+		final List<IncludedNote> includedNotes = new ArrayList<>();
+		Optional.ofNullable(exportableTransaction.getNotesWithSubjectCode()).ifPresent(includedNotes::addAll);
+
 		if (exportableTransaction.getNotes() != null) {
 			for (final String currentNote : exportableTransaction.getNotes()) {
 				includedNotes.add(IncludedNote.unspecifiedNote(currentNote));


### PR DESCRIPTION
Fixes #412 

The default implementation of `IExportableTransaction`(which is `Invoice`) always returns an `ArrayList` when calling `getNotesWithSubjectCode()`, however the interface only requires a `List` which could also be unmodifiable or immutable. If such a collection is returned the `buildNotes` method on the `ZUGFeRD2PullProvider` throws an UOE when trying to add more notes to the collection.