### PR TITLE
Enable flexible PaymentReference and a DocumentName.

### DIFF
--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -67,6 +67,7 @@ public class Invoice implements IExportableTransaction {
 	protected String vatDueDateTypeCode = null;
 	protected String creditorReferenceID; // required when direct debit is used.
 	private BigDecimal roundingAmount=null;
+	private String paymentReference; // Remittance information / Verwendungszweck, BT-83
 
 	public Invoice() {
 		ZFItems = new ArrayList<>();
@@ -614,6 +615,16 @@ public class Invoice implements IExportableTransaction {
 
 	public Invoice setPaymentTerms(IZUGFeRDPaymentTerms paymentTerms) {
 		this.paymentTerms = paymentTerms;
+		return this;
+	}
+
+	@Override
+	public String getPaymentReference() {
+		return paymentReference;
+	}
+
+	public Invoice setPaymentReference(String paymentReference) {
+		this.paymentReference = paymentReference;
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -312,6 +312,10 @@ public interface IExportableTransaction {
 		return null;
 	}
 
+	default String getPaymentReference() {
+		return null;
+	}
+
 	/**
 	 * returns if a rebate agreements exists
 	 *

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -388,14 +388,13 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				+ "</ram:GuidelineSpecifiedDocumentContextParameter>"
 				+ "</rsm:ExchangedDocumentContext>"
 				+ "<rsm:ExchangedDocument>"
-				+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>"
-				// + "<ram:Name>RECHNUNG</ram:Name>"
-				// + "<ram:TypeCode>380</ram:TypeCode>"
-				+ "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
-				+ "<ram:IssueDateTime>"
-				+ DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
+				+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>";
+				if (profile == Profiles.getByName("Extended") && trans.getDocumentName() != null) {
+					xml += "<ram:Name>" + XMLTools.encodeXML(trans.getDocumentName()) + "</ram:Name>";
+				}
+			xml += "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
+				+ "<ram:IssueDateTime>" + DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
 				+ buildNotes(trans)
-
 				+ "</rsm:ExchangedDocument>"
 				+ "<rsm:SupplyChainTradeTransaction>";
 		int lineID = 0;
@@ -662,8 +661,8 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		if ((trans.getCreditorReferenceID() != null) && (getProfile() != Profiles.getByName("Minimum"))) {
 			xml += "<ram:CreditorReferenceID>" + XMLTools.encodeXML(trans.getCreditorReferenceID()) + "</ram:CreditorReferenceID>";
 		}
-		if ((trans.getNumber() != null) && (getProfile() != Profiles.getByName("Minimum"))) {
-			xml += "<ram:PaymentReference>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:PaymentReference>";
+		if ((trans.getPaymentReference() != null) && (getProfile() != Profiles.getByName("Minimum"))) {
+			xml += "<ram:PaymentReference>" + XMLTools.encodeXML(trans.getPaymentReference()) + "</ram:PaymentReference>";
 		}
 		xml += "<ram:InvoiceCurrencyCode>" + trans.getCurrency() + "</ram:InvoiceCurrencyCode>";
 		if (this.trans.getPayee() != null) {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -288,6 +288,7 @@ public class ZUGFeRDInvoiceImporter {
 	public Invoice extractInto(Invoice zpp) throws XPathExpressionException, ParseException {
 
 		String number = "";
+		String documentName = null;
 		String typeCode = null;
 		String deliveryPeriodStart = null;
 		String deliveryPeriodEnd = null;
@@ -494,6 +495,9 @@ public class ZUGFeRDInvoiceImporter {
 				if ((item.getLocalName() != null) && (item.getLocalName().equals("ID"))) {
 					number = XMLTools.trimOrNull(item);
 				}
+				if ((item.getLocalName() != null) && (item.getLocalName().equals("Name"))) {
+					documentName = XMLTools.trimOrNull(item);
+				}
 				if ((item.getLocalName() != null) && (item.getLocalName().equals("TypeCode"))) {
 					typeCode = XMLTools.trimOrNull(item);
 				}
@@ -660,6 +664,12 @@ public class ZUGFeRDInvoiceImporter {
 			NodeList headerTradeSettlementChilds = headerTradeSettlementNode.getChildNodes();
 			for (int settlementChildIndex = 0; settlementChildIndex < headerTradeSettlementChilds.getLength(); settlementChildIndex++) {
 				if ((headerTradeSettlementChilds.item(settlementChildIndex).getLocalName() != null)
+					&& (headerTradeSettlementChilds.item(settlementChildIndex).getLocalName().equals("PaymentReference"))) {
+					String paymentReference = headerTradeSettlementChilds.item(settlementChildIndex).getTextContent();
+					zpp.setPaymentReference(paymentReference);
+				}
+
+				if ((headerTradeSettlementChilds.item(settlementChildIndex).getLocalName() != null)
 					&& (headerTradeSettlementChilds.item(settlementChildIndex).getLocalName().equals("SpecifiedTradePaymentTerms"))) {
 					NodeList paymentTermChilds = headerTradeSettlementChilds.item(settlementChildIndex).getChildNodes();
 					for (int paymentTermChildIndex = 0; paymentTermChildIndex < paymentTermChilds.getLength(); paymentTermChildIndex++) {
@@ -780,7 +790,7 @@ public class ZUGFeRDInvoiceImporter {
 
 		}
 
-		zpp.setIssueDate(issueDate).setDueDate(dueDate).setDeliveryDate(deliveryDate).setSender(new TradeParty(SellerNodes)).setRecipient(new TradeParty(BuyerNodes)).setNumber(number).setDocumentCode(typeCode);
+		zpp.setIssueDate(issueDate).setDueDate(dueDate).setDeliveryDate(deliveryDate).setSender(new TradeParty(SellerNodes)).setRecipient(new TradeParty(BuyerNodes)).setNumber(number).setDocumentName(documentName).setDocumentCode(typeCode);
 
 		if ((directDebitMandateID != null) && (IBAN != null)) {
 			DirectDebit d = new DirectDebit(IBAN, directDebitMandateID);

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -526,7 +526,7 @@ public class ZF2PushTest extends TestCase {
 			try {
 				SchemedID gtin = new SchemedID("0160", "2001015001325");
 				SchemedID gln = new SchemedID("0088", "4304171000002");
-				ze.setTransaction(new Invoice().setCurrency("CHF").addNote("document level 1/2").addNote("document level 2/2").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				ze.setTransaction(new Invoice().setCurrency("CHF").addNote("document level 1/2").addNote("document level 2/2").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setPaymentReference("Verwendungszweck").setDocumentName("Rechnung")
 					.setSellerOrderReferencedDocumentID("9384").setBuyerOrderReferencedDocumentID("28934")
 					.setDetailedDeliveryPeriod(new SimpleDateFormat("yyyyMMdd").parse(occurrenceFrom), new SimpleDateFormat("yyyyMMdd").parse(occurrenceTo))
 					.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).setEmail("sender@test.org").setID(orgID).addVATID("DE0815"))
@@ -578,6 +578,7 @@ public class ZF2PushTest extends TestCase {
 		assertTrue(zi.getUTF8().contains("++49555123456"));
 		assertTrue(zi.getUTF8().contains("Cash Discount")); // default description for cash discounts
 		assertThat(zi.getUTF8()).valueByXPath("//*[local-name()='ApplicableTradeTax']/*[local-name()='DueDateTypeCode']").asString().isEqualTo(EventTimeCodeTypeConstants.PAYMENT_DATE);
+		assertTrue(zi.getUTF8().contains("<ram:Name>Rechnung</ram:Name>"));
 
 		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_PUSHEDGE);
 		try {
@@ -587,6 +588,8 @@ public class ZF2PushTest extends TestCase {
 			assertEquals("4304171000002", i.getRecipient().getGlobalID());
 			assertEquals("2001015001325", i.getZFItems()[0].getProduct().getGlobalID());
 			assertEquals(orgID, i.getSender().getID());
+			assertEquals("Verwendungszweck", i.getPaymentReference());
+			assertEquals("Rechnung", i.getDocumentName());
 
 		} catch (XPathExpressionException e) {
 			fail("XPathExpressionException should not be raised");


### PR DESCRIPTION
The value for the PaymentRefrence was always the Invoice number. Make it settable by the user.
Business case: Payment reference should also contain the invoice date and the customer id, not only the number.

Add DocumentName for the Extended-Profile only. See #605.

Enhance a test to check the values.