### PR TITLE
Fix potential resource leaks in core file processing classes

### DIFF
--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -307,12 +307,13 @@ public class Main {
 	// Plain Java
 	// based on https://mkyong.com/java/how-to-convert-inputstream-to-string-in-java/
 	private static String convertInputStreamToString(InputStream is) {
-		int DEFAULT_BUFFER_SIZE = 8192;
-		ByteArrayOutputStream result = new ByteArrayOutputStream();
-		byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-		int length;
-		try {
-			while ((length = is.read(buffer)) != -1) {
+		try (InputStream inputStream = is) {
+			int DEFAULT_BUFFER_SIZE = 8192;
+			ByteArrayOutputStream result = new ByteArrayOutputStream();
+			byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+			int length;
+
+			while ((length = inputStream.read(buffer)) != -1) {
 				result.write(buffer, 0, length);
 			}
 
@@ -320,11 +321,10 @@ public class Main {
 			return result.toString(StandardCharsets.UTF_8.name());
 		} catch (IOException e) {
 			e.printStackTrace();
+			return null;
+			// Java 10
+			// return result.toString(StandardCharsets.UTF_8);
 		}
-		return null;
-		// Java 10
-		// return result.toString(StandardCharsets.UTF_8);
-
 	}
 
 	/***

--- a/library/src/main/java/org/mustangproject/XMLTools.java
+++ b/library/src/main/java/org/mustangproject/XMLTools.java
@@ -220,7 +220,8 @@ public class XMLTools extends XMLWriter {
 	}
 
 	public static byte[] getBytesFromStream(InputStream fileinput) throws IOException {
-	  return IOUtils.toByteArray (fileinput);
+		// Stream closing responsibility is with the caller
+		return IOUtils.toByteArray(fileinput);
 	}
 
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
@@ -90,9 +90,10 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 
 	protected byte[] inputstreamToByteArray(InputStream fileInputStream) throws IOException  {
 		byte[] bytes = new byte[fileInputStream.available()];
-		DataInputStream dataInputStream = new DataInputStream(fileInputStream);
-		dataInputStream.readFully(bytes);
-		return bytes;
+		try (DataInputStream dataInputStream = new DataInputStream(fileInputStream)) {
+			dataInputStream.readFully(bytes);
+			return bytes;
+		}
 	}
 
 	/***

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -138,9 +138,9 @@ public class ZUGFeRDInvoiceImporter {
 					return;
 				}
 
-				final InputStream XMP = doc.getDocumentCatalog().getMetadata().exportXMPMetadata();
-
-				xmpString = new String(XMLTools.getBytesFromStream(XMP), StandardCharsets.UTF_8);
+				try (final InputStream XMP = doc.getDocumentCatalog().getMetadata().exportXMPMetadata()) {
+					xmpString = new String(XMLTools.getBytesFromStream(XMP), StandardCharsets.UTF_8);
+				}
 
 				final PDEmbeddedFilesNameTreeNode etn = names.getEmbeddedFiles();
 				if (etn == null) {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -131,8 +131,9 @@ public class ZUGFeRDVisualizer {
 
 	public String visualize(String xmlFilename, Language lang)
 		throws IOException, TransformerException, ParserConfigurationException {
-		FileInputStream fis = new FileInputStream(xmlFilename);
-		return visualize(fis, lang);
+		try (FileInputStream fis = new FileInputStream(xmlFilename)) {
+			return visualize(fis, lang);
+		}
 	}
 
 	public String visualize(InputStream inputXml, Language lang)
@@ -222,12 +223,14 @@ public class ZUGFeRDVisualizer {
 
 	protected String toFOP(String xmlFilename)
 		throws IOException, TransformerException, ParserConfigurationException {
-
-		FileInputStream fis = new FileInputStream(xmlFilename);
-		EStandard theStandard = findOutStandardFromRootNode(fis);
-		fis = new FileInputStream(xmlFilename);//rewind :-(
-
-		return toFOP(fis, theStandard);
+		EStandard theStandard;
+		try (FileInputStream fis = new FileInputStream(xmlFilename)) {
+			theStandard = findOutStandardFromRootNode(fis);
+		}
+		
+		try (FileInputStream fis = new FileInputStream(xmlFilename)) {
+			return toFOP(fis, theStandard);
+		}
 	}
 
 	protected String toFOP(InputStream is, EStandard theStandard)

--- a/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
@@ -301,6 +301,7 @@ public class ZUGFeRDValidator {
 		XMLWriter writer = new XMLWriter(sw, format);
 		try {
 			writer.write(document);
+			writer.close();
 		} catch (Exception e) {
 			LOGGER.error(e.getMessage());
 		}


### PR DESCRIPTION
**Main.java:** Proper closing of the InputStream in the method convertInputStreamToString
**ZUGFeRDExporterFromPDFA.java:** Closing of the DataInputStream
**ZUGFeRDInvoiceImporter.java:** Closing of the InputStream for XMP metadata
**ZUGFeRDValidator.java:** Explicit closing of the XMLWriter
**ZUGFeRDVisualizer.java:** Proper closing of the FileInputStream