### PR TITLE
Invoice setCorrection causes duplicate XML output

### DIFF
--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -154,7 +154,6 @@ public class Invoice implements IExportableTransaction {
 	 */
 	public Invoice setCorrection(String number) {
 		setInvoiceReferencedDocumentID(number);
-		addInvoiceReferencedDocument(new ReferencedDocument(number));
 		documentCode = DocumentCodeTypeConstants.CORRECTEDINVOICE;
 		return this;
 	}


### PR DESCRIPTION
The setCorrection function in the Invoice class uses the old setInvoiceReferencedDocumentID function and the new addInvoiceReferencedDocument function. This results in a duplicate output of InvoiceReferencedDocument in the XML. As the name setCorrection does not indicate that the function works additively, the call to addInvoiceReferencedDocument has been removed.