### PR TITLE
extend ValidationLogVisualizer to not use only file system

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
@@ -1,5 +1,13 @@
 package org.mustangproject.ZUGFeRD;
 
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
 import org.apache.fop.apps.*;
 import org.apache.fop.apps.io.ResourceResolverFactory;
 import org.apache.fop.configuration.Configuration;
@@ -14,7 +22,7 @@ import javax.xml.transform.*;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.*;
+
 import java.nio.charset.StandardCharsets;
 
 public class ValidationLogVisualizer {
@@ -70,7 +78,7 @@ public class ValidationLogVisualizer {
 		return baos.toString(StandardCharsets.UTF_8);
 	}
 
-	public void toPDF(String xmlLogfileContent, String pdfFilename) {
+	public byte[] createPDFBytes(String xmlLogfileContent) {
 
 		// the writing part
 
@@ -111,7 +119,8 @@ public class ValidationLogVisualizer {
 // Step 2: Set up output stream.
 // Note: Using BufferedOutputStream for performance reasons (helpful with FileOutputStreams).
 
-		try (OutputStream out = new BufferedOutputStream(new FileOutputStream(pdfFilename))) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (OutputStream out = new BufferedOutputStream(baos)) {
 
 			// Step 3: Construct fop with desired output format
 			Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
@@ -132,6 +141,20 @@ public class ValidationLogVisualizer {
 
 		} catch (FOPException | IOException | TransformerException e) {
 			LOGGER.error("Failed to create PDF", e);
+		}
+		return baos.toByteArray();
+	}
+
+	public byte[] toPDF(String xmlLogfileContent) {
+		return createPDFBytes(xmlLogfileContent);
+	}
+
+	public void toPDF(String xmlLogfileContent, String pdfFilename) {
+		byte[] pdfData = createPDFBytes(xmlLogfileContent);
+		try (FileOutputStream fos = new FileOutputStream(pdfFilename)) {
+			fos.write(pdfData);
+		} catch (IOException e) {
+			LOGGER.error("Failed to write PDF to file", e);
 		}
 	}
 


### PR DESCRIPTION
Reuse toPDF method to work without any dependencies to the file system for ValidationLogVisualizer as we also do at ZUGFeRDVisualizer #649 