### PR TITLE
Change order of Reason/ReasonCode to the correct sequence.

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -276,20 +276,20 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			chargeIndicator = "true";
 		}
 
-		String reason = "";
-		if ((allowance.getReason() != null) && (profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung")) || profile == Profiles.getByName("EN16931")) {
-			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
-		}
 		String reasonCode = "";
 		if (allowance.getReasonCode() != null) {
 			// only in XRechnung profile
 			reasonCode = "<ram:ReasonCode>" + allowance.getReasonCode() + "</ram:ReasonCode>";
 		}
+		String reason = "";
+		if ((allowance.getReason() != null) && (profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung")) || profile == Profiles.getByName("EN16931")) {
+			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
+		}
 		final String allowanceChargeStr = "<ram:AppliedTradeAllowanceCharge><ram:ChargeIndicator><udt:Indicator>" +
 			chargeIndicator + "</udt:Indicator></ram:ChargeIndicator>" + percentage +
 			"<ram:ActualAmount>" + priceFormat(allowance.getTotalAmount(item)) + "</ram:ActualAmount>" +
-			reason +
 			reasonCode +
+			reason +
 			"</ram:AppliedTradeAllowanceCharge>";
 		return allowanceChargeStr;
 	}
@@ -311,20 +311,20 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			chargeIndicator = "true";
 		}
 
-		String reason = "";
-		if ((allowance.getReason() != null) && (profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung"))) {
-			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
-		}
 		String reasonCode = "";
 		if ((allowance.getReasonCode() != null) && (profile == Profiles.getByName("XRechnung"))) {
 			// only in XRechnung profile
 			reasonCode = "<ram:ReasonCode>" + allowance.getReasonCode() + "</ram:ReasonCode>";
 		}
+		String reason = "";
+		if ((allowance.getReason() != null) && (profile == Profiles.getByName("Extended") || profile == Profiles.getByName("XRechnung"))) {
+			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
+		}
 		final String itemTotalAllowanceChargeStr = "<ram:SpecifiedTradeAllowanceCharge><ram:ChargeIndicator><udt:Indicator>" +
 			chargeIndicator + "</udt:Indicator></ram:ChargeIndicator>" + percentage +
 			"<ram:ActualAmount>" + currencyFormat(allowance.getTotalAmount(item)) + "</ram:ActualAmount>" +
-			reason +
 			reasonCode +
+			reason +
 			"</ram:SpecifiedTradeAllowanceCharge>";
 		return itemTotalAllowanceChargeStr;
 	}
@@ -744,11 +744,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 						"<udt:Indicator>true</udt:Indicator>" +
 						"</ram:ChargeIndicator>" +
 						"<ram:ActualAmount>" + currencyFormat(charge.getTotalAmount(calc)) + "</ram:ActualAmount>";
-					if (charge.getReason() != null) {
-						xml += "<ram:Reason>" + XMLTools.encodeXML(charge.getReason()) + "</ram:Reason>";
-					}
 					if (charge.getReasonCode() != null) {
 						xml += "<ram:ReasonCode>" + charge.getReasonCode() + "</ram:ReasonCode>";
+					}
+					if (charge.getReason() != null) {
+						xml += "<ram:Reason>" + XMLTools.encodeXML(charge.getReason()) + "</ram:Reason>";
 					}
 					xml += "<ram:CategoryTradeTax>" +
 						"<ram:TypeCode>VAT</ram:TypeCode>" +
@@ -787,11 +787,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 						"<udt:Indicator>false</udt:Indicator>" +
 						"</ram:ChargeIndicator>" +
 						"<ram:ActualAmount>" + currencyFormat(allowance.getTotalAmount(calc)) + "</ram:ActualAmount>";
-					if (allowance.getReason() != null) {
-						xml += "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
-					}
 					if (allowance.getReasonCode() != null) {
 						xml += "<ram:ReasonCode>" + allowance.getReasonCode() + "</ram:ReasonCode>";
+					}
+					if (allowance.getReason() != null) {
+						xml += "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
 					}
 					xml += "<ram:CategoryTradeTax>" +
 						"<ram:TypeCode>VAT</ram:TypeCode>" +

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -22,7 +22,6 @@
 package org.mustangproject.ZUGFeRD;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -30,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 
 import org.mustangproject.*;
 import org.junit.FixMethodOrder;
@@ -478,8 +476,8 @@ public class ZF2PushTest extends TestCase {
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), amount, new BigDecimal(1.0)))
-				.addCharge(new Charge(new BigDecimal(0.5)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK"))
-				.addAllowance(new Allowance(new BigDecimal(0.2)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK"))
+				.addCharge(new Charge(new BigDecimal(0.5)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK").setReason("individual upcharge"))
+				.addAllowance(new Allowance(new BigDecimal(0.2)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK").setReason("individual discount"))
 			);
 			String theXML = new String(ze.getProvider().getXML());
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));


### PR DESCRIPTION
Setting a Reason and a ReasonCode for an allowance or upcharge leads to this validation error:
```
      <error type="18">schema validation fails:org.xml.sax.SAXParseException; lineNumber: 149; columnNumber: 25; cvc-complex-type.2.4.a: Ungültiger Content wurde beginnend mit Element '{"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100":ReasonCode}' gefunden. '{"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100":CategoryTradeTax}' wird erwartet.</error>
```

The entity is defined with a sequence of elements , so the elements have to given in the correct order.
```
  <xs:complexType name="TradeAllowanceChargeType">
    <xs:sequence>
      <xs:element name="ChargeIndicator" type="udt:IndicatorType"/>
      <xs:element name="CalculationPercent" type="udt:PercentType" minOccurs="0"/>
      <xs:element name="BasisAmount" type="udt:AmountType" minOccurs="0"/>
      <xs:element name="ActualAmount" type="udt:AmountType"/>
      <xs:element name="ReasonCode" type="qdt:AllowanceChargeReasonCodeType" minOccurs="0"/>
      <xs:element name="Reason" type="udt:TextType" minOccurs="0"/>
      <xs:element name="CategoryTradeTax" type="ram:TradeTaxType" minOccurs="0"/>
    </xs:sequence>
  </xs:complexType>
```

Related to #660.