### PR TITLE
add DeliveryNoteReferencedDocument for import and export

### DIFF
--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -68,6 +68,8 @@ public class Invoice implements IExportableTransaction {
 	protected String specifiedProcuringProjectID = null;
 	protected String specifiedProcuringProjectName = null;
 	protected String despatchAdviceReferencedDocumentID = null;
+	protected String deliveryNoteReferencedDocumentID = null;
+	protected Date deliveryNoteReferencedDocumentDate = null;
 	protected String vatDueDateTypeCode = null;
 	protected String creditorReferenceID; // required when direct debit is used.
 	private BigDecimal roundingAmount=null;
@@ -1070,6 +1072,28 @@ public class Invoice implements IExportableTransaction {
 
 	public Invoice setDespatchAdviceReferencedDocumentID(String despatchAdviceReferencedDocumentID) {
 		this.despatchAdviceReferencedDocumentID = despatchAdviceReferencedDocumentID;
+		return this;
+	}
+
+	@Override
+	public String getDeliveryNoteReferencedDocumentID() {
+		return deliveryNoteReferencedDocumentID;
+	}
+
+
+	public Invoice setDeliveryNoteReferencedDocumentID(String deliveryNoteReferencedDocumentID) {
+		this.deliveryNoteReferencedDocumentID = deliveryNoteReferencedDocumentID;
+		return this;
+	}
+
+	@Override
+	public Date getDeliveryNoteReferencedDocumentDate() {
+		return deliveryNoteReferencedDocumentDate;
+	}
+
+
+	public Invoice setDeliveryNoteReferencedDocumentDate(Date deliveryNoteReferencedDocumentDate) {
+		this.deliveryNoteReferencedDocumentDate = deliveryNoteReferencedDocumentDate;
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -562,6 +562,26 @@ public interface IExportableTransaction {
 		return null;
 	}
 
+	/**
+	 * get delivery note document ID
+	 * ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/IssuerAssignedID
+	 *
+	 * @return the ID of the delivery note document
+	 */
+	default String getDeliveryNoteReferencedDocumentID() {
+		return null;
+	}
+
+	/**
+	 * get delivery note document date
+	 * ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/FormattedIssueDateTime
+	 *
+	 * @return the date of the delivery note document
+	 */
+	default Date getDeliveryNoteReferencedDocumentDate() {
+		return null;
+	}
+
 	/***
 	 * additional text description
 	 *

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -676,12 +676,18 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				+ "<ram:OccurrenceDateTime>" + DATE.udtFormat(trans.getDeliveryDate()) + "</ram:OccurrenceDateTime>"
 				+ "</ram:ActualDeliverySupplyChainEvent>";
 		}
-		/*
-		 * + "<DeliveryNoteReferencedDocument>" +
-		 * "<IssueDateTime format=\"102\">20130603</IssueDateTime>" +
-		 * "<ID>2013-51112</ID>" +
-		 * "</DeliveryNoteReferencedDocument>"
-		 */
+
+		if (trans.getDeliveryNoteReferencedDocumentID() != null && !trans.getDeliveryNoteReferencedDocumentID().trim().isEmpty()) {
+			xml += "<ram:DeliveryNoteReferencedDocument>";
+			xml += "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getDeliveryNoteReferencedDocumentID()) + "</ram:IssuerAssignedID>";
+			if (trans.getDeliveryNoteReferencedDocumentDate() != null) {
+				final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
+				xml += "<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">"+XMLTools.encodeXML(dateFormat102.format(trans.getDeliveryNoteReferencedDocumentDate()))+"</qdt:DateTimeString></ram:FormattedIssueDateTime>";
+			}
+			xml += "</ram:DeliveryNoteReferencedDocument>";
+
+		}
+
 		if (trans.getDespatchAdviceReferencedDocumentID() != null && !trans.getDespatchAdviceReferencedDocumentID().trim().isEmpty()) {
 			xml += "<ram:DespatchAdviceReferencedDocument>";
 			xml += "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getDespatchAdviceReferencedDocumentID()) + "</ram:IssuerAssignedID>";

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -528,6 +528,8 @@ public class ZUGFeRDInvoiceImporter {
 		Date dueDate = null;
 		Date deliveryDate = null;
 		String despatchAdviceReferencedDocument = null;
+		String deliveryNoteReferencedDocumentID = null;
+		Date deliveryNoteReferencedDocumentDate = null;
 
 		for (int i = 0; i < ExchangedDocumentNodes.getLength(); i++) {
 			Node exchangedDocumentNode = ExchangedDocumentNodes.item(i);
@@ -678,6 +680,28 @@ public class ZUGFeRDInvoiceImporter {
 							if (despatchAdviceChilds.item(despatchAdviceChildIndex).getLocalName() != null
 								&& despatchAdviceChilds.item(despatchAdviceChildIndex).getLocalName().equals("IssuerAssignedID")) {
 								despatchAdviceReferencedDocument = XMLTools.trimOrNull(despatchAdviceChilds.item(despatchAdviceChildIndex));
+							}
+						}
+					}
+
+					if (headerTradeDeliveryChilds.item(deliveryChildIndex).getLocalName().equals("DeliveryNoteReferencedDocument")) {
+						NodeList deliveryNoteReferencedDocumentChilds = headerTradeDeliveryChilds.item(deliveryChildIndex).getChildNodes();
+						for (int deliveryNoteReferencedDocumentIndex = 0; deliveryNoteReferencedDocumentIndex < deliveryNoteReferencedDocumentChilds.getLength(); deliveryNoteReferencedDocumentIndex++) {
+							if (deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName() != null
+								&& deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName().equals("IssuerAssignedID")) {
+								deliveryNoteReferencedDocumentID = XMLTools.trimOrNull(deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex));
+							}
+
+							if ((deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName() != null)
+								&& (deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName().equals("FormattedIssueDateTime"))) {
+
+								NodeList FormattedIssueDateTimeChilds = deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getChildNodes();
+								for (int dateChildIndex = 0; dateChildIndex < FormattedIssueDateTimeChilds.getLength(); dateChildIndex++) {
+									if ((FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName() != null)
+										&& (FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName().equals("DateTimeString"))) {
+										deliveryNoteReferencedDocumentDate = XMLTools.tryDate(FormattedIssueDateTimeChilds.item(dateChildIndex));
+									}
+								}
 							}
 						}
 					}
@@ -1007,6 +1031,14 @@ public class ZUGFeRDInvoiceImporter {
 			if (!s.isEmpty()) {
 				zpp.setDespatchAdviceReferencedDocumentID(s);
 			}
+		}
+
+		if (deliveryNoteReferencedDocumentID != null) {
+			zpp.setDeliveryNoteReferencedDocumentID(deliveryNoteReferencedDocumentID);
+		}
+
+		if (deliveryNoteReferencedDocumentDate != null) {
+			zpp.setDeliveryNoteReferencedDocumentDate(deliveryNoteReferencedDocumentDate);
 		}
 
 		String invoiceReferencedDocumentID = extractString("//*[local-name()=\"InvoiceReferencedDocument\"]/*[local-name()=\"IssuerAssignedID\"]|//*[local-name()=\"BillingReference\"]/*[local-name()=\"InvoiceDocumentReference\"]/*[local-name()=\"ID\"]");

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
@@ -304,6 +304,16 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 		return "123";
 	}
 
+	@Override
+	public String getDeliveryNoteReferencedDocumentID() {
+		return "0815";
+	}
+
+	@Override
+	public Date getDeliveryNoteReferencedDocumentDate() {
+		return new GregorianCalendar(2016, Calendar.APRIL, 1).getTime();
+	}
+
 	/**
 	 * Create the test case
 	 *

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -851,6 +851,8 @@ public class ZF2PushTest extends TestCase {
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815").addBankDetails(new BankDetails("DE88200800000970375700", "COBADEFFXXX")))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0815"))
 				.setNumber(number).setDespatchAdviceReferencedDocumentID(despatchAdviceReferencedDocumentID)
+				.setDeliveryNoteReferencedDocumentID("0815")
+				.setDeliveryNoteReferencedDocumentDate(new SimpleDateFormat("dd.MM.yyyy").parse("01.04.2016"))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty)).setCreditNote();
@@ -860,6 +862,8 @@ public class ZF2PushTest extends TestCase {
 			ze.export(TARGET_CREDITNOTEPDF);
 		} catch (IOException e) {
 			fail("IOException should not be raised");
+		} catch (ParseException e) {
+			fail("ParseException should not be raised");
 		}
 
 		// now check the contents (like MustangReaderTest)
@@ -882,6 +886,8 @@ public class ZF2PushTest extends TestCase {
 			Invoice i = zii.extractInvoice();
 
 			assertEquals(despatchAdviceReferencedDocumentID, i.getDespatchAdviceReferencedDocumentID());
+			assertEquals("0815", i.getDeliveryNoteReferencedDocumentID());
+			assertEquals(new SimpleDateFormat("dd.MM.yyyy").parse("01.04.2016"), i.getDeliveryNoteReferencedDocumentDate());
 
 		} catch (XPathExpressionException e) {
 			fail("XPathExpressionException should not be raised");
@@ -912,6 +918,7 @@ public class ZF2PushTest extends TestCase {
 			.setBuyerOrderReferencedDocumentID("")
 			.setContractReferencedDocument("")
 			.setDespatchAdviceReferencedDocumentID("")
+			.setDeliveryNoteReferencedDocumentID("")
 			.setInvoiceReferencedDocumentID("");
 
 		zf2p.generateXML(i);
@@ -928,6 +935,7 @@ public class ZF2PushTest extends TestCase {
 			.setBuyerOrderReferencedDocumentID("  ")
 			.setContractReferencedDocument("   ")
 			.setDespatchAdviceReferencedDocumentID("    ")
+			.setDeliveryNoteReferencedDocumentID("    ")
 			.setInvoiceReferencedDocumentID("     ");
 
 		zf2p.generateXML(i);

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
@@ -894,6 +894,8 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		assertNull(invoice.getSellerOrderReferencedDocumentID());
 		assertNull(invoice.getDespatchAdviceReferencedDocumentID());
 		assertNull(invoice.getInvoiceReferencedDocumentID());
+		assertNull(invoice.getDeliveryNoteReferencedDocumentID());
+		assertNull(invoice.getDeliveryNoteReferencedDocumentDate());
 	}
 
 	@Test


### PR DESCRIPTION
one part of Issue #589 - also see Issue #253

I was not sure if I needed the additional xpath-Parsing in 'ZUGFeRDInvoiceImporter.java' which 'despatchAdviceReferencedDocument' does use. 

It does work without and all tests pass: `146 tests passed, 1 ignored`
