### PR TITLE
Do not output "Adresszusatz 1" as "Postfach".

### DIFF
--- a/library/src/main/resources/stylesheets/xr-mapping.xsl
+++ b/library/src/main/resources/stylesheets/xr-mapping.xsl
@@ -398,7 +398,7 @@
         <nummer>BT-64</nummer>
       </xsl:when>
       <xsl:when test="$identifier = 'xr:Tax_representative_address_line_2'">
-        <label>Postfach</label>
+        <label>Adresszusatz</label>
         <nummer>BT-65</nummer>
       </xsl:when>
       <xsl:when test="$identifier = 'xr:Tax_representative_address_line_3'">
@@ -486,7 +486,7 @@
         <nummer>BT-75</nummer>
       </xsl:when>
       <xsl:when test="$identifier = 'xr:Deliver_to_address_line_2'">
-        <label>Postfach</label>
+        <label>Adresszusatz</label>
         <nummer>BT-76</nummer>
       </xsl:when>
       <xsl:when test="$identifier = 'xr:Deliver_to_address_line_3'">

--- a/library/src/main/resources/stylesheets/xrechnung-html.de.ids.xsl
+++ b/library/src/main/resources/stylesheets/xrechnung-html.de.ids.xsl
@@ -1193,7 +1193,7 @@ function downloadData (element_id) {
                   <div id="BT-50" title="BT-50" class="boxdaten wert"><xsl:value-of select="xr:BUYER_POSTAL_ADDRESS/xr:Buyer_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach (BT-51):</div>
+                  <div class="boxdaten legende">Adresszusatz (BT-51):</div>
                   <div id="BT-51" title="BT-51" class="boxdaten wert"><xsl:value-of select="xr:BUYER_POSTAL_ADDRESS/xr:Buyer_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">
@@ -1258,7 +1258,7 @@ function downloadData (element_id) {
                   <div id="BT-35" title="BT-35" class="boxdaten wert"><xsl:value-of select="xr:SELLER_POSTAL_ADDRESS/xr:Seller_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach (BT-36):</div>
+                  <div class="boxdaten legende">Adresszusatz (BT-36):</div>
                   <div id="BT-36" title="BT-36" class="boxdaten wert"><xsl:value-of select="xr:SELLER_POSTAL_ADDRESS/xr:Seller_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">
@@ -1998,7 +1998,7 @@ function downloadData (element_id) {
                   <div id="BT-64" title="BT-64" class="boxdaten wert"><xsl:value-of select="xr:SELLER_TAX_REPRESENTATIVE_POSTAL_ADDRESS/xr:Tax_representative_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach (BT-65):</div>
+                  <div class="boxdaten legende">Adresszusatz (BT-65):</div>
                   <div id="BT-65" title="BT-65" class="boxdaten wert"><xsl:value-of select="xr:SELLER_TAX_REPRESENTATIVE_POSTAL_ADDRESS/xr:Tax_representative_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">
@@ -2111,7 +2111,7 @@ function downloadData (element_id) {
                   <div id="BT-75" title="BT-75" class="boxdaten wert"><xsl:value-of select="xr:DELIVER_TO_ADDRESS/xr:Deliver_to_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach (BT-76):</div>
+                  <div class="boxdaten legende">Adresszusatz (BT-76):</div>
                   <div id="BT-76" title="BT-76" class="boxdaten wert"><xsl:value-of select="xr:DELIVER_TO_ADDRESS/xr:Deliver_to_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">

--- a/library/src/main/resources/stylesheets/xrechnung-html.de.xsl
+++ b/library/src/main/resources/stylesheets/xrechnung-html.de.xsl
@@ -13,7 +13,7 @@
     <xsl:variable name="i18n.recipientInfo" select="'Informationen zum Käufer'"/>
     <xsl:variable name="i18n.dateOf" select="' vom '"/>
     <xsl:variable name="i18n.bt50" select="'Straße / Haus-Nr.'"/>
-    <xsl:variable name="i18n.bt51" select="'Postfach'"/>
+    <xsl:variable name="i18n.bt51" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt163" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt53" select="'PLZ'"/>
     <xsl:variable name="i18n.bt52" select="'Ort'"/>
@@ -26,7 +26,7 @@
     <xsl:variable name="i18n.bt58" select="'E-Mail-Adresse'"/>
     <xsl:variable name="i18n.bt27" select="'Firmenname'"/>
     <xsl:variable name="i18n.bt35" select="'Straße / Haus-Nr.'"/>
-    <xsl:variable name="i18n.bt36" select="'Postfach'"/>
+    <xsl:variable name="i18n.bt36" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt162" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt38" select="'PLZ'"/>
     <xsl:variable name="i18n.bt37" select="'Ort'"/>
@@ -166,7 +166,7 @@
     <xsl:variable name="i18n.bg11" select="'Steuervertreter des Verkäufers'"/>
     <xsl:variable name="i18n.bt62" select="'Name'"/>
     <xsl:variable name="i18n.bt64" select="'Straße / Hausnummer'"/>
-    <xsl:variable name="i18n.bt65" select="'Postfach'"/>
+    <xsl:variable name="i18n.bt65" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt164" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt67" select="'PLZ'"/>
     <xsl:variable name="i18n.bt66" select="'Ort'"/>
@@ -189,7 +189,7 @@
     <xsl:variable name="i18n.bt72" select="'Lieferdatum'"/>
     <xsl:variable name="i18n.bt70" select="'Name des Empfängers'"/>
     <xsl:variable name="i18n.bt75" select="'Straße / Haus-Nr.'"/>
-    <xsl:variable name="i18n.bt76" select="'Postfach'"/>
+    <xsl:variable name="i18n.bt76" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt165" select="'Adresszusatz'"/>
     <xsl:variable name="i18n.bt78" select="'PLZ'"/>
     <xsl:variable name="i18n.bt77" select="'Ort'"/>

--- a/library/src/main/resources/stylesheets/xrechnung-html.xsl
+++ b/library/src/main/resources/stylesheets/xrechnung-html.xsl
@@ -122,7 +122,7 @@
                   <div title="BT-50" class="boxdaten wert"><xsl:value-of select="xr:BUYER_POSTAL_ADDRESS/xr:Buyer_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach:</div>
+                  <div class="boxdaten legende">Adresszusatz:</div>
                   <div title="BT-51" class="boxdaten wert"><xsl:value-of select="xr:BUYER_POSTAL_ADDRESS/xr:Buyer_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">
@@ -179,7 +179,7 @@
                   <div title="BT-35" class="boxdaten wert"><xsl:value-of select="xr:SELLER_POSTAL_ADDRESS/xr:Seller_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach:</div>
+                  <div class="boxdaten legende">Adresszusatz:</div>
                   <div title="BT-36" class="boxdaten wert"><xsl:value-of select="xr:SELLER_POSTAL_ADDRESS/xr:Seller_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">
@@ -892,7 +892,7 @@
                   <div title="BT-64" class="boxdaten wert"><xsl:value-of select="xr:SELLER_TAX_REPRESENTATIVE_POSTAL_ADDRESS/xr:Tax_representative_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach:</div>
+                  <div class="boxdaten legende">Adresszusatz:</div>
                   <div title="BT-65" class="boxdaten wert"><xsl:value-of select="xr:SELLER_TAX_REPRESENTATIVE_POSTAL_ADDRESS/xr:Tax_representative_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">
@@ -998,7 +998,7 @@
                   <div title="BT-75" class="boxdaten wert"><xsl:value-of select="xr:DELIVER_TO_ADDRESS/xr:Deliver_to_address_line_1"/></div>
                 </div>
                 <div class="boxzeile">
-                  <div class="boxdaten legende">Postfach:</div>
+                  <div class="boxdaten legende">Adresszusatz:</div>
                   <div title="BT-76" class="boxdaten wert"><xsl:value-of select="xr:DELIVER_TO_ADDRESS/xr:Deliver_to_address_line_2"/></div>
                 </div>
                 <div class="boxzeile">

--- a/library/src/test/resources/factur-x-vis-extended.de.html
+++ b/library/src/test/resources/factur-x-vis-extended.de.html
@@ -762,7 +762,7 @@
                                 <div id="BT-50" title="BT-50" class="boxdaten wert">KUNDENWEG 88</div>
                             </div>
                             <div class="boxzeile">
-                                <div class="boxdaten legende">Postfach:</div>
+                                <div class="boxdaten legende">Adresszusatz:</div>
                                 <div id="BT-51" title="BT-51" class="boxdaten wert"></div>
                             </div>
                             <div class="boxzeile">
@@ -826,7 +826,7 @@
                                 <div id="BT-35" title="BT-35" class="boxdaten wert">BAHNHOFSTRASSE 99</div>
                             </div>
                             <div class="boxzeile">
-                                <div class="boxdaten legende">Postfach:</div>
+                                <div class="boxdaten legende">Adresszusatz:</div>
                                 <div id="BT-36" title="BT-36" class="boxdaten wert"></div>
                             </div>
                             <div class="boxzeile">
@@ -2203,7 +2203,7 @@
                                 <div id="BT-75" title="BT-75" class="boxdaten wert">HAUPTSTRASSE 44</div>
                             </div>
                             <div class="boxzeile">
-                                <div class="boxdaten legende">Postfach:</div>
+                                <div class="boxdaten legende">Adresszusatz:</div>
                                 <div id="BT-76" title="BT-76" class="boxdaten wert"></div>
                             </div>
                             <div class="boxzeile">


### PR DESCRIPTION
For "Postfach" instead of "Straße / Hausnummer" Adresszusatz 1 should be used filled with fixed text "Postfach" followed by the number.

_XRG-20 (Erste Adresszeile einheitlich erläutern): In den Beschreibungen zu BT-35 und BT-64 wurde der Hinweis „Üblicherweise ist dies entweder Strasse und Hausnummer oder der Text ‚Postfach‘ gefolgt von der Postfachnummer.“ ergänzt, der bei anderen Elementen, die Adressen beschreiben (z.B. BT-50), bereits vorhanden war._

#742 