### PR TITLE
add tax category code for free export ("G") and add it to "with exemp…

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/model/TaxCategoryCodeTypeConstants.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/model/TaxCategoryCodeTypeConstants.java
@@ -29,6 +29,7 @@ public class TaxCategoryCodeTypeConstants {
 	public static final String ZEROTAXPRODUCTS = "Z";
 	public static final String UNTAXEDSERVICE = "O";
 	public static final String INTRACOMMUNITY = "K";
-	
-	public static Set<String> CATEGORY_CODES_WITH_EXEMPTION_REASON = Stream.of(INTRACOMMUNITY, REVERSECHARGE, TAXEXEMPT).collect(Collectors.toSet());
+	public static final String FREEEXPORT = "G";
+
+	public static Set<String> CATEGORY_CODES_WITH_EXEMPTION_REASON = Stream.of(INTRACOMMUNITY, REVERSECHARGE, TAXEXEMPT, FREEEXPORT).collect(Collectors.toSet());
 }


### PR DESCRIPTION
When a Product is used with `setTaxCategoryCode('G')` ("Free export item, tax not charged") `setTaxExemptionReason("Steuer nicht erhoben aufgrund von Export außerhalb der EU")` i still get the following validation error:

```
[BR-G-10]-A VAT Breakdown (BG-23) with the VAT Category code (BT-118) "Export outside the EU" shall have a VAT exemption reason code (BT-121), meaning "Export outside the EU" or the VAT exemption reason text (BT-120) "Export outside the EU" (or the equivalent standard text in another language).
```

This happens because `ZUGFeRD2PullProvider` sets `<ram:ExemptionReason>` only if the `categoryCode` is set inside `CATEGORY_CODES_WITH_EXEMPTION_REASON`. So i added "G" there.

<img width="766" alt="image" src="https://github.com/user-attachments/assets/3d0ac525-9c38-4376-b38f-6dcd5d55e53d">

_Source of the screenshot: `Factur-X 1.0.07_Technical_Appendix_Profile_EN16931.pdf` downloaded from  [https://www.ferd-net.de/standards/zugferd-version-archive/zugferd-2.3.2.html](https://www.ferd-net.de/standards/zugferd-version-archive/zugferd-2.3.2.html)_