### PR TITLE
ShipToTradeParty should not contain URIUniversalCommunication

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -219,7 +219,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		xml += "<ram:CountryID>" + XMLTools.encodeXML(party.getCountry())
 			+ "</ram:CountryID>"
 			+ "</ram:PostalTradeAddress>";
-		if (party.getUriUniversalCommunicationID() != null && party.getUriUniversalCommunicationIDScheme() != null) {
+		if (party.getUriUniversalCommunicationID() != null && party.getUriUniversalCommunicationIDScheme() != null && (!isShipToTradeParty)) {
 			xml += "<ram:URIUniversalCommunication>" +
 				"<ram:URIID schemeID=\"" + party.getUriUniversalCommunicationIDScheme() + "\">" +
 				XMLTools.encodeXML(party.getUriUniversalCommunicationID())
@@ -462,10 +462,8 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				}
 
 				xml += "<ram:Name>" + XMLTools.encodeXML(currentItem.getProduct().getName()) + "</ram:Name>";
-				if (currentItem.getProduct().getDescription() != null) {
-					xml += "<ram:Description>" +
-						XMLTools.encodeXML(currentItem.getProduct().getDescription()) +
-						"</ram:Description>";
+				if (currentItem.getProduct().getDescription() != null && !currentItem.getProduct().getDescription().isEmpty()) {
+					xml += "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription()) + "</ram:Description>";
 				}
 				if (currentItem.getProduct().getClassifications() != null) {
 					for (IDesignatedProductClassification classification : currentItem.getProduct().getClassifications()) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -106,6 +106,7 @@ public class XRTest extends TestCase {
 		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 			.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").setEmail("sender@example.com").addTaxID("DE4711").addVATID("DE0815").setContact(new Contact("Hans Test", "+49123456789", "test@example.org")).addBankDetails(new BankDetails("DE12500105170648489890", "COBADEFXXX").setAccountName("kontoInhaber")))
 			.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").setEmail("recipient@sample.org"))
+			.setDeliveryAddress(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").setEmail("recipient@sample.org"))
 			.addCashDiscount(new CashDiscount(new BigDecimal(2), 7))
 			.addCashDiscount(new CashDiscount(new BigDecimal(3), 14))
 			.setReferenceNumber("991-01484-64")//leitweg-id

--- a/validator/src/test/java/org/mustangproject/validator/LibraryTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/LibraryTest.java
@@ -177,6 +177,9 @@ public class LibraryTest extends ResourceCase {
 		assertThat(res).valueByXPath("count(//error)")
 				.asInt()
 				.isEqualTo(0);
+		assertThat(res).valueByXPath("count(//warning)")
+				.asInt()
+				.isEqualTo(0);
 		assertThat(res).valueByXPath("/validation/summary/@status")
 				.asString()
 				.isEqualTo("valid");// expect to be valid because XR notices are, well, only notices


### PR DESCRIPTION
When setting the delivery an address with a TradeParty containing an email via setDeliveryAddress(recipientAddress) the resulting XML contains a URIUniversalCommunication tag.
This triggers CII-SR-313: URIUniversalCommunication should not be present.

Enhanced a XRTest to set an DeliveryAddress including an email address.
Enhanced a Test to check for warning also, not only for errors.
Besides the expected warning
```<warning type="24" location="/*:CrossIndustryInvoice[namespace-uri()='urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100'][1]/*:SupplyChainTradeTransaction[namespace-uri()='urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100'][1]/*:ApplicableHeaderTradeDelivery[namespace-uri()='urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100'][1]" criterion="not(ram:ShipToTradeParty/ram:URIUniversalCommunication)">[CII-SR-313] - URIUniversalCommunication should not be present [ID CII-SR-313] from /xslt/en16931schematron/EN16931-CII-validation.xslt)</warning>```
there was another one
```<warning type="27" location="/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction[1]/ram:IncludedSupplyChainTradeLineItem[1]/ram:SpecifiedTradeProduct[1]/ram:Description[1]" criterion="false()">Document MUST not contain empty elements. [ID PEPPOL-EN16931-R008] from /xslt/XR_30/XRechnung-CII-validation.xslt)</warning>```
that needed a fix.