### PR TITLE
Berechnung der AppliedAllowance und SpecifiedTradeAllowanceCharges

### DIFF
--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -15,8 +15,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.HashMap;
-import java.util.Map;
 
 /***
  * describes any invoice line
@@ -96,7 +94,6 @@ public class Item implements IZUGFeRDExportableItem {
 			//icnm.getNode("AdditionalItemProperty").flatMap(n ->n.getAttributes()).ifPresent(product::setAttributes);
 
 
-
 			icnm.getAsNodeMap("ClassifiedTaxCategory").flatMap(m -> m.getAsBigDecimal("Percent"))
 				.ifPresent(product::setVATPercent);
 		});
@@ -133,8 +130,6 @@ public class Item implements IZUGFeRDExportableItem {
 
 		itemMap.getAsString("Note")
 			.ifPresent(this::addNote);
-
-
 
 
 		itemMap.getAsNodeMap("SpecifiedLineTradeAgreement", "SpecifiedSupplyChainTradeAgreement").ifPresent(icnm -> {
@@ -175,26 +170,29 @@ public class Item implements IZUGFeRDExportableItem {
 			icnm.getAsNodeMap("ApplicableTradeTax")
 				.flatMap(cnm -> cnm.getAsString("ExemptionReason"))
 				.ifPresent(product::setTaxExemptionReason);
+			icnm.getAsNodeMap("ApplicableTradeTax")
+				.flatMap(cnm -> cnm.getAsString("CategoryCode"))
+				.ifPresent(product::setTaxCategoryCode);
 			icnm.getAsNodeMap("SpecifiedTradeAllowanceCharge").ifPresent(stac -> {
 				stac.getAsNodeMap("ChargeIndicator").ifPresent(ci -> {
-					String isChargeString=ci.getAsString("Indicator").get();
-					String percentString=stac.getAsStringOrNull("CalculationPercent");
-					String amountString=stac.getAsStringOrNull("ActualAmount");
-					String reason=stac.getAsStringOrNull("Reason");
-					Charge izac= new Charge();
+					String isChargeString = ci.getAsString("Indicator").get();
+					String percentString = stac.getAsStringOrNull("CalculationPercent");
+					String amountString = stac.getAsStringOrNull("ActualAmount");
+					String reason = stac.getAsStringOrNull("Reason");
+					Charge izac = new Charge();
 					if (isChargeString.equalsIgnoreCase("false")) {
 						izac = new Allowance();
 					} else {
 						izac = new Charge();
 					}
-					if (amountString!=null) {
+					if (amountString != null) {
 						izac.setTotalAmount(new BigDecimal(amountString));
 					}
-					if(percentString!=null) {
-					izac.setPercent(new BigDecimal(percentString));
+					if (percentString != null) {
+						izac.setPercent(new BigDecimal(percentString));
 					}
-					if(reason!=null) {
-					izac.setReason(reason);
+					if (reason != null) {
+						izac.setReason(reason);
 					}
 
 					if (isChargeString.equalsIgnoreCase("false")) {
@@ -272,7 +270,7 @@ public class Item implements IZUGFeRDExportableItem {
 	}
 
 	public Item setNotesWithSubjectCode(List<IncludedNote> theList) {
-		includedNotes=theList;
+		includedNotes = theList;
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/XMLTools.java
+++ b/library/src/main/java/org/mustangproject/XMLTools.java
@@ -1,16 +1,16 @@
 package org.mustangproject;
 
+import org.apache.commons.io.IOUtils;
+import org.dom4j.io.XMLWriter;
+import org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat;
+import org.w3c.dom.Node;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
-import org.apache.commons.io.IOUtils;
-import org.dom4j.io.XMLWriter;
-import org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat;
-import org.w3c.dom.Node;
 
 public class XMLTools extends XMLWriter {
 	@Override
@@ -89,6 +89,7 @@ public class XMLTools extends XMLWriter {
 		}
 		return XMLTools.tryBigDecimal(nodeValue);
 	}
+
 	/***
 	 * formats a number so that at least minDecimals are displayed but at the maximum maxDecimals are there, i.e.
 	 * cuts potential 0s off the end until minDecimals
@@ -98,12 +99,12 @@ public class XMLTools extends XMLWriter {
 	 * @return value as String with decimals in the specified range
 	 */
 	public static String nDigitFormatDecimalRange(BigDecimal value, int maxDecimals, int minDecimals) {
-		if ((maxDecimals<minDecimals)||(maxDecimals<0)||(minDecimals<0)) {
+		if ((maxDecimals < minDecimals) || (maxDecimals < 0) || (minDecimals < 0)) {
 			throw new IllegalArgumentException("Invalid scale range provided");
 		}
-		int curDecimals=maxDecimals;
-		while  ( (curDecimals>minDecimals) && (value.setScale(curDecimals, RoundingMode.HALF_UP).compareTo(value.setScale(curDecimals-1, RoundingMode.HALF_UP))==0)) {
-			 curDecimals--;
+		int curDecimals = maxDecimals;
+		while ((curDecimals > minDecimals) && (value.setScale(curDecimals, RoundingMode.HALF_UP).compareTo(value.setScale(curDecimals - 1, RoundingMode.HALF_UP)) == 0)) {
+			curDecimals--;
 		}
 		return value.setScale(curDecimals, RoundingMode.HALF_UP).toPlainString();
 
@@ -130,9 +131,12 @@ public class XMLTools extends XMLWriter {
 	 */
 	public static Date tryDate(String toParse) {
 		SimpleDateFormat formatter = null;
+		if (toParse == null) {
+			return null;
+		}
 		if (toParse.contains("-")) {
 			// from ubl
-			 formatter = new SimpleDateFormat("yyyy-MM-dd");
+			formatter = new SimpleDateFormat("yyyy-MM-dd");
 		} else {
 			formatter = ZUGFeRDDateFormat.DATE.getFormatter();
 		}
@@ -217,7 +221,7 @@ public class XMLTools extends XMLWriter {
 	}
 
 	public static byte[] getBytesFromStream(InputStream fileinput) throws IOException {
-	  return IOUtils.toByteArray (fileinput);
+		return IOUtils.toByteArray(fileinput);
 	}
 
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
@@ -20,21 +20,21 @@
  */
 package org.mustangproject.ZUGFeRD;
 
-import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Optional;
-
 import org.mustangproject.EStandard;
 import org.mustangproject.FileAttachment;
 import org.mustangproject.Invoice;
 import org.mustangproject.XMLTools;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
+
 public class DAPullProvider extends ZUGFeRD2PullProvider {
 
 	protected IExportableTransaction trans;
-	protected Profile profile = Profiles.getByName(EStandard.despatchadvice,"pilot", 1);
+	protected Profile profile = Profiles.getByName(EStandard.despatchadvice, "pilot", 1);
 
 
 	@Override
@@ -46,80 +46,80 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 			typecode = trans.getDocumentCode();
 		}*/
 
-		String testBooleanStr="true";
+		String testBooleanStr = "true";
 		String xml = "<SCRDMCCBDACIDAMessageStructure\n" +
-				"        xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:25\"\n" +
-				"        xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:101\"\n" +
-				"        xmlns:px=\"urn:un:unece:uncefact:data:standard:SCRDMCCBDACIDAMessageStructure:1\">\n"
-				// + "
-				// xsi:schemaLocation=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100
-				// ../Schema/ZUGFeRD1p0.xsd\""
-				+ "<px:ExchangedDocumentContext>"
-				// + "
-				+" <ram:TestIndicator><udt:Indicator>"+testBooleanStr+"</udt:Indicator></ram:TestIndicator>\n"
-				//
-				+ "<ram:BusinessProcessSpecifiedDocumentContextParameter>"
-				+ "<ram:ID>" + getProfile().getID() + "</ram:ID>"
-				+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>"
-				+ "</px:ExchangedDocumentContext>"
-				+ "<px:ExchangedDocument>"
-				+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>"
-				// + " <ram:Name>RECHNUNG</ram:Name>"
-				// + "<ram:TypeCode>380</ram:TypeCode>"
-				+ "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
-				+ "<ram:IssueDateTime>"
-				+ DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
-				+ buildNotes(trans)
+			"        xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:25\"\n" +
+			"        xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:101\"\n" +
+			"        xmlns:px=\"urn:un:unece:uncefact:data:standard:SCRDMCCBDACIDAMessageStructure:1\">\n"
+			// + "
+			// xsi:schemaLocation=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100
+			// ../Schema/ZUGFeRD1p0.xsd\""
+			+ "<px:ExchangedDocumentContext>"
+			// + "
+			+ " <ram:TestIndicator><udt:Indicator>" + testBooleanStr + "</udt:Indicator></ram:TestIndicator>\n"
+			//
+			+ "<ram:BusinessProcessSpecifiedDocumentContextParameter>"
+			+ "<ram:ID>" + getProfile().getID() + "</ram:ID>"
+			+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>"
+			+ "</px:ExchangedDocumentContext>"
+			+ "<px:ExchangedDocument>"
+			+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>"
+			// + " <ram:Name>RECHNUNG</ram:Name>"
+			// + "<ram:TypeCode>380</ram:TypeCode>"
+			+ "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
+			+ "<ram:IssueDateTime>"
+			+ DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
+			+ buildNotes(trans)
 
-				+ "</px:ExchangedDocument>"
-				+ "<px:SupplyChainTradeTransaction>";
+			+ "</px:ExchangedDocument>"
+			+ "<px:SupplyChainTradeTransaction>";
 		int lineID = 0;
 		for (final IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
 			lineID++;
 			if (currentItem.getProduct().getTaxExemptionReason() != null) {
 				//	exemptionReason = "<ram:ExemptionReason>" + XMLTools.encodeXML(currentItem.getProduct().getTaxExemptionReason()) + "</ram:ExemptionReason>";
 			}
-      final LineCalculator lc = new LineCalculator(currentItem);
+			final LineCalculator lc = new LineCalculator(currentItem);
 			xml += "<ram:IncludedSupplyChainTradeLineItem>" +
-					"<ram:AssociatedDocumentLineDocument>"
-					+ "<ram:LineID>" + lineID + "</ram:LineID>"
-          + buildItemNotes(currentItem)
-					+ "</ram:AssociatedDocumentLineDocument>"
+				"<ram:AssociatedDocumentLineDocument>"
+				+ "<ram:LineID>" + lineID + "</ram:LineID>"
+				+ buildItemNotes(currentItem)
+				+ "</ram:AssociatedDocumentLineDocument>"
 
-					+ "<ram:SpecifiedTradeProduct>";
+				+ "<ram:SpecifiedTradeProduct>";
 			// + " <GlobalID schemeID=\"0160\">4012345001235</GlobalID>"
 			if (currentItem.getProduct().getSellerAssignedID() != null) {
 				xml += "<ram:SellerAssignedID>"
-						+ XMLTools.encodeXML(currentItem.getProduct().getSellerAssignedID()) + "</ram:SellerAssignedID>";
+					+ XMLTools.encodeXML(currentItem.getProduct().getSellerAssignedID()) + "</ram:SellerAssignedID>";
 			}
 			if (currentItem.getProduct().getBuyerAssignedID() != null) {
 				xml += "<ram:BuyerAssignedID>"
-						+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>";
+					+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>";
 			}
 			String allowanceChargeStr = "";
-			if (currentItem.getItemAllowances() != null && currentItem.getItemAllowances().length > 0) {
+			if (currentItem.getItemAllowances() != null) {
 				for (final IZUGFeRDAllowanceCharge allowance : currentItem.getItemAllowances()) {
-					allowanceChargeStr += getAllowanceChargeStr(allowance, currentItem);
+					allowanceChargeStr += getAppliedAllowanceStr(allowance, currentItem);
 				}
 			}
-			if (currentItem.getItemCharges() != null && currentItem.getItemCharges().length > 0) {
+			if (currentItem.getItemCharges() != null) {
 				for (final IZUGFeRDAllowanceCharge charge : currentItem.getItemCharges()) {
-					allowanceChargeStr += getAllowanceChargeStr(charge, currentItem);
+					allowanceChargeStr += getAppliedAllowanceStr(charge, currentItem);
 
 				}
 			}
 
 
 			xml += "<ram:Name>" + XMLTools.encodeXML(currentItem.getProduct().getName()) + "</ram:Name>"
-					+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
-					+ "</ram:Description>"
-					+ "</ram:SpecifiedTradeProduct>"
+				+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
+				+ "</ram:Description>"
+				+ "</ram:SpecifiedTradeProduct>"
 
-					+ "<ram:SpecifiedLineTradeDelivery>"
-					+ "<ram:DespatchedQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
-					+ quantityFormat(currentItem.getQuantity()) + "</ram:DespatchedQuantity>"
-					+ "</ram:SpecifiedLineTradeDelivery>"
-					+ "<ram:SpecifiedLineTradeSettlement>";
+				+ "<ram:SpecifiedLineTradeDelivery>"
+				+ "<ram:DespatchedQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
+				+ quantityFormat(currentItem.getQuantity()) + "</ram:DespatchedQuantity>"
+				+ "</ram:SpecifiedLineTradeDelivery>"
+				+ "<ram:SpecifiedLineTradeSettlement>";
 			if ((currentItem.getDetailedDeliveryPeriodFrom() != null) || (currentItem.getDetailedDeliveryPeriodTo() != null)) {
 				xml += "<ram:BillingSpecifiedPeriod>";
 				if (currentItem.getDetailedDeliveryPeriodFrom() != null) {
@@ -133,15 +133,15 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 			}
 
 			xml += "<ram:SpecifiedTradeSettlementLineMonetarySummation>"
-					+ "<ram:LineTotalAmount>" + currencyFormat(lc.getItemTotalNetAmount())
-					+ "</ram:LineTotalAmount>" // currencyID=\"EUR\"
-					+ "</ram:SpecifiedTradeSettlementLineMonetarySummation>";
+				+ "<ram:LineTotalAmount>" + currencyFormat(lc.getItemTotalNetAmount())
+				+ "</ram:LineTotalAmount>" // currencyID=\"EUR\"
+				+ "</ram:SpecifiedTradeSettlementLineMonetarySummation>";
 		/*	if (currentItem.getAdditionalReferencedDocumentID() != null) {
 				xml += "<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>" + currentItem.getAdditionalReferencedDocumentID() + "</ram:IssuerAssignedID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
 
 			}*/
 			xml += "</ram:SpecifiedLineTradeSettlement>"
-					+ "</ram:IncludedSupplyChainTradeLineItem>";
+				+ "</ram:IncludedSupplyChainTradeLineItem>";
 
 		}
 
@@ -151,9 +151,9 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 
 		}
 		xml += "<ram:SellerTradeParty>"
-				+ getTradePartyAsXML(trans.getSender(), true, false)
-				+ "</ram:SellerTradeParty>"
-				+ "<ram:BuyerTradeParty>";
+			+ getTradePartyAsXML(trans.getSender(), true, false)
+			+ "</ram:SellerTradeParty>"
+			+ "<ram:BuyerTradeParty>";
 		// + " <ID>GE2020211</ID>"
 		// + " <GlobalID schemeID=\"0088\">4000001987658</GlobalID>"
 
@@ -162,21 +162,21 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 
 		if (trans.getSellerOrderReferencedDocumentID() != null) {
 			xml += "<ram:SellerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:SellerOrderReferencedDocument>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:SellerOrderReferencedDocument>";
 		}
 		if (trans.getBuyerOrderReferencedDocumentID() != null) {
 			xml += "<ram:BuyerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:BuyerOrderReferencedDocument>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:BuyerOrderReferencedDocument>";
 		}
 		if (trans.getContractReferencedDocument() != null) {
 			xml += "<ram:ContractReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
-					+ "</ram:ContractReferencedDocument>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
+				+ "</ram:ContractReferencedDocument>";
 		}
 
 		// Additional Documents of XRechnung (Rechnungsbegruendende Unterlagen - BG-24 XRechnung)
@@ -184,37 +184,37 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 			for (final FileAttachment f : trans.getAdditionalReferencedDocuments()) {
 				final String documentContent = new String(Base64.getEncoder().encodeToString(f.getData()));
 				xml += "<ram:AdditionalReferencedDocument>"
-						+ "<ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
-						+ "<ram:TypeCode>916</ram:TypeCode>"
-						+ "<ram:Name>" + f.getDescription() + "</ram:Name>"
-						+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
-						+ "filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
-						+ "</ram:AdditionalReferencedDocument>";
+					+ "<ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
+					+ "<ram:TypeCode>916</ram:TypeCode>"
+					+ "<ram:Name>" + f.getDescription() + "</ram:Name>"
+					+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
+					+ "filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
+					+ "</ram:AdditionalReferencedDocument>";
 			}
 		}
 
 		if (trans.getSpecifiedProcuringProjectID() != null) {
 			xml += "<ram:SpecifiedProcuringProject>"
-					+ "<ram:ID>"
-					+ XMLTools.encodeXML(trans.getSpecifiedProcuringProjectID()) + "</ram:ID>";
+				+ "<ram:ID>"
+				+ XMLTools.encodeXML(trans.getSpecifiedProcuringProjectID()) + "</ram:ID>";
 			if (trans.getSpecifiedProcuringProjectName() != null) {
 				xml += "<ram:Name >" + XMLTools.encodeXML(trans.getSpecifiedProcuringProjectName()) + "</ram:Name>";
 			}
 			xml += "</ram:SpecifiedProcuringProject>";
 		}
 		xml += "</ram:ApplicableHeaderTradeAgreement>"
-				+ "<ram:ApplicableHeaderTradeDelivery>";
+			+ "<ram:ApplicableHeaderTradeDelivery>";
 		if (this.trans.getDeliveryAddress() != null) {
 			xml += "<ram:ShipToTradeParty>" +
-					getTradePartyAsXML(this.trans.getDeliveryAddress(), false, true) +
-					"</ram:ShipToTradeParty>";
+				getTradePartyAsXML(this.trans.getDeliveryAddress(), false, true) +
+				"</ram:ShipToTradeParty>";
 		}
 		xml += " <ram:ActualDespatchSupplyChainEvent>\n" +
-				"                <ram:OccurrenceDateTime>\n" +
-				"                    <udt:DateTimeString\n" +
-				"                            format=\"102\">"+ DATE.udtFormat(trans.getDeliveryDate() )+"</udt:DateTimeString>\n" +
-				"                </ram:OccurrenceDateTime>\n" +
-				"            </ram:ActualDespatchSupplyChainEvent>";
+			"                <ram:OccurrenceDateTime>\n" +
+			"                    <udt:DateTimeString\n" +
+			"                            format=\"102\">" + DATE.udtFormat(trans.getDeliveryDate()) + "</udt:DateTimeString>\n" +
+			"                </ram:OccurrenceDateTime>\n" +
+			"            </ram:ActualDespatchSupplyChainEvent>";
 
 /*
 		xml += "<ram:ActualDeliverySupplyChainEvent>"
@@ -235,7 +235,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 		 * "<ID>2013-51112</ID>\n" +
 		 * "</DeliveryNoteReferencedDocument>\n"
 		 */
-		xml+= "</ram:ApplicableHeaderTradeDelivery>\n";
+		xml += "</ram:ApplicableHeaderTradeDelivery>\n";
 		// + " <IncludedSupplyChainTradeLineItem>"
 		// + " <AssociatedDocumentLineDocument>"
 		// + " <IncludedNote>"
@@ -246,7 +246,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 		// + " </IncludedSupplyChainTradeLineItem>\n";
 
 		xml += "</px:SupplyChainTradeTransaction>"
-				+ "</SCRDMCCBDACIDAMessageStructure>";
+			+ "</SCRDMCCBDACIDAMessageStructure>";
 
 		final byte[] zugferdRaw;
 		zugferdRaw = xml.getBytes(StandardCharsets.UTF_8);
@@ -265,17 +265,17 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 		return profile;
 	}
 
-  @Override
-  protected String buildNotes(IExportableTransaction exportableTransaction) {
-    Invoice copyWithoutRebateInfo = new Invoice()
-        .setOwnOrganisationFullPlaintextInfo(exportableTransaction.getOwnOrganisationFullPlaintextInfo())
-        .addNotes(exportableTransaction.getNotesWithSubjectCode());
-    if(exportableTransaction.getNotes() != null) {
-      for (String note : exportableTransaction.getNotes()) {
-        copyWithoutRebateInfo.addNote(note);
-      }
-    }
-    Optional.ofNullable(exportableTransaction.getSubjectNote()).ifPresent(copyWithoutRebateInfo::addNote);
-    return super.buildNotes(copyWithoutRebateInfo);
-  }
+	@Override
+	protected String buildNotes(IExportableTransaction exportableTransaction) {
+		Invoice copyWithoutRebateInfo = new Invoice()
+			.setOwnOrganisationFullPlaintextInfo(exportableTransaction.getOwnOrganisationFullPlaintextInfo())
+			.addNotes(exportableTransaction.getNotesWithSubjectCode());
+		if (exportableTransaction.getNotes() != null) {
+			for (String note : exportableTransaction.getNotes()) {
+				copyWithoutRebateInfo.addNote(note);
+			}
+		}
+		Optional.ofNullable(exportableTransaction.getSubjectNote()).ifPresent(copyWithoutRebateInfo::addNote);
+		return super.buildNotes(copyWithoutRebateInfo);
+	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
@@ -1,46 +1,48 @@
-/** **********************************************************************
- *
+/**
+ * *********************************************************************
+ * <p>
  * Copyright 2018 Jochen Staerk
- *
+ * <p>
  * Use is subject to license terms.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0.
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * <p>
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *********************************************************************** */
+ * <p>
+ * **********************************************************************
+ */
 package org.mustangproject.ZUGFeRD;
 /**
  * Mustangproject's ZUGFeRD implementation
  * Neccessary interface for ZUGFeRD exporter
  * Licensed under the APLv2
+ *
  * @date 2014-05-10
  * @version 1.2.0
  * @author jstaerk
- * */
+ */
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.mustangproject.IncludedNote;
+import org.mustangproject.Item;
 
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
 
-import org.mustangproject.IncludedNote;
-import org.mustangproject.Item;
-
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-
 @JsonDeserialize(as = Item.class)
-public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
+public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	IZUGFeRDExportableProduct getProduct();
 
 	/**
-	 * item level discounts
+	 * item level discounts for the line item total (BG-27)
 	 * @return array of the discounts on a single item
 	 */
 	default IZUGFeRDAllowanceCharge[] getItemAllowances() {
@@ -48,7 +50,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	}
 
 	/**
-	 * item level price additions
+	 * item level additions for the line item total (BG-27)
 	 * @return array of the additional charges on the item
 	 */
 	default IZUGFeRDAllowanceCharge[] getItemCharges() {
@@ -76,6 +78,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	default BigDecimal getValue() {
 		return getPrice();
 	}
+
 	/**
 	 * how many get billed
 	 *
@@ -85,7 +88,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 
 	/**
 	 * how many items units per price
-	 * 
+	 *
 	 * @return item units per price
 	 */
 	default BigDecimal getBasisQuantity() {
@@ -118,6 +121,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	default IReferencedDocument[] getReferencedDocuments() {
 		return null;
 	}
+
 	/***
 	 * descriptive texts
 	 * @return an array of strings of item specific "includedNotes", text values
@@ -125,7 +129,6 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	default String[] getNotes() {
 		return null;
 	}
-
 
 
 	/***
@@ -145,11 +148,11 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	default Date getDetailedDeliveryPeriodTo() {
 		return null;
 	}
-	
+
 	/***
-	 * specify allowances amount for the line item total
+	 * specify applied allowances amount for the item price
 	 *
-	 * @return the sum of allowances for this item
+	 * @return applied allowance amount (BT-147)
 	 */
 	default IZUGFeRDAllowanceCharge[] getItemTotalAllowances() {
 		return null;
@@ -159,7 +162,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	 *
 	 * @return the line ID
 	 */
-	default String getId()  {
+	default String getId() {
 		return null;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
@@ -33,9 +33,9 @@ public class LineCalculator {
 				addAllowanceItemTotal(itemTotalAllowance.getTotalAmount(currentItem));
 			}
 		}
-		
+
 		BigDecimal vatPercent = null;
-		if (currentItem.getProduct()!=null) {
+		if (currentItem.getProduct() != null) {
 			vatPercent = currentItem.getProduct().getVATPercent();
 		}
 		if (vatPercent == null) {
@@ -43,11 +43,11 @@ public class LineCalculator {
 		}
 		BigDecimal multiplicator = vatPercent.divide(BigDecimal.valueOf(100));
 		priceGross = currentItem.getPrice(); // see https://github.com/ZUGFeRD/mustangproject/issues/159
-		price = priceGross.subtract(allowance).add(charge);
+		price = priceGross.subtract(allowanceItemTotal);
 
-		BigDecimal quantity=BigDecimal.ZERO;
-		if ((currentItem!=null)&&(currentItem.getQuantity()!=null)) {
-			quantity=currentItem.getQuantity();
+		BigDecimal quantity = BigDecimal.ZERO;
+		if ((currentItem != null) && (currentItem.getQuantity() != null)) {
+			quantity = currentItem.getQuantity();
 		}
 
 		// Division/Zero occurred here.
@@ -56,7 +56,7 @@ public class LineCalculator {
 			? BigDecimal.ONE.setScale(4)
 			: currentItem.getBasisQuantity();
 		itemTotalNetAmount = quantity.multiply(price).divide(basisQuantity, 18, RoundingMode.HALF_UP)
-				.subtract(allowanceItemTotal).setScale(2, RoundingMode.HALF_UP);
+			.subtract(allowance).add(charge).setScale(2, RoundingMode.HALF_UP);
 		itemTotalVATAmount = itemTotalNetAmount.multiply(multiplicator);
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
@@ -20,8 +20,9 @@
  */
 package org.mustangproject.ZUGFeRD;
 
-import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
-import static org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants.CORRECTEDINVOICE;
+import org.mustangproject.EStandard;
+import org.mustangproject.FileAttachment;
+import org.mustangproject.XMLTools;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -30,16 +31,15 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 
-import org.mustangproject.EStandard;
-import org.mustangproject.FileAttachment;
-import org.mustangproject.XMLTools;
+import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
+import static org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants.CORRECTEDINVOICE;
 
 public class OXPullProvider extends ZUGFeRD2PullProvider {
 
 	protected IExportableTransaction trans;
 	protected TransactionCalculator calc;
 	private String paymentTermsDescription;
-	protected Profile profile = Profiles.getByName(EStandard.orderx,"basic", 1);
+	protected Profile profile = Profiles.getByName(EStandard.orderx, "basic", 1);
 
 
 	@Override
@@ -53,7 +53,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		final String exemptionReason = "";
 
 		if (trans.getPaymentTermDescription() != null) {
-      paymentTermsDescription = XMLTools.encodeXML(trans.getPaymentTermDescription());
+			paymentTermsDescription = XMLTools.encodeXML(trans.getPaymentTermDescription());
 		}
 
 		if ((paymentTermsDescription == null) && (trans.getDocumentCode() != CORRECTEDINVOICE)/* && (trans.getDocumentCode() != DocumentCodeTypeConstants.CREDITNOTE)*/) {
@@ -65,84 +65,84 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		/*if (trans.getDocumentCode() != null) {
 			typecode = trans.getDocumentCode();
 		}*/
-	
+
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 
-				+ "<rsm:SCRDMCCBDACIOMessageStructure\n" +
-				"xmlns:rsm=\"urn:un:unece:uncefact:data:SCRDMCCBDACIOMessageStructure:100\"\n" +
-				"xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:128\"\n" +
-				"xmlns:qdt=\"urn:un:unece:uncefact:data:standard:QualifiedDataType:128\"\n" +
-				"xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:128\"\n" +
-				"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
-				// + "
-				// xsi:schemaLocation=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100
-				// ../Schema/ZUGFeRD1p0.xsd\""
-				+ "<rsm:ExchangedDocumentContext>"
-				// + "
-				// <ram:TestIndicator><udt:Indicator>"+testBooleanStr+"</udt:Indicator></ram:TestIndicator>\n"
-				//
-				+ "<ram:BusinessProcessSpecifiedDocumentContextParameter>"
-				+ "<ram:ID>A1</ram:ID>"
-				+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>"
-				+ "<ram:GuidelineSpecifiedDocumentContextParameter>"
-				+ "<ram:ID>" + getProfile().getID() + "</ram:ID>"
-				+ "</ram:GuidelineSpecifiedDocumentContextParameter>"
-				+ "</rsm:ExchangedDocumentContext>"
-				+ "<rsm:ExchangedDocument>"
-				+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>"
-				// + " <ram:Name>RECHNUNG</ram:Name>"
-				// + "<ram:TypeCode>380</ram:TypeCode>"
-				+ "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
-				+ "<ram:IssueDateTime>"
-				+ DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
-				+ buildNotes(trans)
+			+ "<rsm:SCRDMCCBDACIOMessageStructure\n" +
+			"xmlns:rsm=\"urn:un:unece:uncefact:data:SCRDMCCBDACIOMessageStructure:100\"\n" +
+			"xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:128\"\n" +
+			"xmlns:qdt=\"urn:un:unece:uncefact:data:standard:QualifiedDataType:128\"\n" +
+			"xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:128\"\n" +
+			"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
+			// + "
+			// xsi:schemaLocation=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100
+			// ../Schema/ZUGFeRD1p0.xsd\""
+			+ "<rsm:ExchangedDocumentContext>"
+			// + "
+			// <ram:TestIndicator><udt:Indicator>"+testBooleanStr+"</udt:Indicator></ram:TestIndicator>\n"
+			//
+			+ "<ram:BusinessProcessSpecifiedDocumentContextParameter>"
+			+ "<ram:ID>A1</ram:ID>"
+			+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>"
+			+ "<ram:GuidelineSpecifiedDocumentContextParameter>"
+			+ "<ram:ID>" + getProfile().getID() + "</ram:ID>"
+			+ "</ram:GuidelineSpecifiedDocumentContextParameter>"
+			+ "</rsm:ExchangedDocumentContext>"
+			+ "<rsm:ExchangedDocument>"
+			+ "<ram:ID>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:ID>"
+			// + " <ram:Name>RECHNUNG</ram:Name>"
+			// + "<ram:TypeCode>380</ram:TypeCode>"
+			+ "<ram:TypeCode>" + typecode + "</ram:TypeCode>"
+			+ "<ram:IssueDateTime>"
+			+ DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
+			+ buildNotes(trans)
 
-				+ "</rsm:ExchangedDocument>"
-				+ "<rsm:SupplyChainTradeTransaction>";
+			+ "</rsm:ExchangedDocument>"
+			+ "<rsm:SupplyChainTradeTransaction>";
 		int lineID = 0;
 		for (final IZUGFeRDExportableItem currentItem : trans.getZFItems()) {
 			lineID++;
 			if (currentItem.getProduct().getTaxExemptionReason() != null) {
-			//	exemptionReason = "<ram:ExemptionReason>" + XMLTools.encodeXML(currentItem.getProduct().getTaxExemptionReason()) + "</ram:ExemptionReason>";
+				//	exemptionReason = "<ram:ExemptionReason>" + XMLTools.encodeXML(currentItem.getProduct().getTaxExemptionReason()) + "</ram:ExemptionReason>";
 			}
-    
+
 			final LineCalculator lc = new LineCalculator(currentItem);
 			xml += "<ram:IncludedSupplyChainTradeLineItem>" +
-					"<ram:AssociatedDocumentLineDocument>"
-					+ "<ram:LineID>" + lineID + "</ram:LineID>"
-					+ buildItemNotes(currentItem)
-					+ "</ram:AssociatedDocumentLineDocument>"
+				"<ram:AssociatedDocumentLineDocument>"
+				+ "<ram:LineID>" + lineID + "</ram:LineID>"
+				+ buildItemNotes(currentItem)
+				+ "</ram:AssociatedDocumentLineDocument>"
 
-					+ "<ram:SpecifiedTradeProduct>";
+				+ "<ram:SpecifiedTradeProduct>";
 			// + " <GlobalID schemeID=\"0160\">4012345001235</GlobalID>"
 			if (currentItem.getProduct().getSellerAssignedID() != null) {
 				xml += "<ram:SellerAssignedID>"
-						+ XMLTools.encodeXML(currentItem.getProduct().getSellerAssignedID()) + "</ram:SellerAssignedID>";
+					+ XMLTools.encodeXML(currentItem.getProduct().getSellerAssignedID()) + "</ram:SellerAssignedID>";
 			}
 			if (currentItem.getProduct().getBuyerAssignedID() != null) {
 				xml += "<ram:BuyerAssignedID>"
-						+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>";
+					+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>";
 			}
 			String allowanceChargeStr = "";
-			if (currentItem.getItemAllowances() != null && currentItem.getItemAllowances().length > 0) {
+			if (currentItem.getItemAllowances() != null) {
 				for (final IZUGFeRDAllowanceCharge allowance : currentItem.getItemAllowances()) {
-					allowanceChargeStr += getAllowanceChargeStr(allowance, currentItem);
+					allowanceChargeStr += getAppliedAllowanceStr(allowance, currentItem);
 				}
 			}
-			if (currentItem.getItemCharges() != null && currentItem.getItemCharges().length > 0) {
+			if (currentItem.getItemCharges() != null) {
 				for (final IZUGFeRDAllowanceCharge charge : currentItem.getItemCharges()) {
-					allowanceChargeStr += getAllowanceChargeStr(charge, currentItem);
+					allowanceChargeStr += getAppliedAllowanceStr(charge, currentItem);
 
 				}
 			}
 
 
 			xml += "<ram:Name>" + XMLTools.encodeXML(currentItem.getProduct().getName()) + "</ram:Name>"
-					+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
-					+ "</ram:Description>"
-					+ "</ram:SpecifiedTradeProduct>"
+				+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
+				+ "</ram:Description>"
+				+ "</ram:SpecifiedTradeProduct>"
 
-					+ "<ram:SpecifiedLineTradeAgreement>";
+				+ "<ram:SpecifiedLineTradeAgreement>";
 		/*	if (currentItem.getReferencedDocuments() != null) {
 				for (IReferencedDocument currentReferencedDocument : currentItem.getReferencedDocuments()) {
 					xml += "<ram:AdditionalReferencedDocument>\n" +
@@ -157,43 +157,38 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			}*/
 			if (currentItem.getBuyerOrderReferencedDocumentLineID() != null) {
 				xml += "<ram:BuyerOrderReferencedDocument> \n"
-						+ "<ram:LineID>" + XMLTools.encodeXML(currentItem.getBuyerOrderReferencedDocumentLineID()) + "</ram:LineID>"
-						+ "</ram:BuyerOrderReferencedDocument>";
+					+ "<ram:LineID>" + XMLTools.encodeXML(currentItem.getBuyerOrderReferencedDocumentLineID()) + "</ram:LineID>"
+					+ "</ram:BuyerOrderReferencedDocument>";
 
 			}
 			xml += "<ram:GrossPriceProductTradePrice>"
-					+ "<ram:ChargeAmount>" + priceFormat(lc.getPriceGross())
-					+ "</ram:ChargeAmount>" //currencyID=\"EUR\"
-					+ "<ram:BasisQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit())
-					+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
-					+ allowanceChargeStr
-					// + " <AppliedTradeAllowanceCharge>\n"
-					// + " <ChargeIndicator>false</ChargeIndicator>\n"
-					// + " <ActualAmount currencyID=\"EUR\">0.6667</ActualAmount>\n"
-					// + " <Reason>Rabatt</Reason>\n"
-					// + " </AppliedTradeAllowanceCharge>\n"
-					+ "</ram:GrossPriceProductTradePrice>"
-					+ "<ram:NetPriceProductTradePrice>"
-					+ "<ram:ChargeAmount>" + priceFormat(lc.getPrice())
-					+ "</ram:ChargeAmount>" // currencyID=\"EUR\"
-					+ "<ram:BasisQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit())
-					+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
-					+ "</ram:NetPriceProductTradePrice>"
-					+ "</ram:SpecifiedLineTradeAgreement>"
+				+ "<ram:ChargeAmount>" + priceFormat(lc.getPriceGross())
+				+ "</ram:ChargeAmount>" //currencyID=\"EUR\"
+				+ "<ram:BasisQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit())
+				+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
+				+ allowanceChargeStr
+				+ "</ram:GrossPriceProductTradePrice>"
+				+ "<ram:NetPriceProductTradePrice>"
+				+ "<ram:ChargeAmount>" + priceFormat(lc.getPrice())
+				+ "</ram:ChargeAmount>" // currencyID=\"EUR\"
+				+ "<ram:BasisQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit())
+				+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
+				+ "</ram:NetPriceProductTradePrice>"
+				+ "</ram:SpecifiedLineTradeAgreement>"
 
-					+ "<ram:SpecifiedLineTradeDelivery>"
-					+ "<ram:RequestedQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
-					+ quantityFormat(currentItem.getQuantity()) + "</ram:RequestedQuantity>"
-					+ "</ram:SpecifiedLineTradeDelivery>"
-					+ "<ram:SpecifiedLineTradeSettlement>"
-					+ "<ram:ApplicableTradeTax>"
-					+ "<ram:TypeCode>VAT</ram:TypeCode>"
-					+ exemptionReason
-					+ "<ram:CategoryCode>" + currentItem.getProduct().getTaxCategoryCode() + "</ram:CategoryCode>"
+				+ "<ram:SpecifiedLineTradeDelivery>"
+				+ "<ram:RequestedQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
+				+ quantityFormat(currentItem.getQuantity()) + "</ram:RequestedQuantity>"
+				+ "</ram:SpecifiedLineTradeDelivery>"
+				+ "<ram:SpecifiedLineTradeSettlement>"
+				+ "<ram:ApplicableTradeTax>"
+				+ "<ram:TypeCode>VAT</ram:TypeCode>"
+				+ exemptionReason
+				+ "<ram:CategoryCode>" + currentItem.getProduct().getTaxCategoryCode() + "</ram:CategoryCode>"
 
-					+ "<ram:RateApplicablePercent>"
-					+ vatFormat(currentItem.getProduct().getVATPercent()) + "</ram:RateApplicablePercent>"
-					+ "</ram:ApplicableTradeTax>";
+				+ "<ram:RateApplicablePercent>"
+				+ vatFormat(currentItem.getProduct().getVATPercent()) + "</ram:RateApplicablePercent>"
+				+ "</ram:ApplicableTradeTax>";
 			if ((currentItem.getDetailedDeliveryPeriodFrom() != null) || (currentItem.getDetailedDeliveryPeriodTo() != null)) {
 				xml += "<ram:BillingSpecifiedPeriod>";
 				if (currentItem.getDetailedDeliveryPeriodFrom() != null) {
@@ -207,15 +202,15 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			}
 
 			xml += "<ram:SpecifiedTradeSettlementLineMonetarySummation>"
-					+ "<ram:LineTotalAmount>" + currencyFormat(lc.getItemTotalNetAmount())
-					+ "</ram:LineTotalAmount>" // currencyID=\"EUR\"
-					+ "</ram:SpecifiedTradeSettlementLineMonetarySummation>";
+				+ "<ram:LineTotalAmount>" + currencyFormat(lc.getItemTotalNetAmount())
+				+ "</ram:LineTotalAmount>" // currencyID=\"EUR\"
+				+ "</ram:SpecifiedTradeSettlementLineMonetarySummation>";
 		/*	if (currentItem.getAdditionalReferencedDocumentID() != null) {
 				xml += "<ram:AdditionalReferencedDocument><ram:IssuerAssignedID>" + currentItem.getAdditionalReferencedDocumentID() + "</ram:IssuerAssignedID><ram:TypeCode>130</ram:TypeCode></ram:AdditionalReferencedDocument>";
 
 			}*/
 			xml += "</ram:SpecifiedLineTradeSettlement>"
-					+ "</ram:IncludedSupplyChainTradeLineItem>";
+				+ "</ram:IncludedSupplyChainTradeLineItem>";
 
 		}
 
@@ -225,9 +220,9 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 
 		}
 		xml += "<ram:SellerTradeParty>"
-				+ getTradePartyAsXML(trans.getSender(), true, false)
-				+ "</ram:SellerTradeParty>"
-				+ "<ram:BuyerTradeParty>";
+			+ getTradePartyAsXML(trans.getSender(), true, false)
+			+ "</ram:SellerTradeParty>"
+			+ "<ram:BuyerTradeParty>";
 		// + " <ID>GE2020211</ID>"
 		// + " <GlobalID schemeID=\"0088\">4000001987658</GlobalID>"
 
@@ -236,21 +231,21 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 
 		if (trans.getSellerOrderReferencedDocumentID() != null) {
 			xml += "<ram:SellerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:SellerOrderReferencedDocument>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:SellerOrderReferencedDocument>";
 		}
 		if (trans.getBuyerOrderReferencedDocumentID() != null) {
 			xml += "<ram:BuyerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:BuyerOrderReferencedDocument>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:BuyerOrderReferencedDocument>";
 		}
 		if (trans.getContractReferencedDocument() != null) {
 			xml += "<ram:ContractReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
-					+ "</ram:ContractReferencedDocument>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
+				+ "</ram:ContractReferencedDocument>";
 		}
 
 		// Additional Documents of XRechnung (Rechnungsbegruendende Unterlagen - BG-24 XRechnung)
@@ -258,33 +253,33 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			for (final FileAttachment f : trans.getAdditionalReferencedDocuments()) {
 				final String documentContent = new String(Base64.getEncoder().encodeToString(f.getData()));
 				xml += "<ram:AdditionalReferencedDocument>"
-						+ "<ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
-						+ "<ram:TypeCode>916</ram:TypeCode>"
-						+ "<ram:Name>" + f.getDescription() + "</ram:Name>"
-						+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
-						+ "filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
-						+ "</ram:AdditionalReferencedDocument>";
+					+ "<ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
+					+ "<ram:TypeCode>916</ram:TypeCode>"
+					+ "<ram:Name>" + f.getDescription() + "</ram:Name>"
+					+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
+					+ "filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
+					+ "</ram:AdditionalReferencedDocument>";
 			}
 		}
 
 		if (trans.getSpecifiedProcuringProjectID() != null) {
 			xml += "<ram:SpecifiedProcuringProject>"
-					+ "<ram:ID>"
-					+ XMLTools.encodeXML(trans.getSpecifiedProcuringProjectID()) + "</ram:ID>";
+				+ "<ram:ID>"
+				+ XMLTools.encodeXML(trans.getSpecifiedProcuringProjectID()) + "</ram:ID>";
 			if (trans.getSpecifiedProcuringProjectName() != null) {
 				xml += "<ram:Name >" + XMLTools.encodeXML(trans.getSpecifiedProcuringProjectName()) + "</ram:Name>";
 			}
 			xml += "</ram:SpecifiedProcuringProject>";
 		}
 		xml += "</ram:ApplicableHeaderTradeAgreement>"
-				+ "<ram:ApplicableHeaderTradeDelivery>";
-		IZUGFeRDExportableTradeParty deliveryAddress=this.trans.getDeliveryAddress();
+			+ "<ram:ApplicableHeaderTradeDelivery>";
+		IZUGFeRDExportableTradeParty deliveryAddress = this.trans.getDeliveryAddress();
 		if (deliveryAddress == null) {
 			deliveryAddress = this.trans.getRecipient();
 		}
 		xml += "<ram:ShipToTradeParty>" +
-				getTradePartyAsXML(deliveryAddress, false, true) +
-				"</ram:ShipToTradeParty>";
+			getTradePartyAsXML(deliveryAddress, false, true) +
+			"</ram:ShipToTradeParty>";
 /*
 		xml += "<ram:ActualDeliverySupplyChainEvent>"
 				+ "<ram:OccurrenceDateTime>";
@@ -298,21 +293,21 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		xml += "</ram:ActualDeliverySupplyChainEvent>\n"
 
  */
-				/*
-				 * + "<DeliveryNoteReferencedDocument>\n" +
-				 * "<IssueDateTime format=\"102\">20130603</IssueDateTime>\n" +
-				 * "<ID>2013-51112</ID>\n" +
-				 * "</DeliveryNoteReferencedDocument>\n"
-				 */
-				xml+= "</ram:ApplicableHeaderTradeDelivery>\n<ram:ApplicableHeaderTradeSettlement>"
-	//			+ "<ram:PaymentReference>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:PaymentReference>"
-				+ "<ram:OrderCurrencyCode>" + trans.getCurrency() + "</ram:OrderCurrencyCode>";
+		/*
+		 * + "<DeliveryNoteReferencedDocument>\n" +
+		 * "<IssueDateTime format=\"102\">20130603</IssueDateTime>\n" +
+		 * "<ID>2013-51112</ID>\n" +
+		 * "</DeliveryNoteReferencedDocument>\n"
+		 */
+		xml += "</ram:ApplicableHeaderTradeDelivery>\n<ram:ApplicableHeaderTradeSettlement>"
+			//			+ "<ram:PaymentReference>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:PaymentReference>"
+			+ "<ram:OrderCurrencyCode>" + trans.getCurrency() + "</ram:OrderCurrencyCode>";
 
 		if (trans.getTradeSettlementPayment() != null) {
 			for (final IZUGFeRDTradeSettlementPayment payment : trans.getTradeSettlementPayment()) {
 				if (payment != null) {
 					hasDueDate = true;
-				//	xml += payment.getSettlementXML();
+					//	xml += payment.getSettlementXML();
 				}
 			}
 		}
@@ -322,14 +317,14 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 					if (payment instanceof IZUGFeRDTradeSettlementPayment) {
 						hasDueDate = true;
 					}
-				//	xml += payment.getSettlementXML();
+					//	xml += payment.getSettlementXML();
 				}
 			}
 		}
 		if (trans.getDocumentCode() != null) {
-  		if ((trans.getDocumentCode().equals(CORRECTEDINVOICE))/*||(trans.getDocumentCode().equals (DocumentCodeTypeConstants.CREDITNOTE))*/) {
-  			hasDueDate = false;
-  		}
+			if ((trans.getDocumentCode().equals(CORRECTEDINVOICE))/*||(trans.getDocumentCode().equals (DocumentCodeTypeConstants.CREDITNOTE))*/) {
+				hasDueDate = false;
+			}
 		}
 
 		final Map<BigDecimal, VATAmount> VATPercentAmountMap = calc.getVATPercentAmountMap();
@@ -371,17 +366,17 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 
 
 					xml += " <ram:SpecifiedTradeAllowanceCharge>" +
-							"<ram:ChargeIndicator>" +
-							"<udt:Indicator>true</udt:Indicator>" +
-							"</ram:ChargeIndicator>" +
-							"<ram:ActualAmount>" + currencyFormat(calc.getChargesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
-							"<ram:Reason>" + XMLTools.encodeXML(calc.getChargeReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
-							"<ram:CategoryTradeTax>" +
-							"<ram:TypeCode>VAT</ram:TypeCode>" +
-							"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
-							"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
-							"</ram:CategoryTradeTax>" +
-							"</ram:SpecifiedTradeAllowanceCharge>";
+						"<ram:ChargeIndicator>" +
+						"<udt:Indicator>true</udt:Indicator>" +
+						"</ram:ChargeIndicator>" +
+						"<ram:ActualAmount>" + currencyFormat(calc.getChargesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
+						"<ram:Reason>" + XMLTools.encodeXML(calc.getChargeReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
+						"<ram:CategoryTradeTax>" +
+						"<ram:TypeCode>VAT</ram:TypeCode>" +
+						"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
+						"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
+						"</ram:CategoryTradeTax>" +
+						"</ram:SpecifiedTradeAllowanceCharge>";
 
 				}
 			}
@@ -392,17 +387,17 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			for (final BigDecimal currentTaxPercent : VATPercentAmountMap.keySet()) {
 				if (calc.getAllowancesForPercent(currentTaxPercent).compareTo(BigDecimal.ZERO) != 0) {
 					xml += "<ram:SpecifiedTradeAllowanceCharge>" +
-							"<ram:ChargeIndicator>" +
-							"<udt:Indicator>false</udt:Indicator>" +
-							"</ram:ChargeIndicator>" +
-							"<ram:ActualAmount>" + currencyFormat(calc.getAllowancesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
-							"<ram:Reason>" + XMLTools.encodeXML(calc.getAllowanceReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
-							"<ram:CategoryTradeTax>" +
-							"<ram:TypeCode>VAT</ram:TypeCode>" +
-							"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
-							"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
-							"</ram:CategoryTradeTax>" +
-							"</ram:SpecifiedTradeAllowanceCharge>	\n";
+						"<ram:ChargeIndicator>" +
+						"<udt:Indicator>false</udt:Indicator>" +
+						"</ram:ChargeIndicator>" +
+						"<ram:ActualAmount>" + currencyFormat(calc.getAllowancesForPercent(currentTaxPercent)) + "</ram:ActualAmount>" +
+						"<ram:Reason>" + XMLTools.encodeXML(calc.getAllowanceReasonForPercent(currentTaxPercent)) + "</ram:Reason>" +
+						"<ram:CategoryTradeTax>" +
+						"<ram:TypeCode>VAT</ram:TypeCode>" +
+						"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
+						"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
+						"</ram:CategoryTradeTax>" +
+						"</ram:SpecifiedTradeAllowanceCharge>	\n";
 				}
 			}
 		}
@@ -418,7 +413,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			if (trans.getTradeSettlement() != null) {
 				for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement()) {
 					if ((payment != null) && (payment instanceof IZUGFeRDTradeSettlementDebit)) {
-		//not in order-x				xml += payment.getPaymentXML();
+						//not in order-x				xml += payment.getPaymentXML();
 					}
 				}
 			}
@@ -434,40 +429,40 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		final String chargesTotalLine = "<ram:ChargeTotalAmount>" + currencyFormat(calc.getChargesForPercent(null)) + "</ram:ChargeTotalAmount>";
 
 		xml += "<ram:SpecifiedTradeSettlementHeaderMonetarySummation>"
-				+ "<ram:LineTotalAmount>" + currencyFormat(calc.getTotal()) + "</ram:LineTotalAmount>"
-				+ chargesTotalLine
-				+ allowanceTotalLine
-				+ "<ram:TaxBasisTotalAmount>" + currencyFormat(calc.getTaxBasis()) + "</ram:TaxBasisTotalAmount>"
-				// //
-				// currencyID=\"EUR\"
-				+ "<ram:TaxTotalAmount currencyID=\"" + trans.getCurrency() + "\">"
-				+ currencyFormat(calc.getGrandTotal().subtract(calc.getTaxBasis())) + "</ram:TaxTotalAmount>"
-				+ "<ram:GrandTotalAmount>" + currencyFormat(calc.getGrandTotal()) + "</ram:GrandTotalAmount>"
-				// //
-				// currencyID=\"EUR\"
-				//+ "<ram:TotalPrepaidAmount>" + currencyFormat(calc.getTotalPrepaid()) + "</ram:TotalPrepaidAmount>"
-				//+ "<ram:DuePayableAmount>" + currencyFormat(calc.getGrandTotal().subtract(calc.getTotalPrepaid())) + "</ram:DuePayableAmount>"
-				+ "</ram:SpecifiedTradeSettlementHeaderMonetarySummation>";
+			+ "<ram:LineTotalAmount>" + currencyFormat(calc.getTotal()) + "</ram:LineTotalAmount>"
+			+ chargesTotalLine
+			+ allowanceTotalLine
+			+ "<ram:TaxBasisTotalAmount>" + currencyFormat(calc.getTaxBasis()) + "</ram:TaxBasisTotalAmount>"
+			// //
+			// currencyID=\"EUR\"
+			+ "<ram:TaxTotalAmount currencyID=\"" + trans.getCurrency() + "\">"
+			+ currencyFormat(calc.getGrandTotal().subtract(calc.getTaxBasis())) + "</ram:TaxTotalAmount>"
+			+ "<ram:GrandTotalAmount>" + currencyFormat(calc.getGrandTotal()) + "</ram:GrandTotalAmount>"
+			// //
+			// currencyID=\"EUR\"
+			//+ "<ram:TotalPrepaidAmount>" + currencyFormat(calc.getTotalPrepaid()) + "</ram:TotalPrepaidAmount>"
+			//+ "<ram:DuePayableAmount>" + currencyFormat(calc.getGrandTotal().subtract(calc.getTotalPrepaid())) + "</ram:DuePayableAmount>"
+			+ "</ram:SpecifiedTradeSettlementHeaderMonetarySummation>";
 		if (trans.getInvoiceReferencedDocumentID() != null) {
 			xml += "<ram:InvoiceReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getInvoiceReferencedDocumentID()) + "</ram:IssuerAssignedID>";
+				+ "<ram:IssuerAssignedID>"
+				+ XMLTools.encodeXML(trans.getInvoiceReferencedDocumentID()) + "</ram:IssuerAssignedID>";
 			if (trans.getInvoiceReferencedIssueDate() != null) {
 				xml += "<ram:FormattedIssueDateTime>"
-						+ DATE.qdtFormat(trans.getInvoiceReferencedIssueDate())
-						+ "</ram:FormattedIssueDateTime>";
+					+ DATE.qdtFormat(trans.getInvoiceReferencedIssueDate())
+					+ "</ram:FormattedIssueDateTime>";
 			}
 			xml += "</ram:InvoiceReferencedDocument>";
 		}
 		if (trans.getInvoiceReferencedDocuments() != null) {
 			for (var doc : trans.getInvoiceReferencedDocuments()) {
 				xml += "<ram:InvoiceReferencedDocument>"
-						+ "<ram:IssuerAssignedID>"
-						+ XMLTools.encodeXML(doc.getIssuerAssignedID()) + "</ram:IssuerAssignedID>";
+					+ "<ram:IssuerAssignedID>"
+					+ XMLTools.encodeXML(doc.getIssuerAssignedID()) + "</ram:IssuerAssignedID>";
 				if (doc.getFormattedIssueDateTime() != null) {
 					xml += "<ram:FormattedIssueDateTime>"
-							+ DATE.qdtFormat(doc.getFormattedIssueDateTime())
-							+ "</ram:FormattedIssueDateTime>";
+						+ DATE.qdtFormat(doc.getFormattedIssueDateTime())
+						+ "</ram:FormattedIssueDateTime>";
 				}
 				xml += "</ram:InvoiceReferencedDocument>";
 			}
@@ -484,7 +479,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		// + " </IncludedSupplyChainTradeLineItem>\n";
 
 		xml += "</rsm:SupplyChainTradeTransaction>"
-				+ "</rsm:SCRDMCCBDACIOMessageStructure>";
+			+ "</rsm:SCRDMCCBDACIOMessageStructure>";
 
 		final byte[] zugferdRaw;
 		zugferdRaw = xml.getBytes(StandardCharsets.UTF_8);
@@ -519,7 +514,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			final String basisAmount = currencyFormat(calc.getGrandTotal());
 			paymentTermsXml += "<ram:BasisAmount currencyID=\"" + currency + "\">" + basisAmount + "</ram:BasisAmount>";
 			paymentTermsXml += "<ram:CalculationPercent>" + discountTerms.getCalculationPercentage().toString()
-					+ "</ram:CalculationPercent>";
+				+ "</ram:CalculationPercent>";
 
 			if (discountTerms.getBaseDate() != null) {
 				final Date baseDate = discountTerms.getBaseDate();
@@ -528,7 +523,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 				paymentTermsXml += "</ram:BasisDateTime>";
 
 				paymentTermsXml += "<ram:BasisPeriodMeasure unitCode=\"" + discountTerms.getBasePeriodUnitCode() + "\">"
-						+ discountTerms.getBasePeriodMeasure() + "</ram:BasisPeriodMeasure>";
+					+ discountTerms.getBasePeriodMeasure() + "</ram:BasisPeriodMeasure>";
 			}
 
 			paymentTermsXml += "</ram:ApplicableTradePaymentDiscountTerms>";

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
@@ -1,4 +1,3 @@
-
 /**
  * *********************************************************************
  * <p>
@@ -21,6 +20,14 @@
  */
 package org.mustangproject.ZUGFeRD;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import org.mustangproject.*;
+import org.mustangproject.ZUGFeRD.model.EventTimeCodeTypeConstants;
+
+import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -29,28 +36,6 @@ import java.nio.file.Files;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.TimeZone;
-
-import javax.xml.xpath.XPathExpressionException;
-
-import org.junit.FixMethodOrder;
-import org.junit.experimental.theories.FromDataPoints;
-import org.junit.runners.MethodSorters;
-import org.mustangproject.Allowance;
-import org.mustangproject.BankDetails;
-import org.mustangproject.CalculatedInvoice;
-import org.mustangproject.CashDiscount;
-import org.mustangproject.Charge;
-import org.mustangproject.Contact;
-import org.mustangproject.Invoice;
-import org.mustangproject.Item;
-import org.mustangproject.Product;
-import org.mustangproject.SchemedID;
-import org.mustangproject.TradeParty;
-import org.mustangproject.ZUGFeRD.model.EventTimeCodeTypeConstants;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DeSerializationTest extends ResourceCase {
@@ -326,9 +311,10 @@ public class DeSerializationTest extends ResourceCase {
 
 
 	}
+
 	public void testNulledAttachments() {
 
-		String json="{\n" +
+		String json = "{\n" +
 			"  \"number\": \"471102\",\n" +
 			"  \"currency\": \"EUR\",\n" +
 			"  \"issueDate\": \"2018-03-04T00:00:00.000+01:00\",\n" +
@@ -352,7 +338,7 @@ public class DeSerializationTest extends ResourceCase {
 			"    \"location\": \"Frankfurt\",\n" +
 			"    \"country\": \"DE\"\n" +
 			"  },\n" +
-			"\"additionalReferencedDocuments\":null,"+
+			"\"additionalReferencedDocuments\":null," +
 			"  \"zfitems\": [\n" +
 			"    {\n" +
 			"      \"price\": 9.9,\n" +
@@ -379,23 +365,40 @@ public class DeSerializationTest extends ResourceCase {
 			"  ]\n" +
 			"}\n";
 		ObjectMapper mapper = new ObjectMapper();
-		boolean exceptions=false;
+		boolean exceptions = false;
 		try {
 			Invoice newInvoiceFromJSON = mapper.readValue(json, Invoice.class);
 		} catch (JsonProcessingException e) {
-			exceptions=true;
+			exceptions = true;
 		}
 		assertFalse(exceptions);
 	}
 
 	public void testItemAllowances() {
 
-		String json="{\"number\":\"123\",\"currency\":\"EUR\",\"issueDate\":1738935176399,\"dueDate\":1738935176399,\"sender\":{\"name\":\"Test company\",\"zip\":\"55232\",\"street\":\"teststr\",\"location\":\"teststadt\",\"country\":\"DE\",\"taxID\":\"4711\",\"vatID\":\"DE0815\",\"vatid\":\"DE0815\"},\"recipient\":{\"name\":\"Franz Müller\",\"zip\":\"55232\",\"street\":\"teststr.12\",\"location\":\"Entenhausen\",\"country\":\"DE\",\"contact\":{\"name\":\"contact testname\",\"phone\":\"123456\",\"email\":\"contact.testemail@example.org\",\"fax\":\"0911623562\"}},\"zfitems\":[{\"price\":3.00,\"quantity\":1,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemAllowances\":[{\"totalAmount\":0.1,\"categoryCode\":\"S\"}],\"value\":3.00},{\"price\":3.00,\"quantity\":1,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemAllowances\":[{\"percent\":50,\"taxPercent\":0,\"categoryCode\":\"S\"}],\"value\":3.00},{\"price\":3.00,\"quantity\":2,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemCharges\":[{\"totalAmount\":1,\"reason\":\"AnotherReason\",\"reasonCode\":\"ABK\",\"categoryCode\":\"S\"}],\"value\":3.00},{\"price\":3.00,\"quantity\":1,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemAllowances\":[{\"totalAmount\":1,\"categoryCode\":\"S\"}],\"itemCharges\":[{\"totalAmount\":1,\"categoryCode\":\"S\"}],\"value\":3.00}],\"ownStreet\":\"teststr\",\"ownCountry\":\"DE\",\"zfcharges\":[{\"totalAmount\":1,\"taxPercent\":19,\"reason\":\"AReason\",\"reasonCode\":\"ABK\",\"categoryCode\":\"S\"}],\"ownLocation\":\"teststadt\",\"ownTaxID\":\"4711\",\"ownZIP\":\"55232\",\"ownVATID\":\"DE0815\",\"valid\":true}";
+		String json = "{\"number\":\"123\"," +
+			"\"currency\":\"EUR\"," +
+			"\"issueDate\":1738935176399," +
+			"\"dueDate\":1738935176399," +
+			"\"sender\":{\"name\":\"Test company\",\"zip\":\"55232\",\"street\":\"teststr\",\"location\":\"teststadt\",\"country\":\"DE\",\"taxID\":\"4711\",\"vatID\":\"DE0815\",\"vatid\":\"DE0815\"}," +
+			"\"recipient\":{\"name\":\"Franz Müller\",\"zip\":\"55232\",\"street\":\"teststr.12\",\"location\":\"Entenhausen\",\"country\":\"DE\",\"contact\":{\"name\":\"contact testname\",\"phone\":\"123456\",\"email\":\"contact.testemail@example.org\",\"fax\":\"0911623562\"}}," +
+			"\"zfitems\":[" +
+			"{\"price\":3.00,\"quantity\":1,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemAllowances\":[{\"totalAmount\":0.1,\"categoryCode\":\"S\"}],\"value\":3.00}," +
+			"{\"price\":3.00,\"quantity\":1,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemAllowances\":[{\"percent\":50,\"taxPercent\":0,\"categoryCode\":\"S\"}],\"value\":3.00}," +
+			"{\"price\":3.00,\"quantity\":2,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemCharges\":[{\"totalAmount\":1,\"reason\":\"AnotherReason\",\"reasonCode\":\"ABK\",\"categoryCode\":\"S\"}],\"value\":3.00}," +
+			"{\"price\":3.00,\"quantity\":1,\"basisQuantity\":1,\"product\":{\"unit\":\"C62\",\"name\":\"Testprodukt\",\"taxCategoryCode\":\"S\",\"vatpercent\":19,\"reverseCharge\":false,\"intraCommunitySupply\":false},\"itemAllowances\":[{\"totalAmount\":1,\"categoryCode\":\"S\"}],\"itemCharges\":[{\"totalAmount\":1,\"categoryCode\":\"S\"}],\"value\":3.00}]," +
+			"\"ownStreet\":\"teststr\",\"ownCountry\":\"DE\"," +
+			"\"zfcharges\":[" +
+			"{\"totalAmount\":1,\"taxPercent\":19,\"reason\":\"AReason\",\"reasonCode\":\"ABK\",\"categoryCode\":\"S\"}" +
+			"]," +
+			"\"ownLocation\":\"teststadt\",\"ownTaxID\":\"4711\",\"ownZIP\":\"55232\",\"ownVATID\":\"DE0815\",\"valid\":true}";
 		ObjectMapper mapper = new ObjectMapper();
 		try {
 			Invoice newInvoiceFromJSON = mapper.readValue(json, Invoice.class);
-			TransactionCalculator tc=new TransactionCalculator(newInvoiceFromJSON);
-			assertEquals(new BigDecimal("19.52"),tc.getGrandTotal());
+			//2.9 + 1.5 + 7 + 3 = 14.4
+			//document charge: 15.4
+			TransactionCalculator tc = new TransactionCalculator(newInvoiceFromJSON);
+			assertEquals(new BigDecimal("19.04"), tc.getGrandTotal());
 
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException(e);

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItemImpl.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItemImpl.java
@@ -1,24 +1,28 @@
-/** **********************************************************************
- *
+/**
+ * *********************************************************************
+ * <p>
  * Copyright 2018 Jochen Staerk
- *
+ * <p>
  * Use is subject to license terms.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0.
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
+ * <p>
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *********************************************************************** */
+ * <p>
+ * **********************************************************************
+ */
 package org.mustangproject.ZUGFeRD;
 
 import java.math.BigDecimal;
+import java.util.LinkedList;
+import java.util.List;
 
 public class IZUGFeRDExportableItemImpl implements IZUGFeRDExportableItem {
 	private IZUGFeRDExportableProduct product;
@@ -26,6 +30,7 @@ public class IZUGFeRDExportableItemImpl implements IZUGFeRDExportableItem {
 	private IZUGFeRDAllowanceCharge[] itemCharges;
 	private BigDecimal price;
 	private BigDecimal quantity;
+	private List<IZUGFeRDAllowanceCharge> appliedAllowances = new LinkedList<>();
 
 	@Override
 	public IZUGFeRDExportableProduct getProduct() {
@@ -75,5 +80,18 @@ public class IZUGFeRDExportableItemImpl implements IZUGFeRDExportableItem {
 	public IZUGFeRDExportableItemImpl setQuantity(BigDecimal quantity) {
 		this.quantity = quantity;
 		return this;
+	}
+
+	public IZUGFeRDExportableItemImpl addAllowanceCharge(IZUGFeRDAllowanceCharge allowanceCharges) {
+		this.appliedAllowances.add(allowanceCharges);
+		return this;
+	}
+
+	@Override
+	public IZUGFeRDAllowanceCharge[] getItemTotalAllowances() {
+		if (appliedAllowances.isEmpty()) {
+			return null;
+		}
+		return appliedAllowances.toArray(new IZUGFeRDAllowanceCharge[0]);
 	}
 }

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
@@ -1,4 +1,3 @@
-
 /**
  * *********************************************************************
  * <p>
@@ -21,20 +20,23 @@
  */
 package org.mustangproject.ZUGFeRD;
 
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.assertj.core.api.Assertions;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import org.mustangproject.Invoice;
+
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
-import org.junit.FixMethodOrder;
-import org.junit.runners.MethodSorters;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZF2Test extends MustangReaderTestCase {
@@ -309,5 +311,13 @@ public class ZF2Test extends MustangReaderTestCase {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
+	}
+
+	public void testDKV() throws XPathExpressionException, ParseException {
+		final ZUGFeRDImporter zi = new ZUGFeRDImporter("src/test/resources/AllowancesCharges.xml");
+		Invoice extractedInvoice = zi.extractInvoice();
+
+		TransactionCalculator calculator = new TransactionCalculator(extractedInvoice);
+		Assertions.assertThat(calculator.getDuePayable()).isEqualByComparingTo(new BigDecimal("2552.45"));
 	}
 }

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
@@ -264,7 +264,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		}
 		assertFalse(hasExceptions);
 		TransactionCalculator tc = new TransactionCalculator(invoice);
-		assertEquals(new BigDecimal("19.52"), tc.getGrandTotal());
+		assertEquals(new BigDecimal("18.33"), tc.getGrandTotal());
 	}
 
 	public void testBasisQuantityImport() {

--- a/library/src/test/resources/AllowancesCharges.xml
+++ b/library/src/test/resources/AllowancesCharges.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100">
+	<rsm:ExchangedDocumentContext>
+		<ram:GuidelineSpecifiedDocumentContextParameter>
+			<ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+		</ram:GuidelineSpecifiedDocumentContextParameter>
+	</rsm:ExchangedDocumentContext>
+	<rsm:ExchangedDocument>
+		<ram:ID>25/641123456/001</ram:ID>
+		<ram:TypeCode>380</ram:TypeCode>
+		<ram:IssueDateTime>
+			<udt:DateTimeString format="102">20250115</udt:DateTimeString>
+		</ram:IssueDateTime>
+		<ram:IncludedNote>
+			<ram:Content>SEPA direct debit</ram:Content>
+			<ram:SubjectCode>AAB</ram:SubjectCode>
+		</ram:IncludedNote>
+		<ram:IncludedNote>
+			<ram:Content>PAYMENTAMOUNT:107.51</ram:Content>
+			<ram:SubjectCode>PMD</ram:SubjectCode>
+		</ram:IncludedNote>
+		<ram:IncludedNote>
+			<ram:Content>PAYMENTCURRENCY:EUR</ram:Content>
+			<ram:SubjectCode>PMD</ram:SubjectCode>
+		</ram:IncludedNote>
+	</rsm:ExchangedDocument>
+	<rsm:SupplyChainTradeTransaction>
+		<ram:IncludedSupplyChainTradeLineItem>
+			<ram:AssociatedDocumentLineDocument>
+				<ram:LineID>1</ram:LineID>
+			</ram:AssociatedDocumentLineDocument>
+			<ram:SpecifiedTradeProduct>
+				<ram:SellerAssignedID>0038</ram:SellerAssignedID>
+				<ram:Name>SUPER PLUS</ram:Name>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>LeoID</ram:Description>
+					<ram:Value>704310.0106597948</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>Uhrzeit</ram:Description>
+					<ram:Value>19:46</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>Ort</ram:Description>
+					<ram:Value>VOJTANOV</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>Marke</ram:Description>
+					<ram:Value>ONO</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>Servicestelle</ram:Description>
+					<ram:Value>SS2498209</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>Lieferscheinnummer</ram:Description>
+					<ram:Value>0000442424</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:ApplicableProductCharacteristic>
+					<ram:Description>Kilometerstand</ram:Description>
+					<ram:Value>0000001</ram:Value>
+				</ram:ApplicableProductCharacteristic>
+				<ram:OriginTradeCountry>
+					<ram:ID>CZ</ram:ID>
+				</ram:OriginTradeCountry>
+			</ram:SpecifiedTradeProduct>
+			<ram:SpecifiedLineTradeAgreement>
+				<ram:NetPriceProductTradePrice>
+					<ram:ChargeAmount>2966.99</ram:ChargeAmount>
+					<ram:BasisQuantity unitCode="LTR">100.</ram:BasisQuantity>
+				</ram:NetPriceProductTradePrice>
+			</ram:SpecifiedLineTradeAgreement>
+			<ram:SpecifiedLineTradeDelivery>
+				<ram:BilledQuantity unitCode="LTR">69.01</ram:BilledQuantity>
+			</ram:SpecifiedLineTradeDelivery>
+			<ram:SpecifiedLineTradeSettlement>
+				<ram:ApplicableTradeTax>
+					<ram:TypeCode>VAT</ram:TypeCode>
+					<ram:CategoryCode>S</ram:CategoryCode>
+					<ram:RateApplicablePercent>21.00</ram:RateApplicablePercent>
+				</ram:ApplicableTradeTax>
+				<ram:BillingSpecifiedPeriod>
+					<ram:StartDateTime>
+						<udt:DateTimeString format="102">20250104</udt:DateTimeString>
+					</ram:StartDateTime>
+					<ram:EndDateTime>
+						<udt:DateTimeString format="102">20250104</udt:DateTimeString>
+					</ram:EndDateTime>
+				</ram:BillingSpecifiedPeriod>
+				<ram:SpecifiedTradeAllowanceCharge>
+					<ram:ChargeIndicator>
+						<udt:Indicator>true</udt:Indicator>
+					</ram:ChargeIndicator>
+					<ram:ActualAmount>61.94</ram:ActualAmount>
+					<ram:Reason>Fee</ram:Reason>
+				</ram:SpecifiedTradeAllowanceCharge>
+				<ram:SpecifiedTradeSettlementLineMonetarySummation>
+					<ram:LineTotalAmount>2109.46</ram:LineTotalAmount>
+				</ram:SpecifiedTradeSettlementLineMonetarySummation>
+				<ram:AdditionalReferencedDocument>
+					<ram:IssuerAssignedID>V-FW 2505</ram:IssuerAssignedID>
+					<ram:TypeCode>130</ram:TypeCode>
+					<ram:ReferenceTypeCode>ABZ</ram:ReferenceTypeCode>
+				</ram:AdditionalReferencedDocument>
+				<ram:ReceivableSpecifiedTradeAccountingAccount>
+					<ram:ID>1200</ram:ID>
+				</ram:ReceivableSpecifiedTradeAccountingAccount>
+			</ram:SpecifiedLineTradeSettlement>
+		</ram:IncludedSupplyChainTradeLineItem>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:SellerTradeParty>
+				<ram:ID>CZ123456789</ram:ID>
+				<ram:Name>Service GmbH + Co. KG</ram:Name>
+				<ram:DefinedTradeContact>
+					<ram:PersonName>Kundenberatung</ram:PersonName>
+					<ram:TelephoneUniversalCommunication>
+						<ram:CompleteNumber>0049 (2345) 5518-444</ram:CompleteNumber>
+					</ram:TelephoneUniversalCommunication>
+					<ram:EmailURIUniversalCommunication>
+						<ram:URIID>kundenberatung@service.com</ram:URIID>
+					</ram:EmailURIUniversalCommunication>
+				</ram:DefinedTradeContact>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>12345</ram:PostcodeCode>
+					<ram:LineOne>Baum-Allee 3</ram:LineOne>
+					<ram:CityName>Rabenburg</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+				<ram:SpecifiedTaxRegistration>
+					<ram:ID schemeID="VA">CZ2344566</ram:ID>
+				</ram:SpecifiedTaxRegistration>
+			</ram:SellerTradeParty>
+			<ram:BuyerTradeParty>
+				<ram:ID>666666</ram:ID>
+				<ram:Name>Name und Adresse geaendert</ram:Name>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>55555</ram:PostcodeCode>
+					<ram:LineOne>Forkstr. 9</ram:LineOne>
+					<ram:CityName>Stadt</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+			</ram:BuyerTradeParty>
+			<ram:AdditionalReferencedDocument>
+				<ram:IssuerAssignedID>25/123456789/001</ram:IssuerAssignedID>
+				<ram:TypeCode>130</ram:TypeCode>
+			</ram:AdditionalReferencedDocument>
+		</ram:ApplicableHeaderTradeAgreement>
+		<ram:ApplicableHeaderTradeDelivery/>
+		<ram:ApplicableHeaderTradeSettlement>
+			<ram:InvoiceCurrencyCode>CZK</ram:InvoiceCurrencyCode>
+			<ram:SpecifiedTradeSettlementPaymentMeans>
+				<ram:TypeCode>70</ram:TypeCode>
+				<ram:PayeePartyCreditorFinancialAccount>
+					<ram:IBANID>DE12345678987654321900</ram:IBANID>
+				</ram:PayeePartyCreditorFinancialAccount>
+			</ram:SpecifiedTradeSettlementPaymentMeans>
+			<ram:ApplicableTradeTax>
+				<ram:CalculatedAmount>442.99</ram:CalculatedAmount>
+				<ram:TypeCode>VAT</ram:TypeCode>
+				<ram:BasisAmount>2109.46</ram:BasisAmount>
+				<ram:CategoryCode>S</ram:CategoryCode>
+				<ram:RateApplicablePercent>21.00</ram:RateApplicablePercent>
+			</ram:ApplicableTradeTax>
+			<ram:SpecifiedTradePaymentTerms>
+				<ram:Description>27.01.2025 00:00:00</ram:Description>
+				<ram:DueDateDateTime>
+					<udt:DateTimeString format="102">20250127</udt:DateTimeString>
+				</ram:DueDateDateTime>
+			</ram:SpecifiedTradePaymentTerms>
+			<ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+				<ram:LineTotalAmount>2109.46</ram:LineTotalAmount>
+				<ram:TaxBasisTotalAmount>2109.46</ram:TaxBasisTotalAmount>
+				<ram:TaxTotalAmount currencyID="CZK">442.99</ram:TaxTotalAmount>
+				<ram:GrandTotalAmount>2552.45</ram:GrandTotalAmount>
+				<ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+				<ram:DuePayableAmount>2552.45</ram:DuePayableAmount>
+			</ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+		</ram:ApplicableHeaderTradeSettlement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
Wir hatten ein paar Problem bzgl der Allowances und Charges.
Die ZUGFeRD-Rechnungen der DKV interpretieren die anders als die Mustang-lib.
Ich habe da mal eine Version gebaut, die nahe an der Spezifikation ist und zwischen drei verschiedenen Allowances/Charges unterscheidet:
Auf Dokument-Ebene (0..n), auf Positionsebene (0...n) und auf Positionspreis-Ebene (0..1)
Ich habe dazu auch ein issue gefunden:
https://github.com/ZUGFeRD/mustangproject/issues/663
https://github.com/ZUGFeRD/mustangproject/issues/660

