### PR TITLE
fix: fix MethodNotFoundException when using jackson 2.19.2

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.1</version>
+            <version>2.19.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/fop -->
         <dependency>


### PR DESCRIPTION
Projects with jackson 2.19.2 XMLMapper throw exception MethodNotFoundException ParserMinimalBase.<init> 