### PR TITLE
Fix percentage-based allowance/charge calculations (EN16931 compliance)

### DIFF
--- a/library/src/main/java/org/mustangproject/Allowance.java
+++ b/library/src/main/java/org/mustangproject/Allowance.java
@@ -38,7 +38,7 @@ public class Allowance extends Charge {
 		if(totalAmount != null) {
 			return totalAmount;
 		} else if (percent!=null) {
-			BigDecimal singlePrice=currentItem.getValue().multiply(BigDecimal.ONE.subtract(getPercent().divide(new BigDecimal(100))));
+			BigDecimal singlePrice=currentItem.getValue().multiply(BigDecimal.ONE.subtract(getPercent().divide(new BigDecimal(100), 18, RoundingMode.HALF_UP)));
 			BigDecimal singlePriceDiff=currentItem.getValue().subtract(singlePrice);
 			return singlePriceDiff.multiply(currentItem.getQuantity());
 		} else {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
@@ -22,6 +22,7 @@ package org.mustangproject.ZUGFeRD;
 
 import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
@@ -96,16 +97,27 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 				xml += "<ram:BuyerAssignedID>"
 						+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>";
 			}
+			// Product-level (GrossPrice / product section): ActualAmount must be per-unit (BT-147)
+			final IZUGFeRDExportableItem itemForProduct = currentItem;
+			IAbsoluteValueProvider perUnitProvider = new IAbsoluteValueProvider() {
+				@Override
+				public BigDecimal getValue() {
+					return itemForProduct.getPrice();
+				}
+				@Override
+				public BigDecimal getQuantity() {
+					return BigDecimal.ONE;
+				}
+			};
 			String allowanceChargeStr = "";
 			if (currentItem.getItemAllowances() != null) {
 				for (final IZUGFeRDAllowanceCharge allowance : currentItem.getItemAllowances()) {
-					allowanceChargeStr += getAllowanceChargeStr(allowance, currentItem);
+					allowanceChargeStr += getAllowanceChargeStr(allowance, perUnitProvider);
 				}
 			}
 			if (currentItem.getItemCharges() != null) {
 				for (final IZUGFeRDAllowanceCharge charge : currentItem.getItemCharges()) {
-					allowanceChargeStr += getAllowanceChargeStr(charge, currentItem);
-
+					allowanceChargeStr += getAllowanceChargeStr(charge, perUnitProvider);
 				}
 			}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
@@ -21,31 +21,47 @@ public class LineCalculator {
 	protected BigDecimal allowanceItemTotal = BigDecimal.ZERO;
 
 	public LineCalculator(IZUGFeRDExportableItem currentItem) {
+		// Compute basisQuantity first so it can be used for item-level allowance/charge context
+		BigDecimal basisQuantity = currentItem.getBasisQuantity().compareTo(BigDecimal.ZERO) == 0
+			? BigDecimal.ONE.setScale(4)
+			: currentItem.getBasisQuantity();
+
+		// Provider for item-level: getValue() returns price/basisQty so percentage
+		// allowances compute against the actual line amount (qty * price / basisQty),
+		// not the raw (qty * price). No effect on absolute amounts.
+		IAbsoluteValueProvider itemBasisProvider = new IAbsoluteValueProvider() {
+			@Override
+			public BigDecimal getValue() {
+				return currentItem.getPrice().divide(basisQuantity, 18, RoundingMode.HALF_UP);
+			}
+			@Override
+			public BigDecimal getQuantity() {
+				return currentItem.getQuantity();
+			}
+		};
 
 		if (currentItem.getItemAllowances() != null) {
 			for (IZUGFeRDAllowanceCharge allowance : currentItem.getItemAllowances()) {
-				BigDecimal singleAllowance=allowance.getTotalAmount(currentItem);
+				BigDecimal singleAllowance = allowance.getTotalAmount(itemBasisProvider);
 				addItemAllowance(singleAllowance);
 				addAllowanceItemTotal(singleAllowance);
-
 			}
 		}
 		if (currentItem.getItemCharges() != null) {
 			for (IZUGFeRDAllowanceCharge charge : currentItem.getItemCharges()) {
-				BigDecimal singleCharge=charge.getTotalAmount(currentItem);
+				BigDecimal singleCharge = charge.getTotalAmount(itemBasisProvider);
 				addItemCharge(singleCharge);
 				subtractAllowanceItemTotal(singleCharge);
-
 			}
 		}
 		if (currentItem.getItemTotalAllowances() != null) {
 			for (final IZUGFeRDAllowanceCharge itemTotalAllowance : currentItem.getItemTotalAllowances()) {
-				addAllowanceItemTotal(itemTotalAllowance.getTotalAmount(currentItem));
+				addAllowanceItemTotal(itemTotalAllowance.getTotalAmount(itemBasisProvider));
 			}
 		}
-		
+
 		BigDecimal vatPercent = null;
-		if (currentItem.getProduct()!=null) {
+		if (currentItem.getProduct() != null) {
 			vatPercent = currentItem.getProduct().getVATPercent();
 		}
 		if (vatPercent == null) {
@@ -53,40 +69,48 @@ public class LineCalculator {
 		}
 		BigDecimal multiplicator = vatPercent.divide(BigDecimal.valueOf(100));
 
-		BigDecimal quantity=BigDecimal.ZERO;
-		if ((currentItem!=null)&&(currentItem.getQuantity()!=null)) {
-			quantity=currentItem.getQuantity();
+		BigDecimal quantity = BigDecimal.ZERO;
+		if ((currentItem != null) && (currentItem.getQuantity() != null)) {
+			quantity = currentItem.getQuantity();
 		}
 
-		price=currentItem.getPrice();
-		priceGross=price;
-//		price=price.subtract(itemAllowance).add(itemCharge);
-//		BigDecimal delta=charge.subtract(allowanceItemTotal).subtract(allowance);
-//		delta=delta.divide(currentItem.getQuantity(), 18, RoundingMode.HALF_UP);
+		price = currentItem.getPrice();
+		priceGross = price;
 
-		BigDecimal delta=BigDecimal.ZERO;
-		if(currentItem.getProduct()!=null){
-			if (currentItem.getProduct().getAllowances()!=null) {
-				for (IZUGFeRDAllowanceCharge ccaf:currentItem.getProduct().getAllowances()) {
-					delta=delta.subtract(ccaf.getTotalAmount(currentItem));
+		// Provider for product-level: getQuantity() returns ONE because product
+		// allowances adjust the per-unit price, not the line total.
+		// No effect on absolute amounts.
+		IAbsoluteValueProvider perUnitProvider = new IAbsoluteValueProvider() {
+			@Override
+			public BigDecimal getValue() {
+				return currentItem.getPrice();
+			}
+			@Override
+			public BigDecimal getQuantity() {
+				return BigDecimal.ONE;
+			}
+		};
+
+		BigDecimal delta = BigDecimal.ZERO;
+		if (currentItem.getProduct() != null) {
+			if (currentItem.getProduct().getAllowances() != null) {
+				for (IZUGFeRDAllowanceCharge ccaf : currentItem.getProduct().getAllowances()) {
+					delta = delta.subtract(ccaf.getTotalAmount(perUnitProvider));
 				}
 			}
-			if (currentItem.getProduct().getCharges()!=null) {
+			if (currentItem.getProduct().getCharges() != null) {
 				for (IZUGFeRDAllowanceCharge ccaf : currentItem.getProduct().getCharges()) {
-					delta = delta.add(ccaf.getTotalAmount(currentItem));
+					delta = delta.add(ccaf.getTotalAmount(perUnitProvider));
 				}
 			}
 		}
 
-		price=price.add(delta);
-		// Division/Zero occurred here.
-		// Used the setScale only because that's also done in getBasisQuantity
-		BigDecimal basisQuantity = currentItem.getBasisQuantity().compareTo(BigDecimal.ZERO) == 0
-			? BigDecimal.ONE.setScale(4)
-			: currentItem.getBasisQuantity();
+		price = price.add(delta);
 		itemTotalNetAmount = quantity.multiply(price).divide(basisQuantity, 18, RoundingMode.HALF_UP)
-			.add(lineCharge).subtract(lineAllowance).subtract(allowanceItemTotal.setScale(2, RoundingMode.HALF_UP)).setScale(2, RoundingMode.HALF_UP);
-		itemTotalVATAmount = itemTotalNetAmount.multiply(multiplicator);//.setScale(2, RoundingMode.HALF_UP);
+			.add(lineCharge).subtract(lineAllowance)
+			.subtract(allowanceItemTotal.setScale(2, RoundingMode.HALF_UP))
+			.setScale(2, RoundingMode.HALF_UP);
+		itemTotalVATAmount = itemTotalNetAmount.multiply(multiplicator);
 	}
 
 	public BigDecimal getPrice() {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
@@ -24,6 +24,7 @@ import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
 import static org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants.CORRECTEDINVOICE;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Base64;
@@ -124,16 +125,27 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 				xml += "<ram:BuyerAssignedID>"
 						+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>";
 			}
+			// Product-level (GrossPriceProductTradePrice): ActualAmount must be per-unit (BT-147)
+			final IZUGFeRDExportableItem itemForProduct = currentItem;
+			IAbsoluteValueProvider perUnitProvider = new IAbsoluteValueProvider() {
+				@Override
+				public BigDecimal getValue() {
+					return itemForProduct.getPrice();
+				}
+				@Override
+				public BigDecimal getQuantity() {
+					return BigDecimal.ONE;
+				}
+			};
 			String allowanceChargeStr = "";
 			if (currentItem.getItemAllowances() != null) {
 				for (final IZUGFeRDAllowanceCharge allowance : currentItem.getItemAllowances()) {
-					allowanceChargeStr += getAllowanceChargeStr(allowance, currentItem);
+					allowanceChargeStr += getAllowanceChargeStr(allowance, perUnitProvider);
 				}
 			}
 			if (currentItem.getItemCharges() != null) {
 				for (final IZUGFeRDAllowanceCharge charge : currentItem.getItemCharges()) {
-					allowanceChargeStr += getAllowanceChargeStr(charge, currentItem);
-
+					allowanceChargeStr += getAllowanceChargeStr(charge, perUnitProvider);
 				}
 			}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -306,7 +306,8 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		String chargeIndicator = "false";
 		if ((allowance.getPercent() != null) && (profile == Profiles.getByName("Extended"))) {
 			percentage = "<ram:CalculationPercent>" + vatFormat(allowance.getPercent()) + "</ram:CalculationPercent>";
-			percentage += "<ram:BasisAmount>" + currencyFormat(item.getValue()) + "</ram:BasisAmount>";
+			// BT-137/BT-142: BasisAmount = the value the percentage is applied to = line subtotal (price/basisQty)*qty
+			percentage += "<ram:BasisAmount>" + currencyFormat(item.getValue().multiply(item.getQuantity())) + "</ram:BasisAmount>";
 		}
 		if (allowance.isCharge()) {
 			chargeIndicator = "true";

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -26,6 +26,7 @@ import static org.mustangproject.ZUGFeRD.model.TaxCategoryCodeTypeConstants.CATE
 import java.io.IOException;
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -270,7 +271,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		String chargeIndicator = "false";
 		if ((allowance.getPercent() != null) && (profile == Profiles.getByName("Extended"))) {
 			percentage = "<ram:CalculationPercent>" + vatFormat(allowance.getPercent()) + "</ram:CalculationPercent>";
-			percentage += "<ram:BasisAmount>" + item.getValue() + "</ram:BasisAmount>";
+			percentage += "<ram:BasisAmount>" + currencyFormat(item.getValue()) + "</ram:BasisAmount>";
 		}
 		if (allowance.isCharge()) {
 			chargeIndicator = "true";
@@ -305,7 +306,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		String chargeIndicator = "false";
 		if ((allowance.getPercent() != null) && (profile == Profiles.getByName("Extended"))) {
 			percentage = "<ram:CalculationPercent>" + vatFormat(allowance.getPercent()) + "</ram:CalculationPercent>";
-			percentage += "<ram:BasisAmount>" + item.getValue() + "</ram:BasisAmount>";
+			percentage += "<ram:BasisAmount>" + currencyFormat(item.getValue()) + "</ram:BasisAmount>";
 		}
 		if (allowance.isCharge()) {
 			chargeIndicator = "true";
@@ -499,15 +500,27 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					xml += "</ram:BuyerOrderReferencedDocument>";
 				}
 
+				// Per-unit provider for product-level: ActualAmount must be per-unit (BT-147)
+				final IZUGFeRDExportableItem itemForProduct = currentItem;
+				IAbsoluteValueProvider perUnitProvider = new IAbsoluteValueProvider() {
+					@Override
+					public BigDecimal getValue() {
+						return itemForProduct.getPrice();
+					}
+					@Override
+					public BigDecimal getQuantity() {
+						return BigDecimal.ONE;
+					}
+				};
 				String allowanceChargeStr = "";
 				if (currentItem.getProduct().getAllowances() != null && currentItem.getProduct().getAllowances().length > 0) {
 					for (final IZUGFeRDAllowanceCharge allowance : currentItem.getProduct().getAllowances()) {
-						allowanceChargeStr += getAllowanceChargeStr(allowance, currentItem);
+						allowanceChargeStr += getAllowanceChargeStr(allowance, perUnitProvider);
 					}
 				}
 				if (currentItem.getProduct().getCharges() != null && currentItem.getProduct().getCharges().length > 0) {
 					for (final IZUGFeRDAllowanceCharge charge : currentItem.getProduct().getCharges()) {
-						allowanceChargeStr += getAllowanceChargeStr(charge, currentItem);
+						allowanceChargeStr += getAllowanceChargeStr(charge, perUnitProvider);
 					}
 				}
 				if (!allowanceChargeStr.isEmpty()) {
@@ -588,16 +601,31 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					xml += "</ram:BillingSpecifiedPeriod>";
 				}
 
-				// item charges/allowances
+				// Item-level: use basisQuantity-aware provider so ActualAmount (BT-136) is correct when basisQuantity != 1
+				BigDecimal itemBasisQty = currentItem.getBasisQuantity().compareTo(BigDecimal.ZERO) == 0
+					? BigDecimal.ONE.setScale(4)
+					: currentItem.getBasisQuantity();
+				final IZUGFeRDExportableItem itemForSettlement = currentItem;
+				final BigDecimal basisQty = itemBasisQty;
+				IAbsoluteValueProvider itemBasisProvider = new IAbsoluteValueProvider() {
+					@Override
+					public BigDecimal getValue() {
+						return itemForSettlement.getPrice().divide(basisQty, 18, RoundingMode.HALF_UP);
+					}
+					@Override
+					public BigDecimal getQuantity() {
+						return itemForSettlement.getQuantity();
+					}
+				};
 				String itemTotalAllowanceChargeStr = "";
 				if (currentItem.getAllowances() != null && currentItem.getAllowances().length > 0) {
 					for (final IZUGFeRDAllowanceCharge itemTotalAllowance : currentItem.getAllowances()) {
-						itemTotalAllowanceChargeStr += getItemTotalAllowanceChargeStr(itemTotalAllowance, currentItem);
+						itemTotalAllowanceChargeStr += getItemTotalAllowanceChargeStr(itemTotalAllowance, itemBasisProvider);
 					}
 				}
 				if (currentItem.getCharges() != null && currentItem.getCharges().length > 0) {
 					for (final IZUGFeRDAllowanceCharge itemTotalCharges : currentItem.getCharges()) {
-						itemTotalAllowanceChargeStr += getItemTotalAllowanceChargeStr(itemTotalCharges, currentItem);
+						itemTotalAllowanceChargeStr += getItemTotalAllowanceChargeStr(itemTotalCharges, itemBasisProvider);
 					}
 				}
 				if (!itemTotalAllowanceChargeStr.isEmpty()) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -297,6 +297,7 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(valueOf(4.750).stripTrailingZeros(), calculator.getGrandTotal().stripTrailingZeros());
 	}
 
+	@Test
 	public void testSimpleItemPercentAllowance() {
 		/***
 		 * a product with net 1.10 and qty 5 and relative item allowance of 10% should return 5 as line and grand total
@@ -351,6 +352,7 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(new BigDecimal("4.95"), calculator.getGrandTotal().stripTrailingZeros());
 	}
 
+	@Test
 	public void testSimpleItemPercentCharge() {
 		/***
 		 * a product with net 1.10 and qty 5 and relative item allowance of 10% should return 5 as line and grand total
@@ -405,6 +407,7 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(new BigDecimal("6.05"), calculator.getGrandTotal().stripTrailingZeros());
 	}
 
+	@Test
 	public void testSimpleDocumentPercentCharge() {
 
 		String orgname = "Test company";
@@ -430,6 +433,7 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(new BigDecimal("16.07"), tc.getDuePayable());
 	}
 
+	@Test
 	public void testSimpleDocumentPercentAllowance() {
 
 		String orgname = "Test company";
@@ -455,6 +459,7 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(new BigDecimal("5.36"), tc.getDuePayable());
 	}
 
+	@Test
 	public void testSimpleItemTotalAllowance() {
 		/***
 		 * a product with net 1 and qty 5 and absolute _item_ allowance of 1 should return 4 as line total, and grand total
@@ -497,6 +502,62 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(new BigDecimal(4), calculator.getGrandTotal().stripTrailingZeros());
 	}
 
+
+	@Test
+	public void testPercentProductAllowanceNotMultipliedByQuantity() {
+		// Bug A: 10% product discount on price=100, qty=5
+		// Correct: net price = 90, line total = 5 * 90 = 450
+		// Bug A would give: delta = 10*5 = 50, price = 50, total = 5*50 = 250
+		Product product = new Product("Test", "", "H87", BigDecimal.ZERO);
+		product.addAllowance((Allowance) new Allowance().setPercent(new BigDecimal(10)));
+		Item item = new Item(product, new BigDecimal("100.00"), new BigDecimal("5"));
+
+		LineCalculator lc = item.getCalculation();
+		assertEquals(new BigDecimal("450.00"), lc.getItemTotalNetAmount());
+		assertEquals(new BigDecimal("90.00").stripTrailingZeros(),
+			lc.getPrice().stripTrailingZeros());
+	}
+
+	@Test
+	public void testPercentItemAllowanceWithBasisQuantity() {
+		// Bug B: price=128.49 per 100 LTR, qty=50 LTR, 10% item allowance
+		// Line total before allowance = 50 * 128.49 / 100 = 64.245
+		// Allowance = 10% of 64.245 = 6.4245 -> 6.42 (rounded)
+		// Correct line total = 64.25 - 6.42 = 57.83
+		Product product = new Product("Test", "", "LTR", BigDecimal.ZERO);
+		Item item = new Item(product, new BigDecimal("128.49"), new BigDecimal("50"));
+		item.setBasisQuantity(new BigDecimal("100"));
+		item.addAllowance(new Allowance().setPercent(new BigDecimal(10)));
+
+		LineCalculator lc = item.getCalculation();
+		assertEquals(new BigDecimal("57.83"), lc.getItemTotalNetAmount());
+	}
+
+	@Test
+	public void testPercentProductAllowanceWithBasisQuantity() {
+		// 10% product discount, price=100 per 10 units, qty=50
+		// Net price = 100 - 10 = 90 (per 10 units)
+		// Line total = 50 * 90 / 10 = 450
+		Product product = new Product("Test", "", "H87", BigDecimal.ZERO);
+		product.addAllowance((Allowance) new Allowance().setPercent(new BigDecimal(10)));
+		Item item = new Item(product, new BigDecimal("100.00"), new BigDecimal("50"));
+		item.setBasisQuantity(new BigDecimal("10"));
+
+		LineCalculator lc = item.getCalculation();
+		assertEquals(new BigDecimal("450.00"), lc.getItemTotalNetAmount());
+	}
+
+	@Test
+	public void testPercentItemChargeWithBasisQuantity() {
+		// Item-level 10% charge with basisQuantity: line before charge = 50*100/100 = 50, charge = 5, total = 55
+		Product product = new Product("Test", "", "LTR", BigDecimal.ZERO);
+		Item item = new Item(product, new BigDecimal("100.00"), new BigDecimal("50"));
+		item.setBasisQuantity(new BigDecimal("100"));
+		item.addCharge(new Charge().setPercent(new BigDecimal(10)));
+
+		LineCalculator lc = item.getCalculation();
+		assertEquals(new BigDecimal("55.00"), lc.getItemTotalNetAmount());
+	}
 
 	/**
 	 * LineCalculator should not throw an exception when calculating a non-terminating decimal expansion

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -559,6 +559,92 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(new BigDecimal("55.00"), lc.getItemTotalNetAmount());
 	}
 
+	@Test
+	public void testLineLevelAllowanceBasisAmountIsLineSubtotal() {
+		// BT-137: line-allowance BasisAmount = (price / basisQty) * qty (line subtotal), NOT the per-unit value.
+		// price=128.49 per 100 LTR, qty=50 LTR, basisQty=100
+		// line subtotal before allowance = 128.49 / 100 * 50 = 64.245 -> 64.25 (HALF_UP, BR-DEC-25)
+		// allowance ActualAmount = 10% of 64.245 = 6.4245 -> 6.42
+		SimpleDateFormat sqlDate = new SimpleDateFormat("yyyy-MM-dd");
+
+		Invoice invoice = new Invoice();
+		invoice.setDocumentName("Rechnung");
+		invoice.setNumber("BT137-ALLOWANCE");
+		try {
+			invoice.setIssueDate(sqlDate.parse("2024-01-01"));
+			invoice.setDueDate(sqlDate.parse("2024-01-31"));
+		} catch (Exception e) {
+			LOGGER.error("Failed to set dates", e);
+		}
+		TradeParty sender = new TradeParty("Sender GmbH", "Hauptstr. 1", "10115", "Berlin", "DE");
+		sender.addVATID("DE123456789");
+		invoice.setSender(sender);
+		TradeParty recipient = new TradeParty("Recipient GmbH", "Nebenstr. 2", "10116", "Berlin", "DE");
+		recipient.addVATID("DE987654321");
+		invoice.setRecipient(recipient);
+
+		Product product = new Product("Testartikel", "", "LTR", BigDecimal.ZERO);
+		Item item = new Item(product, new BigDecimal("128.49"), new BigDecimal("50"));
+		item.setBasisQuantity(new BigDecimal("100"));
+		item.addAllowance(new Allowance().setPercent(new BigDecimal(10)).setTaxPercent(BigDecimal.ZERO));
+		invoice.addItem(item);
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("Extended"));
+		zf2p.generateXML(invoice);
+
+		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
+		assertThat(theXML).valueByXPath("//*[local-name()='SpecifiedTradeAllowanceCharge'][*[local-name()='ChargeIndicator']/*[local-name()='Indicator']='false']/*[local-name()='BasisAmount']")
+			.asString()
+			.isEqualTo("64.25"); // (128.49/100)*50 = 64.245 rounded HALF_UP
+		assertThat(theXML).valueByXPath("//*[local-name()='SpecifiedTradeAllowanceCharge'][*[local-name()='ChargeIndicator']/*[local-name()='Indicator']='false']/*[local-name()='ActualAmount']")
+			.asString()
+			.isEqualTo("6.42"); // 64.245 * 0.10 = 6.4245 rounded HALF_UP
+	}
+
+	@Test
+	public void testLineLevelChargeBasisAmountIsLineSubtotal() {
+		// BT-142: line-charge BasisAmount = (price / basisQty) * qty (line subtotal), NOT the per-unit value.
+		// price=200.00 per 4 units, qty=10, basisQty=4
+		// line subtotal before charge = 200.00 / 4 * 10 = 500.00
+		// charge ActualAmount = 5% of 500.00 = 25.00
+		SimpleDateFormat sqlDate = new SimpleDateFormat("yyyy-MM-dd");
+
+		Invoice invoice = new Invoice();
+		invoice.setDocumentName("Rechnung");
+		invoice.setNumber("BT142-CHARGE");
+		try {
+			invoice.setIssueDate(sqlDate.parse("2024-01-01"));
+			invoice.setDueDate(sqlDate.parse("2024-01-31"));
+		} catch (Exception e) {
+			LOGGER.error("Failed to set dates", e);
+		}
+		TradeParty sender = new TradeParty("Sender GmbH", "Hauptstr. 1", "10115", "Berlin", "DE");
+		sender.addVATID("DE123456789");
+		invoice.setSender(sender);
+		TradeParty recipient = new TradeParty("Recipient GmbH", "Nebenstr. 2", "10116", "Berlin", "DE");
+		recipient.addVATID("DE987654321");
+		invoice.setRecipient(recipient);
+
+		Product product = new Product("Testartikel", "", "H87", BigDecimal.ZERO);
+		Item item = new Item(product, new BigDecimal("200.00"), new BigDecimal("10"));
+		item.setBasisQuantity(new BigDecimal("4"));
+		item.addCharge(new Charge().setPercent(new BigDecimal(5)).setTaxPercent(BigDecimal.ZERO));
+		invoice.addItem(item);
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("Extended"));
+		zf2p.generateXML(invoice);
+
+		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
+		assertThat(theXML).valueByXPath("//*[local-name()='SpecifiedTradeAllowanceCharge'][*[local-name()='ChargeIndicator']/*[local-name()='Indicator']='true']/*[local-name()='BasisAmount']")
+			.asString()
+			.isEqualTo("500.00"); // (200.00/4)*10 = 500.00
+		assertThat(theXML).valueByXPath("//*[local-name()='SpecifiedTradeAllowanceCharge'][*[local-name()='ChargeIndicator']/*[local-name()='Indicator']='true']/*[local-name()='ActualAmount']")
+			.asString()
+			.isEqualTo("25.00"); // 500.00 * 0.05 = 25.00
+	}
+
 	/**
 	 * LineCalculator should not throw an exception when calculating a non-terminating decimal expansion
 	 */


### PR DESCRIPTION
# Fix percentage allowance/charge calculations (Item-level & Product-level)

> **Fixes #925**
> **Fixes #1112**
> **Fixes #1113**

## 1. XML evidence 

| Scenario | master output (wrong) | this PR output (validates `status="valid"`) |
|---|---|---|
| Bug 1: Product-level percent allowance | [test-invoice-1.before.changes.xml](https://github.com/user-attachments/files/25374227/test-invoice-1.before.changes.xml) | [output-invoice.xml (EN16931)](https://github.com/user-attachments/files/25374236/output-invoice.xml) · [output-invoice-ext.xml (Extended)](https://github.com/user-attachments/files/25374252/output-invoice-ext.xml) |
| Bug 2: Item-level percent allowance, `basisQty != 1` | [test-invoice-2.before.changes.xml](https://github.com/user-attachments/files/25374231/test-invoice-2.before.changes.xml) | [output-invoice-2.xml (EN16931)](https://github.com/user-attachments/files/25374242/output-invoice-2.xml) · [output-invoice-2-ext.xml (Extended)](https://github.com/user-attachments/files/25374256/output-invoice-2-ext.xml) |

JSON inputs Mustang ingested: [test-invoice.json](https://github.com/user-attachments/files/25374223/test-invoice.json) · [test-invoice-2.json](https://github.com/user-attachments/files/25374225/test-invoice-2.json).

Open `test-invoice-2.before.changes.xml` (master) → `<ram:LineTotalAmount>-578.21</ram:LineTotalAmount>`. Negative line total. The PR's `output-invoice-2.xml` emits `57.83`. No test runner needed; pen and paper or any external EN 16931 validator on the master XML reaches the same conclusion.

## 2. The two bugs in full formulas

**Bug 1: Product-Level Percentage Allowance (Quantity is applied twice)**
Master wrongly multiplies by `BT-129` (`Quantity`) when calculating the per-unit product allowance, meaning the discount scales quadratically with quantity.

*   **master (wrong):**
    `UnitAllowance = BT-146 * BT-129   * Percent / 100`
    `UnitAllowance = Price  * Quantity * Percent / 100`

    `BT-131        = (BT-146 - UnitAllowance) / BT-149   * BT-129`
    `LineTotal     = (Price  - UnitAllowance) / BasisQty * Quantity`

*   **this PR (right):**
    `UnitAllowance = BT-146 * Percent / 100`
    `UnitAllowance = Price  * Percent / 100`

    `BT-131        = (BT-146 - UnitAllowance) / BT-149   * BT-129`
    `LineTotal     = (Price  - UnitAllowance) / BasisQty * Quantity`

**Bug 2: Item-Level Percentage Allowance (BasisQuantity is ignored)**
Master drops `BT-149` (`BasisQty`) when calculating the allowance, applying the percentage to the raw `BT-146 * BT-129` (`Price * Quantity`).

*   **master (wrong):**
    `BT-136    = BT-146 * BT-129   * Percent / 100`
    `Allowance = Price  * Quantity * Percent / 100`

    `BT-131    = (BT-146 / BT-149)   * BT-129   - BT-136`
    `LineTotal = (Price  / BasisQty) * Quantity - Allowance`

*   **this PR (right):**
    `BT-136    = (BT-146 / BT-149)   * BT-129   * Percent / 100`
    `Allowance = (Price  / BasisQty) * Quantity * Percent / 100`

    `BT-131    = (BT-146 / BT-149)   * BT-129   - BT-136`
    `LineTotal = (Price  / BasisQty) * Quantity - Allowance`

## 3. The formulas with real values

**Bug 1 Values (Product-Level):** `BT-146` (Price) = 10.00, `BT-149` (BasisQty) = 1, `BT-129` (Quantity) = 5, Percent = 10%.
*   **master (wrong):**
    `UnitAllowance = 10.00 * 5 * 10 / 100 = 5.00` (Discount became 50% just because Quantity is 5!)
    `BT-131        = (10.00 - 5.00) / 1 * 5 = 25.00`
*   **this PR (right):**
    `UnitAllowance = 10.00 * 10 / 100 = 1.00` (Discount stays 10% per unit)
    `BT-131        = (10.00 - 1.00) / 1 * 5 = 45.00` (Correct!)

**Bug 2 Values (Item-Level):** `BT-146` (Price) = 128.49, `BT-149` (BasisQty) = 100, `BT-129` (Quantity) = 50, Percent = 10%.
*   **master (wrong):**
    `BT-136 = 128.49 * 50 * 10 / 100 = 642.45`
    `BT-131 = (128.49 / 100) * 50 - 642.45 = 64.245 - 642.45 = -578.21` (Negative line total!)
*   **this PR (right):**
    `BT-136 = (128.49 / 100) * 50 * 10 / 100 = 64.245 * 10 / 100 = 6.42`
    `BT-131 = (128.49 / 100) * 50 - 6.42 = 64.245 - 6.42 = 57.83` (Correct!)

## 4. Why master violates EN 16931

**EN 16931-1:2017+A1:2019, BR-67 (fatal):**
> *"Invoice line net amount MUST equal (Invoiced quantity * (Item net price / item price base quantity) + Sum of invoice line charge amount - sum of invoice line allowance amount."*

**EN 16931-1:2017+A1:2019, BT-137 / BT-142 (semantic definition):**
> *"The base amount that may be used, in conjunction with the Invoice line allowance / charge percentage, to calculate the Invoice line allowance / charge amount."*

The "base amount" for item-level allowances is the line subtotal `(BT-146 / BT-149) * BT-129` — explicitly **not** the raw `BT-146 * BT-129`. Master violates this by dropping `BT-149` in Bug 2. For product-level allowances, the base amount is the unit `BT-146`, but master violates this by multiplying by `BT-129` in Bug 1.

##Files changed (5 files, no public API change)

| File | Change |
|---|---|
| `LineCalculator.java` | Wrap item with `IAbsoluteValueProvider` whose `getValue() = BT-146 / BT-149` for item-level allowances/charges; wrap with `getQuantity() = 1` for product-level (fixes the double-quantity bug). |
| `Allowance.java` | Add `RoundingMode.HALF_UP` to `getPercent().divide(100, …)`, matching `Charge.java`. |
| `ZUGFeRD2PullProvider.java`, `OXPullProvider.java`, `DAPullProvider.java` | Emit line-level `<ram:BasisAmount>` (BT-137 / BT-142) = `(BT-146 / BT-149) * BT-129` (Extended profile, matching the existing gating). |
| `CalculationTest.java` | 6 new regression tests; 5 orphan tests get `@Test`. |