### PR TITLE
Fix for #536: Support for BT-18

### DIFF
--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -55,6 +55,7 @@ public class Invoice implements IExportableTransaction {
 	protected Date detailedDeliveryDateStart = null;
 	protected Date detailedDeliveryPeriodEnd = null;
 	protected IReferencedDocument tenderReference = null;
+	protected IReferencedDocument objectIdentifierReference = null;
 
 	protected ArrayList<IZUGFeRDAllowanceCharge> Allowances = new ArrayList<>(),
 		Charges = new ArrayList<>(), LogisticsServiceCharges = new ArrayList<>();
@@ -172,6 +173,28 @@ public class Invoice implements IExportableTransaction {
 	public Invoice setTenderReferencedDocument(String ID) {
 		ReferencedDocument dr=new ReferencedDocument(ID);
 		setTenderReferencedDocument(dr);
+		return this;
+	}
+
+
+
+	/** BT-18 */
+	@Override
+	public IReferencedDocument getObjectIdentifierReferencedDocument() {
+		return objectIdentifierReference;
+	}
+
+
+	/** BT-18 */
+	public Invoice setObjectIdentifierReferencedDocument(ReferencedDocument dr) {
+		dr.setTypeCode("130");//50 is fixed for tender documents
+		objectIdentifierReference=dr;
+		return this;
+	}
+
+	public Invoice setObjectIdentifierReferencedDocument(String id) {
+		ReferencedDocument dr=new ReferencedDocument(id);
+		setObjectIdentifierReferencedDocument(dr);
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -225,6 +225,15 @@ public interface IExportableTransaction {
 	}
 
 	/**
+	 * BT-18 Invoiced Object Identifier
+	 *
+	 * @return mandatory ID, optional Date
+	 */
+	default IReferencedDocument getObjectIdentifierReferencedDocument() {
+		return null;
+	}
+
+	/**
 	 * own name
 	 *
 	 * @return the sender's organisation name

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -645,17 +645,22 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "</ram:AdditionalReferencedDocument>";
 			}
 		}
-
-		if(trans.getTenderReferencedDocument() != null){
+		if (trans.getObjectIdentifierReferencedDocument() != null) {
+			xml += "<ram:AdditionalReferencedDocument>"
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getObjectIdentifierReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "<ram:TypeCode>130</ram:TypeCode>";
+			if (trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime()!=null) {
+				xml += "<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>";
+			}
+			xml += "</ram:AdditionalReferencedDocument>";
+		}
+		if (trans.getTenderReferencedDocument() != null){
 			xml += "<ram:AdditionalReferencedDocument>"
 				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getTenderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
-				+ "<ram:TypeCode>" + 50 + "</ram:TypeCode>";
+				+ "<ram:TypeCode>50</ram:TypeCode>";
 			if (trans.getTenderReferencedDocument().getFormattedIssueDateTime()!=null) {
-				final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-				xml += "<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">"+XMLTools.encodeXML(dateFormat102.format(trans.getTenderReferencedDocument().getFormattedIssueDateTime()))+"</qdt:DateTimeString></ram:FormattedIssueDateTime>";
+				xml += "<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getTenderReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>";
 			}
-
-
 			xml += "</ram:AdditionalReferencedDocument>";
 		}
 		if (trans.getSpecifiedProcuringProjectID() != null) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
@@ -176,6 +176,38 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 		};
 	}
 
+
+	@Override
+	public IReferencedDocument getObjectIdentifierReferencedDocument() {
+		return new IReferencedDocument() {
+			@Override
+			public String getIssuerAssignedID() {
+				return "gPogKLtac0";
+			}
+
+			@Override
+			public String getTypeCode() {
+				return "130";
+			}
+
+			@Override
+			public String getReferenceTypeCode() {
+				return "";
+			}
+
+			@Override
+			public Date getFormattedIssueDateTime() {
+				SimpleDateFormat sdf=new SimpleDateFormat("YYYY-mm-dd");
+				try {
+					return sdf.parse("2026-01-26");
+				} catch (ParseException e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+		};
+	}
+
 	@Override
 	public String getOwnLocation() {
 		return "Stadthausen";


### PR DESCRIPTION
Support for BT-18 as requested in XRechnung based on the implementation of BT-17 which is technically equal.


( fixes #536 )