### PR TITLE
Fix for #1020: LineCalculator.getItemTotalGrossAmount() returns itemTotalNetAmount

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
@@ -101,9 +101,7 @@ public class LineCalculator {
 		return itemTotalVATAmount;
 	}
 
-	public BigDecimal getItemTotalGrossAmount() {
-		return itemTotalNetAmount;
-	}
+	public BigDecimal getItemTotalGrossAmount() { return itemTotalNetAmount.add(itemTotalVATAmount); }
 
 	public BigDecimal getPriceGross() {
 		return priceGross;

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -41,6 +41,7 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(valueOf(100).stripTrailingZeros(), calculator.getPrice().stripTrailingZeros());
 		assertEquals(valueOf(1000).stripTrailingZeros(), calculator.getItemTotalNetAmount().stripTrailingZeros());
 		assertEquals(valueOf(160).stripTrailingZeros(), calculator.getItemTotalVATAmount().stripTrailingZeros());
+		assertEquals(valueOf(1160).stripTrailingZeros(), calculator.getItemTotalGrossAmount().stripTrailingZeros());
 	}
 
 	@Test


### PR DESCRIPTION
The implementation of the LineCalculator#getItemTotalNetAmount is the same as LineCalculator#getItemTotalGrossAmount.
Fixed LineCalculator#getItemTotalGrossAmount to return the net amount + vat amount and added a test case to CalculationTest.

( fixes #1020 )