### PR TITLE
Add sevdesk signature to valid PDF creators

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
@@ -269,6 +269,7 @@ public class PDFValidator extends Validator {
 		final byte[] cibpdfbrewerSignature = "CIB pdf brewer".getBytes(StandardCharsets.UTF_8);
 		final byte[] lexofficeSignature = "lexoffice".getBytes(StandardCharsets.UTF_8);		
 		final byte[] s2IndustriesSignature = "s2industries.ZUGFeRD.PDF".getBytes(StandardCharsets.UTF_8); // https://github.com/stephanstapel/ZUGFeRD-csharp
+		final byte[] sevdeskSignature = "sevdesk".getBytes(StandardCharsets.UTF_8);
 
 		if (ByteArraySearcher.contains(fileContents, symtraxSignature)) {
 			Signature = "Symtrax";
@@ -290,6 +291,8 @@ public class PDFValidator extends Validator {
 			Signature = "Lexware office";
 		} else if (ByteArraySearcher.contains(fileContents, s2IndustriesSignature)) {
 			Signature = "ZUGFeRD.PDF-csharp";
+		} else if (ByteArraySearcher.contains(fileContents, sevdeskSignature)) {
+			Signature = "sevdesk";
 		}
 
 		context.setSignature(Signature);


### PR DESCRIPTION
Sevdesk can be used to create ZUGFeRD invoices. In order to get the sevdesk signature listed in the PDFvalidator I added it to the list of valid creators.