### PR TITLE
Treat all fatal XR schematron rules as errors, not as warnings.

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
@@ -424,11 +424,6 @@ public class XMLValidator extends Validator {
 	 */
 	public void validateSchematron(String xml, String xsltFilename, int section, ESeverity defaultSeverity) throws IrrecoverableValidationError {
 		ISchematronResource aResSCH = null;
-		ESeverity severity=defaultSeverity;
-		if (defaultSeverity!=ESeverity.notice) {
-			severity=ESeverity.error;
-		}
-
 		aResSCH = SchematronResourceXSLT.fromClassPath(xsltFilename);
 
 		if (aResSCH != null) {
@@ -470,14 +465,15 @@ public class XMLValidator extends Validator {
 							thisFailLocation = currentFailNode.getAttributes().getNamedItem("location").getNodeValue();
 						}
 
-						if (currentFailNode.getAttributes().getNamedItem("flag") != null) {
+						ESeverity severity;
+						if (defaultSeverity == ESeverity.notice) {
+							severity = defaultSeverity;
+						} else if (currentFailNode.getAttributes().getNamedItem("flag") != null
+							    && currentFailNode.getAttributes().getNamedItem("flag").getNodeValue().equals("warning")) {
 							// the XR issues warnings with flag=warning
-							if  (currentFailNode.getAttributes().getNamedItem("flag").getNodeValue().equals("warning")) {
-								if (defaultSeverity!=ESeverity.notice) {
-									severity=ESeverity.warning;
-								}
-							}
-
+							severity = ESeverity.warning;
+						} else {
+							severity = ESeverity.error;
 						}
 
 						NodeList failChilds = currentFailNode.getChildNodes();

--- a/validator/src/test/java/org/mustangproject/validator/ZUGFeRDValidatorTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/ZUGFeRDValidatorTest.java
@@ -216,10 +216,10 @@ public class ZUGFeRDValidatorTest extends ResourceCase {
 
 		assertThat(res).valueByXPath("count(//error)")
 			.asInt()
-			.isEqualTo(1);
+			.isEqualTo(2);
 		assertThat(res).valueByXPath("count(//warning)")
 			.asInt()
-			.isEqualTo(3);
+			.isEqualTo(2);
 
 		assertThat(res).valueByXPath("count(//notice)")
 			.asInt()


### PR DESCRIPTION
In org.mustangproject.validator.XMLValidator.validateSchematron(), the severity has to be determined for every node of the validation result.  Otherwise, all schematron assertions tagged as "fatal" will be treated as warnings after the first warning.