### PR TITLE
Close resources after usage

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -126,8 +126,7 @@ public class ZUGFeRDInvoiceImporter {
 		if (Arrays.equals(pad, pdfSignature)) { // we have a pdf
 
 
-			try {
-				PDDocument doc = Loader.loadPDF(IOUtils.toByteArray(pdfStream));
+			try(PDDocument doc = Loader.loadPDF(IOUtils.toByteArray(pdfStream))) {
 				// PDDocumentInformation info = doc.getDocumentInformation();
 				final PDDocumentNameDictionary names = new PDDocumentNameDictionary(doc.getDocumentCatalog());
 				//start

--- a/validator/src/test/java/org/mustangproject/validator/ResourceCase.java
+++ b/validator/src/test/java/org/mustangproject/validator/ResourceCase.java
@@ -17,8 +17,7 @@ public class ResourceCase extends TestCase {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ResourceCase.class.getCanonicalName()); // log output is
 	
 	public static File getResourceAsFile(String resourcePath) {
-		try {
-			InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream(resourcePath);
+		try(InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream(resourcePath)) {
 			if (in == null) {
 				return null;
 			}
@@ -42,8 +41,7 @@ public class ResourceCase extends TestCase {
 	}
 
 	public static byte[] getResourceAsByteArray(String resourcePath) {
-		try {
-			InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream(resourcePath);
+		try(InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream(resourcePath)) {
 			if (in == null) {
 				return null;
 			}


### PR DESCRIPTION
`PDDocument` implements the `AutoClosable` interface and therefore can be closed automatically with the try-with-resources mechanism.

