### PR TITLE
Skip PDNameTreeNodes if the names are null or empty

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -161,6 +161,9 @@ public class ZUGFeRDInvoiceImporter {
 					}
 					for (final PDNameTreeNode<PDComplexFileSpecification> node : kids) {
 						final Map<String, PDComplexFileSpecification> namesL = node.getNames();
+						if (namesL == null || namesL.isEmpty()) {
+							continue;
+						}
 						extractFiles(namesL);
 					}
 				}


### PR DESCRIPTION
We encountered a NullPointerException when processing certain PDFs. After investigating, we identified the root cause: node.getNames() can return null, which was not previously accounted for.

This PR adds a null check to safely handle this edge case.