### PR TITLE
Wrapping Message Text in Validation Result PDF

### DIFF
--- a/library/src/main/resources/stylesheets/result-pdf.xsl
+++ b/library/src/main/resources/stylesheets/result-pdf.xsl
@@ -276,7 +276,9 @@
                 <fo:block color="{$msg_color}"
                           margin="0mm"
                           padding="1mm">
-                    <xsl:value-of select="$msg_text"/>
+                    <xsl:call-template name="IntersperseWithZeroSpaces">
+                        <xsl:with-param name="str" select="$msg_text"/>
+                    </xsl:call-template>
                 </fo:block>
             </fo:table-cell>
         </fo:table-row>
@@ -349,4 +351,27 @@
             </xsl:choose>
         </xsl:for-each>
     </xsl:template>
+    <xsl:template name="IntersperseWithZeroSpaces">
+      <xsl:param name="str"/>
+      <xsl:variable name="spacechars">
+          &#x9;&#xA;
+          &#x2000;&#x2001;&#x2002;&#x2003;&#x2004;&#x2005;
+          &#x2006;&#x2007;&#x2008;&#x2009;&#x200A;&#x200B;
+      </xsl:variable>
+      <xsl:if test="string-length($str) &gt; 0">
+        <xsl:variable name="c1" select="substring($str, 1, 1)"/>
+        <xsl:variable name="c2" select="substring($str, 2, 1)"/>
+
+        <xsl:value-of select="$c1"/>
+        <xsl:if test="$c2 != '' and
+            not(contains($spacechars, $c1) or
+            contains($spacechars, $c2))">
+            <xsl:text>&#x200B;</xsl:text>
+        </xsl:if>
+
+        <xsl:call-template name="IntersperseWithZeroSpaces">
+          <xsl:with-param name="str" select="substring($str, 2)"/>
+        </xsl:call-template>
+      </xsl:if>
+    </xsl:template> 
 </xsl:stylesheet>


### PR DESCRIPTION
Problem:

If a Validation Result XML ([validationReport.txt](https://github.com/user-attachments/files/19905909/validationReport.txt)) is transformed to an PDF using ValidationLogVisualizer the output of the PDF is following:

![image-20250326-092836](https://github.com/user-attachments/assets/14b53f90-574f-4273-b01d-3b5adf7881e8)

Solution:

Changes in xlst-transformation file with help of "IntersperseWithZeroSpaces" to wrap the message and display all characters.