### PR TITLE
Concurrency problems in ZUGFeRDDateFormat

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDDateFormat.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDDateFormat.java
@@ -2,23 +2,24 @@ package org.mustangproject.ZUGFeRD;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.function.Supplier;
 
 import org.mustangproject.ZUGFeRD.model.DateTimeTypeConstants;
 
 public enum ZUGFeRDDateFormat {
 
-	MONTH_OF_YEAR(DateTimeTypeConstants.MONTH, new SimpleDateFormat("yyyyMM")),
-	WEEK_OF_YEAR(DateTimeTypeConstants.WEEK, new SimpleDateFormat("yyyyww")),
-	DATE(DateTimeTypeConstants.DATE, new SimpleDateFormat("yyyyMMdd"));
+	MONTH_OF_YEAR(DateTimeTypeConstants.MONTH, () -> new SimpleDateFormat("yyyyMM")),
+	WEEK_OF_YEAR(DateTimeTypeConstants.WEEK, () -> new SimpleDateFormat("yyyyww")),
+	DATE(DateTimeTypeConstants.DATE, () -> new SimpleDateFormat("yyyyMMdd"));
 
 	private String dateTimeType;
-	private SimpleDateFormat formatter;
+	private ThreadLocal<SimpleDateFormat> formatter;
 	private static final String QDT_FORMAT = "<qdt:DateTimeString format=\"%s\">%s</qdt:DateTimeString>";
 	private static final String UDT_FORMAT = "<udt:DateTimeString format=\"%s\">%s</udt:DateTimeString>";
 
-	private ZUGFeRDDateFormat(String dateTimeType, SimpleDateFormat formatter) {
+	private ZUGFeRDDateFormat(String dateTimeType, Supplier<SimpleDateFormat> formatter) {
 		this.dateTimeType = dateTimeType;
-		this.formatter = formatter;
+		this.formatter = ThreadLocal.withInitial(formatter);
 	}
 
 	public String getDateTimeType() {
@@ -26,7 +27,7 @@ public enum ZUGFeRDDateFormat {
 	}
 
 	public SimpleDateFormat getFormatter() {
-		return formatter;
+		return formatter.get();
 	}
 	
 	public String simpleFormat(Date date){


### PR DESCRIPTION
ZUGFeRDDateFormat uses SimpleDateFormat which is not thread-safe. This results in problems (e.g. wrong date strings) when generating multiple invoices in the same JVM in different threads.

Recommended solution is to replace SimpleDateFormat by the thread-safe DateTimeFormatter. 
To keep the public method ZUGFeRDDateFormat#getFormatter intact I rather chose keeping SimpleDateFormat instances in a ThreadLocal wrapper.