### PR TITLE
Added XEE Protection features (that were missing according to Stackoverflow

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -260,12 +260,23 @@ public class ZUGFeRDInvoiceImporter {
 
 	private void setDocument() throws ParserConfigurationException, IOException, SAXException, ParseException {
 		final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		dbf.setNamespaceAware(true);
-		dbf.setExpandEntityReferences(false);
-		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		//REDHAT
+		//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
+		dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+		//OWASP
+		//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
 		dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		// Disable external DTDs as well
+		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+		dbf.setXIncludeAware(false);
+		dbf.setExpandEntityReferences(false);
+		dbf.setNamespaceAware(true);
 		final DocumentBuilder builder = dbf.newDocumentBuilder();
 		final ByteArrayInputStream is = new ByteArrayInputStream(rawXML);
 		///    is.skip(guessBOMSize(is));

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -102,12 +102,23 @@ public class ZUGFeRDVisualizer {
 		String cioSignature = "SCRDMCCBDACIOMessageStructure";
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		dbf.setNamespaceAware(true);
-		dbf.setExpandEntityReferences(false);
-		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		//REDHAT
+		//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
+		dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+		//OWASP
+		//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
 		dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		// Disable external DTDs as well
+		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+		dbf.setXIncludeAware(false);
+		dbf.setExpandEntityReferences(false);
+		dbf.setNamespaceAware(true);
 		try {
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document doc = db.parse(new InputSource(fis));

--- a/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
@@ -150,13 +150,23 @@ public class XMLValidator extends Validator {
 				 */
 
 				final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-				dbf.setNamespaceAware(true); // otherwise we can not act namespace independently, i.e. use
-				// document.getElementsByTagNameNS("*",...
-				dbf.setExpandEntityReferences(false);
-				dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+				//REDHAT
+				//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
+				dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+				dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+				dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+				//OWASP
+				//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
 				dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 				dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 				dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+				// Disable external DTDs as well
+				dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+				// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+				dbf.setXIncludeAware(false);
+				dbf.setExpandEntityReferences(false);
+				dbf.setNamespaceAware(true);
 
 				final DocumentBuilder db = dbf.newDocumentBuilder();
 				final InputSource is = new InputSource(new StringReader(zfXML));

--- a/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
@@ -143,12 +143,23 @@ public class ZUGFeRDValidator {
 					String xmlAsString = null;
 					try {
 						DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-						dbf.setNamespaceAware(true);
-						dbf.setExpandEntityReferences(false);
-						dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+						//REDHAT
+						//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
+						dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+						dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+						dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+						//OWASP
+						//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
 						dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 						dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
 						dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+						// Disable external DTDs as well
+						dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+						// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+						dbf.setXIncludeAware(false);
+						dbf.setExpandEntityReferences(false);
+						dbf.setNamespaceAware(true);
 						DocumentBuilder db = dbf.newDocumentBuilder();
 
 						content = XMLTools.removeBOM(content);


### PR DESCRIPTION
As outlined in this [comment](https://github.com/ZUGFeRD/mustangproject/issues/685#issuecomment-2687858642), there's even more features that should be set for XEE protection.

On the current master, there's quite a lot of failing tests, but having added these to the 2.16.4 tag and run the tests, nothing goes wrong so I would say they should be safe to add and overall improve security.

Also as said in the linked comment, including 
```
dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
```
might be a problem since I've personally seen some invoices that try to write their product description in HTML and include a html doctype declaration because of that.