### PR TITLE
Ignore calculation errors when extracting xml from pdf.

### DIFF
--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -565,7 +565,9 @@ public class Main {
 		ensureFileNotExists(xmlName);
 
 		// All params are good! continue...
-		ZUGFeRDImporter zi = new ZUGFeRDImporter(pdfName);
+		ZUGFeRDImporter zi = new ZUGFeRDImporter();
+		zi.doIgnoreCalculationErrors();
+		zi.setPDFFilename(pdfName);
 		byte[] XMLContent = zi.getRawXML();
 		if (XMLContent == null) {
 			System.err.println("No ZUGFeRD XML found in PDF file");


### PR DESCRIPTION
With this change, the extract processs is quiet.

```
$ java -jar Mustang-CLI/target/Mustang-CLI-2.17.0-SNAPSHOT.jar --action extract --source *.pdf
Source PDF set to Rechnung_50006.1.pdf
ZUGFeRD XML (default: factur-x.xml):
Written to factur-x.xml
```