### PR TITLE
Fix current validation errors.

### DIFF
--- a/library/src/main/java/org/mustangproject/Product.java
+++ b/library/src/main/java/org/mustangproject/Product.java
@@ -93,6 +93,9 @@ public class Product implements IZUGFeRDExportableProduct {
 	 */
 	@Override
 	public String getTaxCategoryCode() {
+		if (taxCategoryCode == null) {
+			return IZUGFeRDExportableProduct.super.getTaxCategoryCode();
+		}
 		return taxCategoryCode;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -144,7 +144,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		if (party.getLegalOrganisation() != null) {
 			xml += "<ram:SpecifiedLegalOrganization> ";
 			if (party.getLegalOrganisation().getSchemedID() != null) {
-				xml += "<ram:ID schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getScheme()) + "\">" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getID()) + "</ram:ID>";
+				if (profile == Profiles.getByName("Minimum")) {
+					xml += "<ram:ID>" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getID()) + "</ram:ID>";
+				} else {
+					xml += "<ram:ID schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getScheme()) + "\">" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getID()) + "</ram:ID>";
+				}
 			}
 			if (party.getLegalOrganisation().getTradingBusinessName() != null) {
 				xml += "<ram:TradingBusinessName>" + XMLTools.encodeXML(party.getLegalOrganisation().getTradingBusinessName()) + "</ram:TradingBusinessName>";


### PR DESCRIPTION
TaxCategory ws null now at a couple of tests.
Fall back to the default implementation in the interface to fill the gap.

Open failures then:
```
[ERROR]   LibraryTest.testMinimumProfileValidityCreditNote:280 [XPath "count(//error)" evaluated to value] expected:<[0]> but was:<[1]>
[ERROR]   LibraryTest.testMinimumProfileValidityInvoice:256 [XPath "count(//error)" evaluated to value] expected:<[0]> but was:<[1]>
```

```
    <messages>
      <error type="4" location="/*[local-name()='CrossIndustryInvoice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='ApplicableHeaderTradeAgreement']/*[local-name()='BuyerTradeParty']/*[local-name()='SpecifiedLegalOrganization']/*[local-name()='ID']" criterion="document('FACTUR-X_MINIMUM_codedb.xml')//cl[@id=5]/enumeration[@value=$codeValue5]">Value of '@schemeID' is not allowed. from /xslt/ZF_221/FACTUR-X_MINIMUM.xslt)</error>
    </messages>
```
Set attribute schemeID for a LegalOrganisation only, if not minimum profile. Otherwise only the id value.