### PR TITLE
Fixes a problem where a stream was not safely closed

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
@@ -83,8 +83,9 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 	}
 
 	protected byte[] filenameToByteArray(String pdfFilename) throws IOException {
-		FileInputStream fileInputStream = new FileInputStream(pdfFilename);
-		return inputstreamToByteArray(fileInputStream);
+		try (FileInputStream fileInputStream = new FileInputStream(pdfFilename)) {
+			return inputstreamToByteArray(fileInputStream);
+		}
 	}
 
 	protected byte[] inputstreamToByteArray(InputStream fileInputStream) throws IOException  {


### PR DESCRIPTION
In ZUGFeRDExporterFromPDFA, the open filestream was not safely closed when the load(String) function was called.