### PR TITLE
Fix build/checks by removing some settings for Schema/Transformer.

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -371,9 +371,6 @@ public class ZUGFeRDVisualizer {
 			// Step 4: Setup JAXP using identity transformer
 			TransformerFactory factory = TransformerFactory.newInstance();
 			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			Transformer transformer = factory.newTransformer(); // identity transformer
 
 			// Step 5: Setup input and output for XSLT transformation

--- a/validator/src/main/java/org/mustangproject/validator/Validator.java
+++ b/validator/src/main/java/org/mustangproject/validator/Validator.java
@@ -61,10 +61,6 @@ public abstract class Validator {
 		Source xmlData = new StreamSource(new ByteArrayInputStream(xmlRawData));
 		SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 		try {
-			schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			schemaFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			schemaFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 			Schema schema = schemaFactory.newSchema(schemaFile);
 			javax.xml.validation.Validator validator = schema.newValidator();
 			validator.validate(xmlData);


### PR DESCRIPTION
Example from build after latest commit:
```
javax.xml.transform.TransformerConfigurationException: Unsupported TransformerFactory feature: http://apache.org/xml/features/disallow-doctype-decl
	at net.sf.saxon.jaxp.SaxonTransformerFactory.setFeature(SaxonTransformerFactory.java:552)
	at org.mustangproject.ZUGFeRD.ZUGFeRDVisualizer.toPDFfromFOP(ZUGFeRDVisualizer.java:374)
	at org.mustangproject.ZUGFeRD.ZUGFeRDVisualizer.toPDF(ZUGFeRDVisualizer.java:295)
	at org.mustangproject.ZUGFeRD.VisualizationTest.testPDFVisualizationCII(VisualizationTest.java:107)
```
```
[main] ERROR org.mustangproject.validator.ZUGFeRDValidator - Error 18: schema validation fails:org.xml.sax.SAXNotRecognizedException: Feature 'http://xml.org/sax/features/external-general-entities' is not recognized.
```
