### PR TITLE
Draft: Fix for #640 

### DIFF
--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -7,6 +7,8 @@ import org.mustangproject.ZUGFeRD.IAbsoluteValueProvider;
 import org.mustangproject.ZUGFeRD.IZUGFeRDAllowanceCharge;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
 
 /***
  * Absolute and relative charges for document and item level
@@ -59,11 +61,9 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	/***
 	 * sets the total amount to be changed to, e.g. if not specified via constructor
 	 * @param totalAmount 2 decimal money amount
-	 * @return fluid setter
 	 */
-	public Charge setTotalAmount(BigDecimal totalAmount) {
+	public void setTotalAmount(BigDecimal totalAmount) {
 		this.totalAmount = totalAmount;
-		return this;
 	}
 
 	/***
@@ -121,10 +121,10 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	
 	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
-		if (percent!=null) {
-			return currentItem.getValue().multiply(getPercent().divide(new BigDecimal(100)));
-		} else if(totalAmount != null) {
+		if (Objects.nonNull(totalAmount)) {
 			return totalAmount;
+	  } else if (Objects.nonNull(percent)) {
+			return currentItem.getValue().multiply(getPercent().divide(new BigDecimal(100), 2, RoundingMode.HALF_UP));
 		} else {
 			throw new RuntimeException("percent must be set");
 		}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -33,6 +33,13 @@ public interface IZUGFeRDAllowanceCharge {
 	BigDecimal getTotalAmount(IAbsoluteValueProvider trans);
 
 	/***
+	 * set the absolute amount
+	 *
+	 * @param totalAmount new total
+	 */
+	void setTotalAmount(BigDecimal totalAmount);
+
+	/***
 	 * returns a percentage, if relative abount, or null for absolute amounts
 	 * @return null or Percentage as Bigdecimal
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
@@ -32,14 +32,15 @@ import java.math.RoundingMode;
  */
 public class VATAmount {
 
+	private BigDecimal basis;
+	private BigDecimal calculated;
+	private BigDecimal applicablePercent;
 
-	protected BigDecimal basis, calculated, applicablePercent;
+	private String categoryCode;
 
-	protected String categoryCode;
+	private String vatExemptionReasonText;
 
-	protected String vatExemptionReasonText;
-
-	protected String dueDateTypeCode;
+	private String dueDateTypeCode;
 
 
 	public VATAmount(BigDecimal basis, String categoryCode) {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
@@ -42,18 +42,18 @@ public class VATAmount {
 	protected String dueDateTypeCode;
 
 
-	public VATAmount(BigDecimal basis, BigDecimal calculated, String categoryCode) {
+	public VATAmount(BigDecimal basis, String categoryCode) {
 		super();
 		this.basis = basis;
-		this.calculated = calculated;
+		this.calculated = BigDecimal.ZERO;
 		this.categoryCode = categoryCode;
 		this.dueDateTypeCode = null;
 	}
 
-	public VATAmount(BigDecimal basis, BigDecimal calculated, String categoryCode, String dueDateTypeCode) {
+	public VATAmount(BigDecimal basis, String categoryCode, String dueDateTypeCode) {
 		super();
 		this.basis = basis;
-		this.calculated = calculated;
+		this.calculated = BigDecimal.ZERO;
 		this.categoryCode = categoryCode;
 		this.dueDateTypeCode = dueDateTypeCode;
 	}
@@ -135,11 +135,11 @@ public class VATAmount {
 	}
 
 	public VATAmount add(VATAmount v) {
-		return new VATAmount(basis.add(v.getBasis()), calculated.add(v.getCalculated()), this.categoryCode, this.dueDateTypeCode).setVatExemptionReasonText(v.getVatExemptionReasonText());
+		return new VATAmount(basis.add(v.getBasis()), this.categoryCode, this.dueDateTypeCode).setVatExemptionReasonText(v.getVatExemptionReasonText());
 	}
 
 	public VATAmount subtract(VATAmount v) {
-		return new VATAmount(basis.subtract(v.getBasis()), calculated.subtract(v.getCalculated()), this.categoryCode, this.dueDateTypeCode).setVatExemptionReasonText(v.getVatExemptionReasonText());
+		return new VATAmount(basis.subtract(v.getBasis()), this.categoryCode, this.dueDateTypeCode).setVatExemptionReasonText(v.getVatExemptionReasonText());
 	}
 
 }

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -30,7 +30,6 @@ public class CalculationTest {
 
 		assertEquals(valueOf(100).stripTrailingZeros(), calculator.getPrice().stripTrailingZeros());
 		assertEquals(valueOf(1000).stripTrailingZeros(), calculator.getItemTotalNetAmount().stripTrailingZeros());
-		assertEquals(valueOf(160).stripTrailingZeros(), calculator.getItemTotalVATAmount().stripTrailingZeros());
 	}
 
 	@Test
@@ -49,7 +48,6 @@ public class CalculationTest {
 
 		assertEquals(valueOf(133.857).stripTrailingZeros(), calculator.getPrice().stripTrailingZeros());
 		assertEquals(valueOf(1606.28).stripTrailingZeros(), calculator.getItemTotalNetAmount().stripTrailingZeros());
-		assertEquals(valueOf(257.0048).stripTrailingZeros(), calculator.getItemTotalVATAmount().stripTrailingZeros());
 	}
 
 	@Test
@@ -69,7 +67,6 @@ public class CalculationTest {
 
 		assertEquals(valueOf(163.603).stripTrailingZeros(), calculator.getPrice().stripTrailingZeros());
 		assertEquals(valueOf(1963.24).stripTrailingZeros(), calculator.getItemTotalNetAmount().stripTrailingZeros());
-		assertEquals(valueOf(314.1184).stripTrailingZeros(), calculator.getItemTotalVATAmount().stripTrailingZeros());
 	}
 
 

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -37,7 +37,8 @@ public class CalculationTest {
 		//This test failed with previous implementation. By rounding the totalVATAmount to 2 decimal places the result became wrong
 		final IZUGFeRDExportableProduct product = new IZUGFeRDExportableProductImpl().setVatPercent(valueOf(16));
 		// 10 % discount on each item
-		final IZUGFeRDAllowanceCharge allowance = new IZUGFeRDAllowanceChargeImpl().setTotalAmount(valueOf(14.8730));
+		IZUGFeRDAllowanceCharge allowance = new IZUGFeRDAllowanceChargeImpl();
+		allowance.setTotalAmount(valueOf(14.8730));
 
 		final IZUGFeRDExportableItem currentItem = new IZUGFeRDExportableItemImpl().setPrice(valueOf(148.73))
 			.setQuantity(valueOf(12))
@@ -54,9 +55,11 @@ public class CalculationTest {
 	public void testLineCalculatorInclusiveAllowanceAndCharge() {
 		final IZUGFeRDExportableProduct product = new IZUGFeRDExportableProductImpl().setVatPercent(valueOf(16));
 		// 10 % discount on each item
-		final IZUGFeRDAllowanceCharge allowance = new IZUGFeRDAllowanceChargeImpl().setTotalAmount(valueOf(14.873));
+		IZUGFeRDAllowanceCharge allowance = new IZUGFeRDAllowanceChargeImpl();
+		allowance.setTotalAmount(valueOf(14.873));
 		// 20 % charge
-		final IZUGFeRDAllowanceCharge charge = new IZUGFeRDAllowanceChargeImpl().setTotalAmount(valueOf(29.746));
+		IZUGFeRDAllowanceCharge charge = new IZUGFeRDAllowanceChargeImpl();
+		allowance.setTotalAmount(valueOf(29.746));
 		final IZUGFeRDExportableItem currentItem = new IZUGFeRDExportableItemImpl().setPrice(valueOf(148.73))
 			.setQuantity(valueOf(12))
 			.setItemAllowances(new IZUGFeRDAllowanceCharge[]{allowance})

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ChargesOnDocumentLevelTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ChargesOnDocumentLevelTest.java
@@ -1,0 +1,79 @@
+package org.mustangproject.ZUGFeRD;
+
+import org.mustangproject.Charge;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.TradeParty;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.util.Date;
+
+public class ChargesOnDocumentLevelTest {
+
+	public static void main(String[] args) {
+		BigDecimal thePercent = new BigDecimal("10");
+		BigDecimal vat1       = new BigDecimal("19");
+		BigDecimal vat2       = new BigDecimal("7");
+
+		TradeParty recipient = new TradeParty("Franz Müller",
+																					"teststr.12",
+																					"55232",
+																					"Entenhausen",
+																					"DE").setEmail("info@mueller.com");
+		Invoice i = new Invoice().setDueDate(new Date())
+														 .setIssueDate(new Date())
+														 .setDeliveryDate(new Date())
+														 .setSender(new TradeParty("Test company",
+																											 "teststr",
+																											 "55232",
+																											 "teststadt",
+																											 "DE").addTaxID("DE4711")
+																														.addVATID("DE0815")
+																														.setContact(new org.mustangproject.Contact("Hans Test",
+																																																			 "+49123456789",
+																																																			 "test@example.org"))
+																														.addBankDetails(new org.mustangproject.BankDetails("DE12500105170648489890",
+																																																							 "COBADEFXXX"))
+																														.setEmail("info@example.org"))
+														 .setRecipient(recipient)
+														 .setReferenceNumber("991-01484-64")//leitweg-id
+														 .setNumber("123")
+														 .addItem(new Item(new Product("item 01",
+																													 "",
+																													 "C62",
+																													 vat1),
+																							 new BigDecimal("10.00"),
+																							 new BigDecimal("10.0")))
+														 .addItem(new Item(new Product("item 02",
+																													 "",
+																													 "C62",
+																													 vat2),
+																							 new BigDecimal("1.00"),
+																							 new BigDecimal("10.0")))
+														 .addCharge(new Charge().setPercent(thePercent)
+																										.setTaxPercent(vat1)
+																										.setReason("Teuerungszuschlag"))
+														 .addCharge(new Charge().setPercent(thePercent)
+																										.setTaxPercent(vat2)
+																										.setReason("Teuerungszuschlag"));
+
+		// Expected values
+
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("XRechnung"));
+		zf2p.generateXML(i);
+
+		try {
+			Files.write(new File("ChargesOnDocumentLevel.xml").toPath(),
+									zf2p.getXML());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}
+

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ChargesOnItemLevelTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ChargesOnItemLevelTest.java
@@ -1,0 +1,76 @@
+package org.mustangproject.ZUGFeRD;
+
+import org.mustangproject.Charge;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.TradeParty;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.util.Date;
+
+public class ChargesOnItemLevelTest {
+
+	public static void main(String[] args) {
+		BigDecimal thePercent = new BigDecimal("10");
+		BigDecimal vat1       = new BigDecimal("19");
+		BigDecimal vat2       = new BigDecimal("7");
+
+		Item item01 = new Item(new Product("item 01",
+																			 "",
+																			 "C62",
+																			 vat1),
+													 new BigDecimal("10.00"),
+													 new BigDecimal("10.0"));
+		Item item02 = new Item(new Product("item 02",
+																			"",
+																			"C62",
+																			vat2),
+													new BigDecimal("1.00"),
+													new BigDecimal("10.0"));
+		item02.addCharge(new Charge().setPercent(thePercent)
+																 .setTaxPercent(vat1)
+																 .setReason("Teuerungszuschlag"));
+
+			TradeParty recipient = new TradeParty("Franz Müller",
+																					"teststr.12",
+																					"55232",
+																					"Entenhausen",
+																					"DE").setEmail("info@mueller.com");
+		Invoice i = new Invoice().setDueDate(new Date())
+														 .setIssueDate(new Date())
+														 .setDeliveryDate(new Date())
+														 .setSender(new TradeParty("Test company",
+																											 "teststr",
+																											 "55232",
+																											 "teststadt",
+																											 "DE").addTaxID("DE4711")
+																														.addVATID("DE0815")
+																														.setContact(new org.mustangproject.Contact("Hans Test",
+																																																			 "+49123456789",
+																																																			 "test@example.org"))
+																														.addBankDetails(new org.mustangproject.BankDetails("DE12500105170648489890",
+																																																							 "COBADEFXXX"))
+																														.setEmail("info@example.org"))
+														 .setRecipient(recipient)
+														 .setReferenceNumber("991-01484-64")//leitweg-id
+														 .setNumber("123")
+														 .addItem(item01)
+														 .addItem(item02);
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("XRechnung"));
+		zf2p.generateXML(i);
+
+		try {
+			Files.write(new File("ChargesOnDocumentLevel.xml").toPath(),
+									zf2p.getXML());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}
+

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
@@ -42,6 +42,8 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DeSerializationTest extends ResourceCase {
 	public void testJackson() throws JsonProcessingException {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
@@ -57,9 +57,8 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 		return this;
 	}
 
-	public IZUGFeRDAllowanceChargeImpl setTotalAmount(BigDecimal totalAmount) {
+	public void setTotalAmount(BigDecimal totalAmount) {
 		this.totalAmount = totalAmount;
-		return this;
 	}
 
 	public IZUGFeRDAllowanceChargeImpl setReason(String reason) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 


### PR DESCRIPTION
ATM this PR is nothing more than a draft. It should be used a base for a discussion how to fix the issue. Also it needs further testing!

This PR improves the TransactionCalculator-class. The calculation inside the getVATPercentAmountMap-method is improved and stored as an instance variable to avoid the calculation of the valiues several times.