### PR TITLE
Upgrades VeraPDF dependency to version 1.26.2

### DIFF
--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.verapdf</groupId>
             <artifactId>validation-model-jakarta</artifactId>
-            <version>1.26.1</version>
+            <version>1.26.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.helger/ph-schematron -->
         <dependency>


### PR DESCRIPTION
Hello,

I noticed today that the validator includes VeraPDF in the version 1.26.1. However, there is a vulnerability tracked under [CVE-2024-52800](https://nvd.nist.gov/vuln/detail/CVE-2024-52800) for this version of VeraPDF. Luckily, this was addressed by the VeraPDF authors and fixed in version 1.26.2 (see https://github.com/veraPDF/veraPDF-library/releases/tag/v1.26.5 ). I think it would be a good thing, if we upgraded that dependency too.

I've upgraded the VeraPDF dependency to 1.26.2 and ran all tests locally, which passed.

Kind Regards,
Fatih