### PR TITLE
Revert "Remove duplicate paymentTerms"

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -1012,6 +1012,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 		ArrayList<IZUGFeRDPaymentTerms> paymentTerms = new ArrayList<IZUGFeRDPaymentTerms>(Arrays.asList(trans.getExtendedPaymentTerms()));
 
+		IZUGFeRDPaymentTerms izpt= trans.getPaymentTerms();
+		if (izpt!=null) {
+			paymentTerms.add(izpt);
+		}
+
 		String paymentTermsXml = "";
 		if (paymentTerms.size() == 0) {
 			return "";


### PR DESCRIPTION
Reverts ZUGFeRD/mustangproject#963
did you run the tests before the PR? org.mustangproject.ZUGFeRD.ZF2EdgeTest.testEdgeExport(ZF2EdgeTest.java:361) seems to fail, maybe because of this change? We dont need them duplicated but for backward compatibility we should run those on the interface, not on the class (which may very well implement the interface)