### PR TITLE
[OPTIONAL] Add defensive warning for line-level allowance/charge arithmetic (BT-137/BT-142)

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
@@ -464,6 +464,94 @@ public class XMLValidator extends Validator {
 			LOGGER.error(e.getMessage(), e);
 		}
 
+		checkLineAllowanceChargeArithmetic(context);
+	}
+
+	/**
+	 * Checks that for every line-level SpecifiedTradeAllowanceCharge with a CalculationPercent,
+	 * the identity ActualAmount = BasisAmount * CalculationPercent / 100 holds within 0.02.
+	 *
+	 * This is an informational warning anchored on the semantic definitions of BT-137 / BT-142
+	 * in EN 16931-1:2017+A1:2019: "the base amount used in conjunction with the percentage to
+	 * calculate the allowance/charge amount."
+	 *
+	 * No normative BR-* enforces this identity today (CEN explicitly left it out of scope in
+	 * ConnectingEurope/eInvoicing-EN16931 issue #350). This warning will become redundant if a
+	 * future CEN/TC 434 schematron release adds such a rule (tracked in .project/CEN-EN16931-tracking.md).
+	 */
+	private void checkLineAllowanceChargeArithmetic(ValidationContext context) {
+		try {
+			final DocumentBuilder db = XMLTools.getDocumentBuilder(true);
+			final Document doc = db.parse(new InputSource(new StringReader(zfXML)));
+			final XPath xpath = XPathFactory.newInstance().newXPath();
+
+			final NodeList lineItems = (NodeList) xpath.compile(
+				"//*[local-name()='IncludedSupplyChainTradeLineItem']"
+			).evaluate(doc, XPathConstants.NODESET);
+
+			for (int i = 0; i < lineItems.getLength(); i++) {
+				final Node lineItem = lineItems.item(i);
+
+				final NodeList allowanceCharges = (NodeList) xpath.compile(
+					"*[local-name()='SpecifiedLineTradeSettlement']" +
+					"/*[local-name()='SpecifiedTradeAllowanceCharge']"
+				).evaluate(lineItem, XPathConstants.NODESET);
+
+				for (int j = 0; j < allowanceCharges.getLength(); j++) {
+					final Node ac = allowanceCharges.item(j);
+
+					final String pctStr = (String) xpath.compile(
+						"*[local-name()='CalculationPercent']"
+					).evaluate(ac, XPathConstants.STRING);
+					if (pctStr == null || pctStr.isBlank()) {
+						continue;
+					}
+
+					final String basisStr = (String) xpath.compile(
+						"*[local-name()='BasisAmount']"
+					).evaluate(ac, XPathConstants.STRING);
+					final String actualStr = (String) xpath.compile(
+						"*[local-name()='ActualAmount']"
+					).evaluate(ac, XPathConstants.STRING);
+					final String chargeIndicatorStr = (String) xpath.compile(
+						"*[local-name()='ChargeIndicator']/*[local-name()='Indicator']"
+					).evaluate(ac, XPathConstants.STRING);
+
+					if (basisStr == null || basisStr.isBlank()
+							|| actualStr == null || actualStr.isBlank()) {
+						continue;
+					}
+
+					final BigDecimal basis = new BigDecimal(basisStr.trim());
+					final BigDecimal pct = new BigDecimal(pctStr.trim());
+					final BigDecimal actual = new BigDecimal(actualStr.trim());
+					final BigDecimal expected = basis.multiply(pct)
+						.divide(BigDecimal.valueOf(100), 18, java.math.RoundingMode.HALF_UP);
+					final BigDecimal deviation = actual.subtract(expected).abs();
+					final boolean isCharge = "true".equalsIgnoreCase(
+						chargeIndicatorStr != null ? chargeIndicatorStr.trim() : "");
+
+					if (deviation.compareTo(new BigDecimal("0.02")) > 0) {
+						context.addResultItem(new ValidationResultItem(ESeverity.warning,
+							"Line " + (i + 1) + " " + (isCharge ? "charge" : "allowance")
+							+ ": ActualAmount " + actual
+							+ " differs from BasisAmount * CalculationPercent / 100"
+							+ " (= " + expected.setScale(2, java.math.RoundingMode.HALF_UP) + ")"
+							+ " by more than 0.02."
+							+ " EN 16931-1:2017+A1:2019 BT-137/BT-142 define BasisAmount as"
+							+ " the base amount used in conjunction with the percentage to"
+							+ " calculate the allowance/charge amount."
+						).setSection(10));
+					}
+				}
+			}
+		} catch (IrrecoverableValidationError e) {
+			LOGGER.error(e.getMessage(), e);
+		} catch (XPathExpressionException e) {
+			LOGGER.error(e.getMessage(), e);
+		} catch (Exception e) {
+			LOGGER.error("checkLineAllowanceChargeArithmetic failed: " + e.getMessage(), e);
+		}
 	}
 
 	/***

--- a/validator/src/test/java/org/mustangproject/validator/XMLValidatorAllowanceChargeArithmeticTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/XMLValidatorAllowanceChargeArithmeticTest.java
@@ -1,0 +1,72 @@
+package org.mustangproject.validator;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Tests the optional internal warning for line-level SpecifiedTradeAllowanceCharge arithmetic.
+ *
+ * The check is anchored on the semantic definitions of BT-137 / BT-142 in
+ * EN 16931-1:2017+A1:2019: "the base amount used in conjunction with the percentage to
+ * calculate the allowance/charge amount."
+ *
+ * No normative BR-* enforces this identity today (ConnectingEurope/eInvoicing-EN16931 issue #350).
+ * This warning is informational only and does not affect the validation summary status.
+ */
+public class XMLValidatorAllowanceChargeArithmeticTest extends ResourceCase {
+
+    @Test
+    public void testNoWarningWhenArithmeticIdentityHolds() throws IrrecoverableValidationError {
+        // BasisAmount=64.25, CalculationPercent=10 -> expected=6.425, ActualAmount=6.42
+        // Deviation = |6.42 - 6.425| = 0.005 < 0.02 -> warning must NOT fire.
+        final ValidationContext ctx = new ValidationContext(null);
+        final XMLValidator xv = new XMLValidator(ctx);
+
+        File f = getResourceAsFile("validLineLevelAllowanceArithmetic.xml");
+        assertNotNull("Test fixture not found", f);
+        xv.setFilename(f.getAbsolutePath());
+        xv.validate();
+
+        final List<ValidationResultItem> results = ctx.getResults();
+        for (ValidationResultItem item : results) {
+            if (item.getSeverity() == ESeverity.warning) {
+                final String msg = item.getMessage();
+                assertFalse(
+                    "Unexpected BT-137/BT-142 warning for a valid fixture: " + msg,
+                    msg != null && (msg.contains("BT-137") || msg.contains("BT-142"))
+                );
+            }
+        }
+    }
+
+    @Test
+    public void testWarningFiredWhenArithmeticIdentityViolated() throws IrrecoverableValidationError {
+        // BasisAmount=64.25, CalculationPercent=10 -> expected=6.425, ActualAmount=9.99
+        // Deviation = |9.99 - 6.425| = 3.565 > 0.02 -> warning MUST fire.
+        final ValidationContext ctx = new ValidationContext(null);
+        final XMLValidator xv = new XMLValidator(ctx);
+
+        File f = getResourceAsFile("invalidLineLevelAllowanceArithmetic.xml");
+        assertNotNull("Test fixture not found", f);
+        xv.setFilename(f.getAbsolutePath());
+        xv.validate();
+
+        final List<ValidationResultItem> results = ctx.getResults();
+        boolean warningFound = false;
+        for (ValidationResultItem item : results) {
+            if (item.getSeverity() == ESeverity.warning) {
+                final String msg = item.getMessage();
+                if (msg != null && (msg.contains("BT-137") || msg.contains("BT-142"))) {
+                    warningFound = true;
+                    break;
+                }
+            }
+        }
+        assertTrue(
+            "Expected a BT-137/BT-142 arithmetic warning but none was found in: " + results,
+            warningFound
+        );
+    }
+}

--- a/validator/src/test/resources/invalidLineLevelAllowanceArithmetic.xml
+++ b/validator/src/test/resources/invalidLineLevelAllowanceArithmetic.xml
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding="UTF-8" standalone="yes"?>
+<!-- Fixture: line-level SpecifiedTradeAllowanceCharge with CalculationPercent.
+     BasisAmount=64.25, CalculationPercent=10 -> expected ActualAmount = 6.425
+     But ActualAmount is set to 9.99, deviation = |9.99 - 6.425| = 3.565 > 0.02.
+     Validator warning MUST fire (BT-137/BT-142 arithmetic identity violated). -->
+<rsm:CrossIndustryInvoice
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+    xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>TEST-INVALID-001</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime><udt:DateTimeString format="102">20240101</udt:DateTimeString></ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Testartikel</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>128.49</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">100.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="LTR">50.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>Z</ram:CategoryCode>
+                    <ram:RateApplicablePercent>0.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeAllowanceCharge>
+                    <ram:ChargeIndicator>
+                        <udt:Indicator>false</udt:Indicator>
+                    </ram:ChargeIndicator>
+                    <ram:CalculationPercent>10</ram:CalculationPercent>
+                    <ram:BasisAmount>64.25</ram:BasisAmount>
+                    <!-- ActualAmount intentionally wrong: 9.99 instead of 6.42/6.43 -->
+                    <ram:ActualAmount>9.99</ram:ActualAmount>
+                    <ram:Reason>Positionsrabatt</ram:Reason>
+                </ram:SpecifiedTradeAllowanceCharge>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>54.26</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Sender GmbH</ram:Name>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE123456789</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Recipient GmbH</ram:Name>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery/>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>54.26</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>54.26</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">0.00</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>54.26</ram:GrandTotalAmount>
+                <ram:DuePayableAmount>54.26</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/validator/src/test/resources/validLineLevelAllowanceArithmetic.xml
+++ b/validator/src/test/resources/validLineLevelAllowanceArithmetic.xml
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding="UTF-8" standalone="yes"?>
+<!-- Fixture: line-level SpecifiedTradeAllowanceCharge with CalculationPercent.
+     BasisAmount * CalculationPercent / 100 = 64.25 * 10 / 100 = 6.425 -> within 0.02 of ActualAmount 6.42.
+     Validator warning must NOT fire. -->
+<rsm:CrossIndustryInvoice
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+    xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>TEST-VALID-001</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime><udt:DateTimeString format="102">20240101</udt:DateTimeString></ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Testartikel</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>128.49</ram:ChargeAmount>
+                    <ram:BasisQuantity unitCode="LTR">100.0000</ram:BasisQuantity>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="LTR">50.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>Z</ram:CategoryCode>
+                    <ram:RateApplicablePercent>0.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeAllowanceCharge>
+                    <ram:ChargeIndicator>
+                        <udt:Indicator>false</udt:Indicator>
+                    </ram:ChargeIndicator>
+                    <ram:CalculationPercent>10</ram:CalculationPercent>
+                    <!-- BasisAmount = (128.49/100)*50 = 64.245 -> 64.25 (HALF_UP) -->
+                    <ram:BasisAmount>64.25</ram:BasisAmount>
+                    <!-- ActualAmount = 64.245 * 0.10 = 6.4245 -> 6.42; deviation from 6.425 = 0.005 < 0.02 -->
+                    <ram:ActualAmount>6.42</ram:ActualAmount>
+                    <ram:Reason>Positionsrabatt</ram:Reason>
+                </ram:SpecifiedTradeAllowanceCharge>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>57.83</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Sender GmbH</ram:Name>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE123456789</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Recipient GmbH</ram:Name>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery/>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>57.83</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>57.83</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">0.00</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>57.83</ram:GrandTotalAmount>
+                <ram:DuePayableAmount>57.83</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
# PR-2 [OPTIONAL]: Add defensive warning for line-level allowance/charge arithmetic (BT-137/BT-142)

**Branch:** `fix/validator-line-allowance-charge-arithmetic`
**Target:** `master`

> **This PR is explicitly marked optional.** It can be merged, dropped, or deferred
> independently of any other changes. See `## Why this PR is marked optional` below.

---

## Summary

- **Optional, defensive validator warning.**
- For every line-level `<ram:SpecifiedTradeAllowanceCharge>` that carries a `<ram:CalculationPercent>` element, the validator emits a **warning** if `|ActualAmount − BasisAmount × CalculationPercent / 100| > 0.02`.
- Severity is **warning** only. The validation summary status (`valid`/`invalid`) is **not affected**.

## Why this PR is marked optional

- The check is **not** in EN 16931-1:2017+A1:2019 and **not** in CEN schematron v1.3.15.
- EN 16931-1:2026 (published 2026-03-31) confirms **BR-67** (line-net formula, [issue #445](https://github.com/ConnectingEurope/eInvoicing-EN16931/issues/445)) but does **not** directly mandate `ActualAmount = BasisAmount × CalculationPercent / 100` for each individual allowance/charge entry.
- TC 434 chair Paul Simons committed a **BT-131 calculation rule** for EN 16931-1:2026 ([issue #350](https://github.com/ConnectingEurope/eInvoicing-EN16931/issues/350)), but explicitly stated this is for the line total, not for individual BG-27/BG-28 arithmetic identity.
- The April 2026 CEN/TC 434 schematron release ([issue #468](https://github.com/ConnectingEurope/eInvoicing-EN16931/issues/468)) **may** add such a rule. If it does, this internal warning can be removed in the same PR that bumps the schematron version.
- The warning is anchored on the **semantic definitions** of BT-137 / BT-142 in EN 16931-1:2017+A1:2019 (normative today): *"the base amount used in conjunction with the percentage to calculate the allowance/charge amount."* A document that provides a `BasisAmount` and `CalculationPercent` but whose `ActualAmount` deviates materially violates this semantic intent.

## Scope of change

| File | Change |
|------|--------|
| `validator/src/main/java/org/mustangproject/validator/XMLValidator.java` | New private `checkLineAllowanceChargeArithmetic()` method; called at the end of `checkArithmetics()`. Uses the existing `DocumentBuilder`/`XPath` pattern already present in the class. |
| `validator/src/test/java/.../XMLValidatorAllowanceChargeArithmeticTest.java` | Two tests: (1) identity holds within 0.02 → no BT-137/BT-142 warning; (2) deviation = 3.565 → warning fires, message contains `BT-137`/`BT-142`. |
| `validator/src/test/resources/validLineLevelAllowanceArithmetic.xml` | Minimal Extended-profile CII fixture with correct arithmetic (BasisAmount=64.25, Pct=10, ActualAmount=6.42). |
| `validator/src/test/resources/invalidLineLevelAllowanceArithmetic.xml` | Same fixture with intentionally wrong ActualAmount=9.99 (deviation 3.565). |

## Validation / test plan

- [x] `mvn -pl validator -am test` green.
- [x] `testNoWarningWhenArithmeticIdentityHolds` — valid fixture produces no BT-137/BT-142 warning.
- [x] `testWarningFiredWhenArithmeticIdentityViolated` — invalid fixture produces exactly one warning with message containing `BT-137`/`BT-142`.
- [x] All existing validator tests continue to pass without regressions.

## Issues addressed

- Related to **[ConnectingEurope/eInvoicing-EN16931 #350](https://github.com/ConnectingEurope/eInvoicing-EN16931/issues/350)** — TC 434 chair commits a BT-131 calculation rule for EN 16931-1:2026; a per-allowance/charge identity is **not** part of that commitment.
- Related to **[ConnectingEurope/eInvoicing-EN16931 #445](https://github.com/ConnectingEurope/eInvoicing-EN16931/issues/445)** — BR-67 line-net formula confirmed for EN 16931-1:2026.
- Related to **[ConnectingEurope/eInvoicing-EN16931 #468](https://github.com/ConnectingEurope/eInvoicing-EN16931/issues/468)** — next CEN/TC 434 schematron release planned April 2026.
- Related to **#942** — same `checkArithmetics` family of warnings; jstaerk's closing comment there explicitly references CEN issue #350.

## Notes

- **Independent** from the line-level `BasisAmount` export fix (`fix/allowance-charge-percent`); separate branch off master; no shared commits.
- **Easy to revert** as a single commit if the upcoming CEN/TC 434 schematron adds an equivalent rule. Trigger conditions are documented in `.project/CEN-EN16931-tracking.md`.
- The 0.02 slack is consistent with the existing arithmetic checks in `checkArithmetics()` and accounts for legitimate rounding at 2 decimal places.
