### PR TITLE
Add CIB pdf brewer signature

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
@@ -264,6 +264,7 @@ public class PDFValidator extends Validator {
 		final byte[] konikSignature = "Konik".getBytes(StandardCharsets.UTF_8);
 		final byte[] pdfMachineSignature = "pdfMachine from Broadgun Software".getBytes(StandardCharsets.UTF_8);
 		final byte[] ghostscriptSignature = "%%Invocation:".getBytes(StandardCharsets.UTF_8);
+		final byte[] cibpdfbrewerSignature = "CIB pdf brewer".getBytes(StandardCharsets.UTF_8);
 
 		if (ByteArraySearcher.contains(fileContents, symtraxSignature)) {
 			Signature = "Symtrax";
@@ -279,6 +280,8 @@ public class PDFValidator extends Validator {
 			Signature = "pdfMachine";
 		} else if (ByteArraySearcher.contains(fileContents, ghostscriptSignature)) {
 			Signature = "Ghostscript";
+		} else if (ByteArraySearcher.contains(fileContents, cibpdfbrewerSignature)) {
+			Signature = "CIB pdf brewer";
 		}
 
 		context.setSignature(Signature);


### PR DESCRIPTION
Note: Searching on the whole file contents for a specific siganture string can be unsuccessful. E.g. info dictionary can be missing and XMP data can be compressed. Beginning with PDF 2.0 info dictionaries became also deprecated. 