### PR TITLE
Updates about SpecifiedTradeSettlementHeaderMonetarySummation and SpecifiedTradeSettlementPaymentMeans

### DIFF
--- a/library/src/main/java/org/mustangproject/BankDetails.java
+++ b/library/src/main/java/org/mustangproject/BankDetails.java
@@ -23,6 +23,14 @@ public class BankDetails implements IZUGFeRDTradeSettlementPayment {
 	 * the "name" of the bank account (holder)
 	 */
 	protected String accountName = null;
+	/**
+	 * payment means code
+	 */
+	protected String paymentMeansCode = "58";
+	/**
+	 * payment means information
+	 */
+	protected String paymentMeansInformation = "SEPA credit transfer";
 
 	/***
 	 * bean constructor
@@ -123,5 +131,31 @@ public class BankDetails implements IZUGFeRDTradeSettlementPayment {
 		return accountName;
 	}
 
+	/**
+	 * set payment means code
+	 *
+	 * @param paymentMeansCode the payment means code
+	 * @return fluent setter
+	 */
+	public BankDetails setPaymentMeansCode(String paymentMeansCode) {
+		this.paymentMeansCode = paymentMeansCode;
+		return this;
+	}
 
+	@Override
+	public String getPaymentMeansCode() { return paymentMeansCode; }
+
+	/**
+	 * set payment means information
+	 *
+	 * @param paymentMeansInformation the payment mean information
+	 * @return fluent setter
+	 */
+	public BankDetails setPaymentMeansInformation(String paymentMeansInformation) {
+		this.paymentMeansInformation = paymentMeansInformation;
+		return this;
+	}
+
+	@Override
+	public String getPaymentMeansInformation() { return paymentMeansInformation; }
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
@@ -59,6 +59,16 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 	 */
 	default String getAccountName() { return null; }
 
+	/***
+	 * @return payment means code (BT-81 / UNTDID 4461)
+	 */
+	default String getPaymentMeansCode() { return null; };
+
+	/***
+	 * @return payment means description (BT-82) (optional)
+	 */
+	default String getPaymentMeansInformation() { return null; };
+
 
 	@Override
 	@JsonIgnore
@@ -70,12 +80,14 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 		}
 
 		String xml = "<ram:SpecifiedTradeSettlementPaymentMeans>"
-				+ "<ram:TypeCode>58</ram:TypeCode>"
-				+ "<ram:Information>SEPA credit transfer</ram:Information>"
-				+ "<ram:PayeePartyCreditorFinancialAccount>"
-				+ "<ram:IBANID>" + XMLTools.encodeXML(getOwnIBAN()) + "</ram:IBANID>";
-		xml+= accountNameStr;
-		xml+= "</ram:PayeePartyCreditorFinancialAccount>";
+				+ "<ram:TypeCode>" + XMLTools.encodeXML(getPaymentMeansCode()) + "</ram:TypeCode>"
+				+ "<ram:Information>" + XMLTools.encodeXML(getPaymentMeansInformation()) + "</ram:Information>";
+		if (getOwnIBAN() != null) {
+			xml += "<ram:PayeePartyCreditorFinancialAccount>"
+				+ "<ram:IBANID>" + XMLTools.encodeXML(getOwnIBAN()) + "</ram:IBANID>"
+				+ accountNameStr
+				+ "</ram:PayeePartyCreditorFinancialAccount>";
+		}
 		if (getOwnBIC()!=null) {
 			xml+= "<ram:PayeeSpecifiedCreditorFinancialInstitution>"
 					+ "<ram:BICID>" + XMLTools.encodeXML(getOwnBIC()) + "</ram:BICID>"

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -859,7 +859,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		final String chargesTotalLine = "<ram:ChargeTotalAmount>" + currencyFormat(calc.getChargesForPercent(null)) + "</ram:ChargeTotalAmount>";
 
 		xml += "<ram:SpecifiedTradeSettlementHeaderMonetarySummation>";
-		if ((getProfile() != Profiles.getByName("Minimum")) && (getProfile() != Profiles.getByName("BASICWL"))) {
+		if ((getProfile() != Profiles.getByName("Minimum"))) {
 			xml += "<ram:LineTotalAmount>" + currencyFormat(calc.getTotal()) + "</ram:LineTotalAmount>";
 			xml += chargesTotalLine
 				+ allowanceTotalLine;


### PR DESCRIPTION
This pull request introduces two new changes:
- Addition of the tag `/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:LineTotalAmount` which must be present in the BASICWL profile according to the Factur-X v1.07.2 standard.
- Possibility of setting a code other than 58 in the `/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode` tag. The Factur-X v1.07.2 standard allows codes other than this one. In particular, when transferring Factur-X to ChorusPro. Chorus Pro is a French government platform for invoice transmission. For example, the platform only accepts code 30 for SEPA transfers.

I hope this pull request can be merged soon.