### PR TITLE
Treat schematron rule flag "information" as notice.

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
@@ -536,12 +536,15 @@ public class XMLValidator extends Validator {
 						}
 
 						ESeverity severity;
+						Node failNode = currentFailNode.getAttributes().getNamedItem("flag");
+						String failVal = failNode == null ? null : failNode.getNodeValue();
 						if (defaultSeverity == ESeverity.notice) {
 							severity = defaultSeverity;
-						} else if (currentFailNode.getAttributes().getNamedItem("flag") != null
-							&& "warning".equals(currentFailNode.getAttributes().getNamedItem("flag").getNodeValue())) {
+						} else if ("warning".equals(failVal)) {
 							// the XR issues warnings with flag=warning
 							severity = ESeverity.warning;
+						} else if ("information".equals(failVal)) {
+							severity = ESeverity.notice;
 						} else {
 							severity = ESeverity.error;
 						}

--- a/validator/src/test/java/org/mustangproject/validator/ZUGFeRDValidatorTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/ZUGFeRDValidatorTest.java
@@ -202,7 +202,7 @@ public class ZUGFeRDValidatorTest extends ResourceCase {
 
 		assertThat(res).valueByXPath("count(//notice)")
 			.asInt()
-			.isEqualTo(0);
+			.isEqualTo(1);
 		assertThat(res).valueByXPath("/validation/summary/@status")
 			.asString()
 			.isEqualTo("valid");// expect to be valid because XR notices are, well, only notices
@@ -216,14 +216,14 @@ public class ZUGFeRDValidatorTest extends ResourceCase {
 
 		assertThat(res).valueByXPath("count(//error)")
 			.asInt()
-			.isEqualTo(5);
+			.isEqualTo(4);
 		assertThat(res).valueByXPath("count(//warning)")
 			.asInt()
 			.isEqualTo(1);
 
 		assertThat(res).valueByXPath("count(//notice)")
 			.asInt()
-			.isEqualTo(0); // 12 notices RE XRechnung 3.0
+			.isEqualTo(1); // 12 notices RE XRechnung 3.0
 		assertThat(res).valueByXPath("/validation/summary/@status")
 			.asString()
 			.isEqualTo("invalid");// expect to be valid

--- a/validator/src/test/resources/validXRV30.xml
+++ b/validator/src/test/resources/validXRV30.xml
@@ -102,6 +102,32 @@
                 </ram:SpecifiedTradeSettlementLineMonetarySummation>
             </ram:SpecifiedLineTradeSettlement>
         </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>Zeitlose Diensleistung</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Zeitlose Diensleistung</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>0.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="XPP">1</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>7</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>0.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
         <ram:ApplicableHeaderTradeAgreement>
             <ram:BuyerReference>04011000-12345-03</ram:BuyerReference>
             <ram:SellerTradeParty>


### PR DESCRIPTION
XRechnung 3.0.3 Summer 2025 edition introduced a rule with flag="information", breaking the Mustangproject validator which doesn't expect such a flag value.

See
https://projekte.kosit.org/xrechnung/xrechnung-schematron/-/commit/06be5b2c75f79a5f5e2f5156a34117f60f1fe099

Explicitly mapping "information" to ESeverity.notice hopefully fixes this and any future additions of rules with flag="information".