### PR TITLE
Fix current check failures.

### DIFF
--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
@@ -21,26 +21,35 @@
  */
 package org.mustangproject.ZUGFeRD;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import junit.framework.TestCase;
-import org.junit.Assert;
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
-import org.mustangproject.*;
-import org.mustangproject.ZUGFeRD.model.EventTimeCodeTypeConstants;
-
-import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
+
+import javax.xml.xpath.XPathExpressionException;
+
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import org.mustangproject.Allowance;
+import org.mustangproject.BankDetails;
+import org.mustangproject.CalculatedInvoice;
+import org.mustangproject.CashDiscount;
+import org.mustangproject.Charge;
+import org.mustangproject.Contact;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.SchemedID;
+import org.mustangproject.TradeParty;
+import org.mustangproject.ZUGFeRD.model.EventTimeCodeTypeConstants;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DeSerializationTest extends ResourceCase {
@@ -223,7 +232,7 @@ public class DeSerializationTest extends ResourceCase {
 			"\n" +
 			"  \"number\": \"471102\",\n" +
 			"  \"currency\": \"EUR\",\n" +
-			"  \"issueDate\": \"2018-03-04T00:00:00.000+01:00\",\n" +
+			"  \"issueDate\": \"2018-03-04T00:00:00.000\",\n" +
 			"  \"dueDate\": \"2018-03-04T00:00:00.000+01:00\",\n" +
 			"  \"deliveryDate\": \"2018-03-04T00:00:00.000+01:00\",\n" +
 			"  \"sender\": {\n" +

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
@@ -245,7 +245,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		}
 		assertFalse(hasExceptions);
 		TransactionCalculator tc = new TransactionCalculator(invoice);
-		assertEquals(new BigDecimal("18.33"), tc.getGrandTotal());
+		assertEquals(new BigDecimal("19.52"), tc.getGrandTotal());
 	}
 
 	public void testBasisQuantityImport() {
@@ -357,7 +357,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 			ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(new FileInputStream(CIIinputFile));
 			Invoice i = zii.extractInvoice();
 
-			assertEquals("DE21860000000086001055", i.getSender().getBankDetails().get(0).getIBAN());
+			assertEquals("DE21860000000086001055", i.getRecipient().getBankDetails().get(0).getIBAN());
 			ObjectMapper mapper = new ObjectMapper();
 
 			String jsonArray = mapper.writeValueAsString(i);


### PR DESCRIPTION
Fix current failures.
JSON-Datetime with timezone gets deserialized using the current timezone.
I have set TZ to Europe/Berlin , there the test worked.
Githup possiby is using American timezone, so the date only part gets shifted to the previous day.
Removing the timezone on ohne of the datetime values is sufficient, because contains("<udt:DateTimeString format=\"102\">20180304</udt:DateTimeString>") is used. One date with this value is sufficient.

testImportDebit uses cii/minimalDebit.xml containing TypeCode 59 / DirectDebit.
So the Recipient gets the BankDetails assigned (library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java#816).

Due to the additional charge in library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java, testItemChargesAllowancesExport the amount increased, has to be changed here also.