### PR TITLE
Correct version of org.apache.pdfbox:fontbox from 3.0.3 to 3.0.6.

### DIFF
--- a/library/pom.xml
+++ b/library/pom.xml
@@ -73,6 +73,10 @@
                 <groupId>xml-apis</groupId>
                 <artifactId>xml-apis</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.apache.pdfbox</groupId>
+                <artifactId>fontbox</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Exclude dependency org.apache.pdfbox:fontbox from org.apache.xmlgraphics:fop-core in favor of same dependency but correct version beyond org.apache.pdfbox:pdfbox.