### PR TITLE
dom4j: exclude all (optional) dependencies to avoid potential conflicts.

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -116,6 +116,12 @@
             <groupId>org.dom4j</groupId>
             <artifactId>dom4j</artifactId>
             <version>2.1.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 		<!-- CII to UBL conversion -->
 		<dependency>

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -44,6 +44,12 @@
 			<groupId>org.dom4j</groupId>
 			<artifactId>dom4j</artifactId>
 			<version>2.1.4</version>
+			<exclusions>
+				<exclusion>
+					<groupId>*</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
Refers to https://github.com/ZUGFeRD/mustangproject/issues/574.

For more see
https://stackoverflow.com/questions/57286825/the-package-org-w3c-dom-is-accessible-from-more-than-one-module-unnamed-java
also.
