### PR TITLE
Fixes issue 954

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -107,9 +107,23 @@ public class ZUGFeRDVisualizer {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		//REDHAT
 		//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
-		dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		try
+		{
+			dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		}
+		catch (IllegalArgumentException e)
+		{
+			LOGGER.warn("Property: \"Access external DTD\" not supported.");
+		}
+		try
+		{
+			dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		}
+		catch (IllegalArgumentException e)
+		{
+			LOGGER.warn("Property: \"Access external schema\" not supported.");
+		}
 
 		//OWASP
 		//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html


### PR DESCRIPTION
Additionally the code guards the two attributes XMLConstants.ACCESS_EXTERNAL_DTD and XMLConstants.ACCESS_EXTERNAL_SCHEMA with a try catch, as not all XML libraries seem to implement those.