### PR TITLE
Fix #632: Return ubl_creditnote as Standard for CreditNotes

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -1037,7 +1037,7 @@ public class ZUGFeRDInvoiceImporter {
 		} else if (rootNode.equals("Invoice")) {
 			return EStandard.ubl;
 		} else if (rootNode.equals("CreditNote")) {
-			return EStandard.ubl;
+			return EStandard.ubl_creditnote;
 		} else if (rootNode.equals("CrossIndustryInvoice")) {
 			return EStandard.facturx;
 		} else if (rootNode.equals("SCRDMCCBDACIDAMessageStructure")) {


### PR DESCRIPTION
This allows to distinguish between UBL's Invoice and UBL's CreditNote. I think this is usefule, since further processing with UBL libraries requires knowledge about the document type.