### PR TITLE
Fix transformation scripts

### DIFF
--- a/library/src/main/resources/stylesheets/ZUGFeRD_1p0_c1p0_s1p0.xslt
+++ b/library/src/main/resources/stylesheets/ZUGFeRD_1p0_c1p0_s1p0.xslt
@@ -1007,7 +1007,7 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 																											<xsl:for-each select="ram:ChargeIndicator">
 																												<xsl:for-each select="udt:Indicator">
 																													<span>
-																														<xsl:value-of select="if (. eq fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
+																														<xsl:value-of select="if (xs:boolean(.) eq fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
 																													</span>
 																												</xsl:for-each>
 																											</xsl:for-each>
@@ -1924,7 +1924,7 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 																				<xsl:for-each select="ram:ChargeIndicator">
 																					<xsl:for-each select="udt:Indicator">
 																						<span>
-																							<xsl:value-of select="if (. eq fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
+																							<xsl:value-of select="if (xs:boolean(.) eq fn:true())then &apos;Zuschlag&apos; else &apos;Abschlag&apos;"/>
 																						</span>
 																					</xsl:for-each>
 																				</xsl:for-each>
@@ -1982,7 +1982,7 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 																				<xsl:for-each select="ram:ActualAmount">
 																					<span>
 																						<xsl:variable name="altova:seqContentStrings_37">
-																							<xsl:value-of select="format-number(number(if (../ram:ChargeIndicator/udt:Indicator eq fn:true()) then . else -1 * .), '##0,00', 'format1')"/>
+																							<xsl:value-of select="format-number(number(if (xs:boolean(../ram:ChargeIndicator/udt:Indicator) eq fn:true()) then . else -1 * .), '##0,00', 'format1')"/>
 																						</xsl:variable>
 																						<xsl:variable name="altova:sContent_37" select="string($altova:seqContentStrings_37)"/>
 																						<xsl:value-of select="$altova:sContent_37"/>
@@ -2079,9 +2079,11 @@ Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können
 													<br/>
 												</xsl:for-each>
 											</xsl:for-each>
+											<!--
 											<xsl:for-each select="rsm:SpecifiedSupplyChainTradeTransaction">
 												<xsl:for-each select="ram:ApplicableSupplyChainTradeSettlement"/>
 											</xsl:for-each>
+											-->
 										</td>
 									</tr>
 									<tr>
@@ -2949,7 +2951,7 @@ if (. eq &apos;SH&apos;) then &apos;Spezielle Handhabungsdienstleistungen&apos; 
 	</xsl:function>
 	<xsl:function name="altova:GetChartLabelForPos" as="xs:string">
 		<xsl:param name="nodeParam" as="node()"/>
-		<xsl:value-of select="string-join($nodeParam/ancestor-or-self::altova:Pos/@altova:sLabel, ' ')"/>
+		<xsl:sequence select="string-join($nodeParam/ancestor-or-self::altova:Pos/@altova:sLabel, ' ')"/>
 	</xsl:function>
 	<xsl:function name="altova:convert-length-to-pixel" as="xs:decimal">
 		<xsl:param name="altova:length"/>

--- a/validator/src/main/resources/xslt/XR_30/XRechnung-CII-validation.xslt
+++ b/validator/src/main/resources/xslt/XR_30/XRechnung-CII-validation.xslt
@@ -39,7 +39,7 @@
                 select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)"/>
       <variable name="weightedSum"
                 select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (1 + ((($i + 1) mod 2) * 2)))"/>
-      <value-of select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
+      <sequence select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:slack"
@@ -47,7 +47,7 @@
       <param name="exp" as="xs:decimal"/>
       <param name="val" as="xs:decimal"/>
       <param name="slack" as="xs:decimal"/>
-      <value-of select="xs:decimal($exp + $slack) &gt;= $val and xs:decimal($exp - $slack) &lt;= $val"/>
+      <sequence select="xs:decimal($exp + $slack) &gt;= $val and xs:decimal($exp - $slack) &lt;= $val"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:mod11"
@@ -58,7 +58,7 @@
                 select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)"/>
       <variable name="weightedSum"
                 select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (($i mod 6) + 2))"/>
-      <value-of select="number($val) &gt; 0 and (11 - ($weightedSum mod 11)) mod 11 = number(substring($val, $length + 1, 1))"/>
+      <sequence select="number($val) &gt; 0 and (11 - ($weightedSum mod 11)) mod 11 = number(substring($val, $length + 1, 1))"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:mod97-0208"
@@ -67,7 +67,7 @@
       <variable name="checkdigits" select="substring($val,9,2)"/>
       <variable name="calculated_digits"
                 select="xs:string(97 - (xs:integer(substring($val,1,8)) mod 97))"/>
-      <value-of select="number($checkdigits) = number($calculated_digits)"/>
+      <sequence select="number($checkdigits) = number($calculated_digits)"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:checkCodiceIPA"
@@ -118,7 +118,7 @@
              name="u:abn"
              as="xs:boolean">
       <param name="val"/>
-      <value-of select="( ((string-to-codepoints(substring($val,1,1)) - 49) * 10) + ((string-to-codepoints(substring($val,2,1)) - 48) * 1) + ((string-to-codepoints(substring($val,3,1)) - 48) * 3) + ((string-to-codepoints(substring($val,4,1)) - 48) * 5) + ((string-to-codepoints(substring($val,5,1)) - 48) * 7) + ((string-to-codepoints(substring($val,6,1)) - 48) * 9) + ((string-to-codepoints(substring($val,7,1)) - 48) * 11) + ((string-to-codepoints(substring($val,8,1)) - 48) * 13) + ((string-to-codepoints(substring($val,9,1)) - 48) * 15) + ((string-to-codepoints(substring($val,10,1)) - 48) * 17) + ((string-to-codepoints(substring($val,11,1)) - 48) * 19)) mod 89 = 0 "/>
+      <sequence select="( ((string-to-codepoints(substring($val,1,1)) - 49) * 10) + ((string-to-codepoints(substring($val,2,1)) - 48) * 1) + ((string-to-codepoints(substring($val,3,1)) - 48) * 3) + ((string-to-codepoints(substring($val,4,1)) - 48) * 5) + ((string-to-codepoints(substring($val,5,1)) - 48) * 7) + ((string-to-codepoints(substring($val,6,1)) - 48) * 9) + ((string-to-codepoints(substring($val,7,1)) - 48) * 11) + ((string-to-codepoints(substring($val,8,1)) - 48) * 13) + ((string-to-codepoints(substring($val,9,1)) - 48) * 15) + ((string-to-codepoints(substring($val,10,1)) - 48) * 17) + ((string-to-codepoints(substring($val,11,1)) - 48) * 19)) mod 89 = 0 "/>
    </function>
    <!--DEFAULT RULES-->
    <!--MODE: SCHEMATRON-SELECT-FULL-PATH-->

--- a/validator/src/main/resources/xslt/XR_30/XRechnung-UBL-validation.xslt
+++ b/validator/src/main/resources/xslt/XR_30/XRechnung-UBL-validation.xslt
@@ -41,7 +41,7 @@
                 select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)"/>
       <variable name="weightedSum"
                 select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (1 + ((($i + 1) mod 2) * 2)))"/>
-      <value-of select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
+      <sequence select="(10 - ($weightedSum mod 10)) mod 10 = number(substring($val, $length + 1, 1))"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:slack"
@@ -49,7 +49,7 @@
       <param name="exp" as="xs:decimal"/>
       <param name="val" as="xs:decimal"/>
       <param name="slack" as="xs:decimal"/>
-      <value-of select="xs:decimal($exp + $slack) &gt;= $val and xs:decimal($exp - $slack) &lt;= $val"/>
+      <sequence select="xs:decimal($exp + $slack) &gt;= $val and xs:decimal($exp - $slack) &lt;= $val"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:mod11"
@@ -60,7 +60,7 @@
                 select="reverse(for $i in string-to-codepoints(substring($val, 0, $length + 1)) return $i - 48)"/>
       <variable name="weightedSum"
                 select="sum(for $i in (0 to $length - 1) return $digits[$i + 1] * (($i mod 6) + 2))"/>
-      <value-of select="number($val) &gt; 0 and (11 - ($weightedSum mod 11)) mod 11 = number(substring($val, $length + 1, 1))"/>
+      <sequence select="number($val) &gt; 0 and (11 - ($weightedSum mod 11)) mod 11 = number(substring($val, $length + 1, 1))"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:mod97-0208"
@@ -69,7 +69,7 @@
       <variable name="checkdigits" select="substring($val,9,2)"/>
       <variable name="calculated_digits"
                 select="xs:string(97 - (xs:integer(substring($val,1,8)) mod 97))"/>
-      <value-of select="number($checkdigits) = number($calculated_digits)"/>
+      <sequence select="number($checkdigits) = number($calculated_digits)"/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:checkCodiceIPA"
@@ -120,7 +120,7 @@
              name="u:abn"
              as="xs:boolean">
       <param name="val"/>
-      <value-of select="( ((string-to-codepoints(substring($val,1,1)) - 49) * 10) + ((string-to-codepoints(substring($val,2,1)) - 48) * 1) + ((string-to-codepoints(substring($val,3,1)) - 48) * 3) + ((string-to-codepoints(substring($val,4,1)) - 48) * 5) + ((string-to-codepoints(substring($val,5,1)) - 48) * 7) + ((string-to-codepoints(substring($val,6,1)) - 48) * 9) + ((string-to-codepoints(substring($val,7,1)) - 48) * 11) + ((string-to-codepoints(substring($val,8,1)) - 48) * 13) + ((string-to-codepoints(substring($val,9,1)) - 48) * 15) + ((string-to-codepoints(substring($val,10,1)) - 48) * 17) + ((string-to-codepoints(substring($val,11,1)) - 48) * 19)) mod 89 = 0 "/>
+      <sequence select="( ((string-to-codepoints(substring($val,1,1)) - 49) * 10) + ((string-to-codepoints(substring($val,2,1)) - 48) * 1) + ((string-to-codepoints(substring($val,3,1)) - 48) * 3) + ((string-to-codepoints(substring($val,4,1)) - 48) * 5) + ((string-to-codepoints(substring($val,5,1)) - 48) * 7) + ((string-to-codepoints(substring($val,6,1)) - 48) * 9) + ((string-to-codepoints(substring($val,7,1)) - 48) * 11) + ((string-to-codepoints(substring($val,8,1)) - 48) * 13) + ((string-to-codepoints(substring($val,9,1)) - 48) * 15) + ((string-to-codepoints(substring($val,10,1)) - 48) * 17) + ((string-to-codepoints(substring($val,11,1)) - 48) * 19)) mod 89 = 0 "/>
    </function>
    <function xmlns="http://www.w3.org/1999/XSL/Transform"
              name="u:TinVerification"
@@ -130,7 +130,7 @@
                 select="    for $ch in string-to-codepoints($val)    return codepoints-to-string($ch)"/>
       <variable name="checksum"
                 select="    (number($digits[8])*2) +    (number($digits[7])*4) +    (number($digits[6])*8) +    (number($digits[5])*16) +    (number($digits[4])*32) +    (number($digits[3])*64) +    (number($digits[2])*128) +    (number($digits[1])*256) "/>
-      <value-of select="($checksum  mod 11) mod 10 = number($digits[9])"/>
+      <sequence select="($checksum  mod 11) mod 10 = number($digits[9])"/>
    </function>
    <!--DEFAULT RULES-->
    <!--MODE: SCHEMATRON-SELECT-FULL-PATH-->


### PR DESCRIPTION
Fix the following warnings:

[main] WARN  c.h.x.t.LoggingTransformErrorListener - [warn] Transformation warning (net.sf.saxon.trans.XPathException: A function that computes atomic values should use xsl:sequence rather than xsl:value-of)

Warning at char 27 in xsl:value-of/@select on line 1985 column 166 
  SXWN9026: Comparison of xs:untypedAtomic? to xs:boolean will fail unless the first operand is empty

Warning at xsl:for-each on line 2083 column 78 
  SXWN9009: An empty xsl:for-each instruction has no effect
