### PR TITLE
Fix POM missing dependencies

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -64,7 +64,8 @@
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
             <version>12.4</version>
-        </dependency><!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        </dependency>
+		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -82,18 +83,24 @@
               </exclusion>
             </exclusions>
         </dependency>
-
+        <!-- JAXB -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>4.0.2</version>
         </dependency>
-        <dependency>
+		<!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>4.0.5</version>
+		</dependency>
+		<dependency>
             <groupId>org.eclipse.angus</groupId>
             <artifactId>angus-activation</artifactId>
             <version>2.0.2</version>
         </dependency>
-
+        <!-- Apache PDFBox -->
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>preflight</artifactId>
@@ -104,11 +111,20 @@
             <artifactId>pdfbox</artifactId>
             <version>3.0.2</version>
         </dependency>
+		<!-- DOM4j -->
         <dependency>
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
             <version>2.1.4</version>
         </dependency>
+		<!-- CII to UBL conversion -->
+		<dependency>
+			<groupId>com.helger</groupId>
+			<artifactId>en16931-cii2ubl</artifactId>
+			<version>2.2.4</version>
+		</dependency>
+
+		<!-- test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -121,27 +137,12 @@
             <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- CII to UBL conversion -->
-        <dependency>
-            <groupId>com.helger</groupId>
-            <artifactId>en16931-cii2ubl</artifactId>
-            <version>2.2.4</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.5</version>
-        </dependency>
-
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj</artifactId>
@@ -232,11 +233,9 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.3</version>
                 <configuration>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <minimizeJar>false
-                    </minimizeJar><!-- no longer java 11 compatible if set to true because it removes e.g. javax/xml/bind/annotation/XmlSchema-->
+					<shadedArtifactAttached>true</shadedArtifactAttached>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
                     <filters>
-
                         <filter>
                             <artifact>*:*</artifact>
                             <excludes>
@@ -244,18 +243,6 @@
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>
                             </excludes>
-                        </filter>
-                        <filter>
-                            <artifact>log4j:log4j</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
-                        <filter>
-                            <artifact>commons-logging:commons-logging</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
                         </filter>
                     </filters>
                 </configuration>
@@ -265,15 +252,6 @@
                         <goals>
                             <goal>shade</goal>
                         </goals>
-                        <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <!--exclude>classworlds:classworlds</exclude> <exclude>junit:junit</exclude>
-                                        <exclude>jmock:*</exclude> <exclude>*:xml-apis</exclude> <exclude>org.apache.maven:lib:tests</exclude>
-                                        <exclude>log4j:log4j:jar:</exclude -->
-                                </excludes>
-                            </artifactSet>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Fixes #422 
Fixes #505 

This is the result of the reduced POM generation by the maven-shade-plugin. Some unnecessary configuration was clean up, too.

This also re-orders the dependencies so that the `test` dependencies are grouped at the end and all others before.