### PR TITLE
Secure setting of features/properties for DocumentBuilderFactory etc.

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
@@ -15,10 +15,10 @@ import org.apache.fop.configuration.ConfigurationException;
 import org.apache.fop.configuration.DefaultConfigurationBuilder;
 import org.apache.xmlgraphics.util.MimeConstants;
 import org.mustangproject.ClasspathResolverURIAdapter;
+import org.mustangproject.util.SecurityConfigurater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.XMLConstants;
 import javax.xml.transform.*;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamResult;
@@ -42,8 +42,8 @@ public class ValidationLogVisualizer {
 
 
 	public ValidationLogVisualizer() {
-		mFactory = new net.sf.saxon.TransformerFactoryImpl();
-		// fact = TransformerFactory.newInstance();
+		mFactory = TransformerFactory.newInstance();
+		SecurityConfigurater.configure(mFactory);
 		mFactory.setURIResolver(new ValidationLogVisualizer.ClasspathResourceURIResolver());
 	}
 
@@ -127,10 +127,7 @@ public class ValidationLogVisualizer {
 			Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
 
 			// Step 4: Setup JAXP using identity transformer
-			TransformerFactory factory = TransformerFactory.newInstance();
-
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			Transformer transformer = factory.newTransformer(); // identity transformer
+			Transformer transformer = mFactory.newTransformer(); // identity transformer
 
 			// Step 5: Setup input and output for XSLT transformation
 			// Setup input stream

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMLUpgrader.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMLUpgrader.java
@@ -16,6 +16,8 @@ import javax.xml.transform.URIResolver;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import org.mustangproject.util.SecurityConfigurater;
+
 
 /***
  * Uses a XSLT transformation to upgrade
@@ -31,8 +33,8 @@ public class XMLUpgrader {
 	private Templates mXsltTemplate = null;
 
 	public XMLUpgrader() {
-		mFactory = new net.sf.saxon.TransformerFactoryImpl();
-		//fact = TransformerFactory.newInstance();
+		mFactory = TransformerFactory.newInstance();
+		SecurityConfigurater.configure(mFactory);
 		mFactory.setURIResolver(new ClasspathResourceURIResolver());
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -11,6 +11,7 @@ import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
 import org.mustangproject.*;
 import org.mustangproject.Exceptions.StructureException;
 import org.mustangproject.util.NodeMap;
+import org.mustangproject.util.SecurityConfigurater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -18,7 +19,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -313,23 +313,8 @@ public class ZUGFeRDInvoiceImporter {
 
 	private void setDocument() throws ParserConfigurationException, IOException, SAXException, ParseException {
 		final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		//REDHAT
-		//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
-		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		SecurityConfigurater.configure(dbf, true);
 
-		//OWASP
-		//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-		dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-		// Disable external DTDs as well
-		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-		// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-		dbf.setXIncludeAware(false);
-		dbf.setExpandEntityReferences(false);
-		dbf.setNamespaceAware(true);
 		final DocumentBuilder builder = dbf.newDocumentBuilder();
 		final ByteArrayInputStream is = new ByteArrayInputStream(rawXML);
 		///    is.skip(guessBOMSize(is));

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -21,7 +21,6 @@
 package org.mustangproject.ZUGFeRD;
 
 import com.helger.commons.io.stream.StreamHelper;
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.io.IOUtils;
 import org.apache.fop.apps.*;
@@ -32,6 +31,7 @@ import org.apache.fop.configuration.DefaultConfigurationBuilder;
 import org.apache.xmlgraphics.util.MimeConstants;
 import org.mustangproject.ClasspathResolverURIAdapter;
 import org.mustangproject.EStandard;
+import org.mustangproject.util.SecurityConfigurater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -47,8 +47,6 @@ import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -85,8 +83,8 @@ public class ZUGFeRDVisualizer {
 	private Templates mXsltZF1HTMLTemplate = null;
 
 	public ZUGFeRDVisualizer() {
-		mFactory = new net.sf.saxon.TransformerFactoryImpl();
-		// fact = TransformerFactory.newInstance();
+		mFactory = TransformerFactory.newInstance();
+		SecurityConfigurater.configure(mFactory);
 		mFactory.setURIResolver(new ClasspathResourceURIResolver());
 	}
 
@@ -105,37 +103,8 @@ public class ZUGFeRDVisualizer {
 		String cioSignature = "SCRDMCCBDACIOMessageStructure";
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		//REDHAT
-		//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
-		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-		try
-		{
-			dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-		}
-		catch (IllegalArgumentException e)
-		{
-			LOGGER.warn("Property: \"Access external DTD\" not supported.");
-		}
-		try
-		{
-			dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-		}
-		catch (IllegalArgumentException e)
-		{
-			LOGGER.warn("Property: \"Access external schema\" not supported.");
-		}
+		SecurityConfigurater.configure(dbf, true);
 
-		//OWASP
-		//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-		dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-		// Disable external DTDs as well
-		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-		// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-		dbf.setXIncludeAware(false);
-		dbf.setExpandEntityReferences(false);
-		dbf.setNamespaceAware(true);
 		try {
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			Document doc = db.parse(new InputSource(fis));
@@ -389,9 +358,7 @@ public class ZUGFeRDVisualizer {
 			Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
 
 			// Step 4: Setup JAXP using identity transformer
-			TransformerFactory factory = TransformerFactory.newInstance();
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			Transformer transformer = factory.newTransformer(); // identity transformer
+			Transformer transformer = mFactory.newTransformer(); // identity transformer
 
 			// Step 5: Setup input and output for XSLT transformation
 			// Setup input stream

--- a/library/src/main/java/org/mustangproject/util/SecurityConfigurater.java
+++ b/library/src/main/java/org/mustangproject/util/SecurityConfigurater.java
@@ -1,0 +1,96 @@
+package org.mustangproject.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+public class SecurityConfigurater {
+	private SecurityConfigurater()
+	{
+		/* This utility class should not be instantiated */
+	}
+
+	public static void configure(DocumentBuilderFactory dbf, boolean namespaceAware)
+	{
+		//REDHAT
+		//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
+		try {
+			// prevent external connections
+			dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		} catch (ParserConfigurationException e) {
+			// ignore
+		}
+		try {
+			dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		} catch (IllegalArgumentException e) {
+			// ignore
+		}
+		try {
+			dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		} catch (IllegalArgumentException e) {
+			// ignore
+		}
+
+		//OWASP
+		//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+		try {
+			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		} catch (ParserConfigurationException e) {
+			// ignore
+		}
+		try {
+			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		} catch (ParserConfigurationException e) {
+			// ignore
+		}
+		try {
+			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		} catch (ParserConfigurationException e) {
+			// ignore
+		}
+		// Disable external DTDs as well
+		try {
+			dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		} catch (ParserConfigurationException e) {
+			// ignore
+		}
+		// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+		dbf.setXIncludeAware(false);
+		dbf.setExpandEntityReferences(false);
+		dbf.setNamespaceAware(namespaceAware);
+	}
+
+	public static void configure(TransformerFactory factory)
+	{
+		try {
+			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		} catch (TransformerConfigurationException e) {
+			// ignore
+		}
+	}
+
+	public static void configure(SchemaFactory factory)
+	{
+		try {
+			factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		} catch (SAXNotSupportedException | SAXNotRecognizedException e) {
+			// ignore
+		}
+	}
+
+	public static void configure(Validator validator)
+	{
+		try {
+			validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		} catch (SAXNotSupportedException | SAXNotRecognizedException e) {
+			// ignore
+		}
+	}
+}

--- a/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
@@ -23,6 +23,7 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.mustangproject.util.ByteArraySearcher;
+import org.mustangproject.util.SecurityConfigurater;
 import org.mustangproject.ZUGFeRD.ZUGFeRDImporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,9 +144,7 @@ public class PDFValidator extends Validator {
 			 */
 			try {
 				final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-				factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-				// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-				factory.setXIncludeAware(false);
+				SecurityConfigurater.configure(factory, false);
 
 				final DocumentBuilder builder = factory.newDocumentBuilder();
 				final InputSource is = new InputSource(new StringReader(xmp));

--- a/validator/src/main/java/org/mustangproject/validator/Validator.java
+++ b/validator/src/main/java/org/mustangproject/validator/Validator.java
@@ -10,6 +10,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import org.mustangproject.util.SecurityConfigurater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
@@ -60,11 +61,11 @@ public abstract class Validator {
 		URL schemaFile = Thread.currentThread().getContextClassLoader().getResource("schema/" + schemaPath);
 		Source xmlData = new StreamSource(new ByteArrayInputStream(xmlRawData));
 		SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+		SecurityConfigurater.configure(schemaFactory);
 		try {
-			schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 			Schema schema = schemaFactory.newSchema(schemaFile);
 			javax.xml.validation.Validator validator = schema.newValidator();
-			validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			SecurityConfigurater.configure(validator);
 			validator.validate(xmlData);
 		} catch (SAXException e) {
 			context.addResultItem(new ValidationResultItem(ESeverity.error, "schema validation fails:" + e)

--- a/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
@@ -13,7 +13,6 @@ import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Set;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.stream.StreamSource;
@@ -28,6 +27,7 @@ import org.mustangproject.XMLTools;
 import org.mustangproject.ZUGFeRD.IZUGFeRDExportableItem;
 import org.mustangproject.ZUGFeRD.LineCalculator;
 import org.mustangproject.ZUGFeRD.ZUGFeRDInvoiceImporter;
+import org.mustangproject.util.SecurityConfigurater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -157,23 +157,7 @@ public class XMLValidator extends Validator {
 				 */
 
 				final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-				//REDHAT
-				//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
-				dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-				dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-				dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-
-				//OWASP
-				//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-				dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-				dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-				dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-				// Disable external DTDs as well
-				dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-				// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-				dbf.setXIncludeAware(false);
-				dbf.setExpandEntityReferences(false);
-				dbf.setNamespaceAware(true);
+				SecurityConfigurater.configure(dbf, true);
 
 				final DocumentBuilder db = dbf.newDocumentBuilder();
 				final InputSource is = new InputSource(new StringReader(zfXML));

--- a/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
@@ -17,7 +17,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -27,6 +26,7 @@ import org.dom4j.DocumentHelper;
 import org.dom4j.io.OutputFormat;
 import org.dom4j.io.XMLWriter;
 import org.mustangproject.util.ByteArraySearcher;
+import org.mustangproject.util.SecurityConfigurater;
 import org.mustangproject.XMLTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -144,22 +144,8 @@ public class ZUGFeRDValidator {
 					String xmlAsString = null;
 					try {
 						DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-						//REDHAT
-						//https://www.blackhat.com/docs/us-15/materials/us-15-Wang-FileCry-The-New-Age-Of-XXE-java-wp.pdf
-						dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-						dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-						dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+						SecurityConfigurater.configure(dbf, true);
 
-						//OWASP
-						//https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
-						dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-						dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-						// Disable external DTDs as well
-						dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-						// and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
-						dbf.setXIncludeAware(false);
-						dbf.setExpandEntityReferences(false);
-						dbf.setNamespaceAware(true);
 						DocumentBuilder db = dbf.newDocumentBuilder();
 
 						content = XMLTools.removeBOM(content);


### PR DESCRIPTION
Centralized security related configuration for factories and validator.
Surrounded each setting of a feature / property with try/catch/ignore to make it independent of the implementation used for parsing, validating, serializing and manipulating XML, e.g. Saxon or Xerces.

Related to #972.