### PR TITLE
Update xr-content.xsl - fix #499

### DIFF
--- a/library/src/main/resources/stylesheets/xr-content.xsl
+++ b/library/src/main/resources/stylesheets/xr-content.xsl
@@ -807,10 +807,11 @@
   </xsl:template>
 
   <xsl:template name="zusaetzeVertrag">
-    <xsl:call-template name="box">
+    <xsl:call-template name="spanned-box">
       <xsl:with-param name="identifier" select="'zusaetzeVertrag'"/>
       <xsl:with-param name="content">
         <xsl:call-template name="list">
+          <xsl:with-param name="layout" select="'einspaltig'"/>
           <xsl:with-param name="content">            
             <xsl:apply-templates mode="list-entry" select="xr:Tender_or_lot_reference"/>
             <xsl:apply-templates mode="list-entry" select="xr:Receiving_advice_reference"/>


### PR DESCRIPTION
Change layout for Informationen zum Vertrag layout to display information on single column to prevent long text overlay.
Closes #499 