### PR TITLE
Feature fix xml description

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
@@ -684,7 +684,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		}
 
 		PDFAttachGenericFile(doc, filename, relationship,
-			"Invoice metadata conforming to ZUGFeRD standard (http://www.ferd-net.de/front_content.php?idcat=231&lang=4)",
+			"Invoice metadata conforming to ZUGFeRD standard (https://www.ferd-net.de/en/standards/zugferd/factur-x)",
 			"text/xml", xmlProvider.getXML());
 
 		for (FileAttachment attachment : fileAttachments) {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
@@ -78,6 +78,8 @@ import jakarta.activation.FileDataSource;
 
 public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporter {
 
+	private static final String XML_DESCRIPTION = "Invoice metadata conforming to ZUGFeRD standard (https://www.ferd-net.de/en/standards/zugferd/factur-x)";
+
 	private boolean isFacturX = true;
 	
 	public static final int DefaultZUGFeRDVersion = 2;
@@ -684,8 +686,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		}
 
 		PDFAttachGenericFile(doc, filename, relationship,
-			"Invoice metadata conforming to ZUGFeRD standard (https://www.ferd-net.de/en/standards/zugferd/factur-x)",
-			"text/xml", xmlProvider.getXML());
+			XML_DESCRIPTION, "text/xml", xmlProvider.getXML());
 
 		for (FileAttachment attachment : fileAttachments) {
 			PDFAttachGenericFile(doc, attachment.getFilename(), attachment.getRelation(), attachment.getDescription(), attachment.getMimetype(), attachment.getData());


### PR DESCRIPTION
# Issue

The XML description currently holds an invalid link that throws a 404 and is http.

# Fix

Added the current link to the ZUGFeRD and factur-x documentation and extracted it to a constant for better readability.
This time **didn't change** any legacy PDFs.

# Sources

[Old link](http://www.ferd-net.de/front_content.php?idcat=231&lang=4)
[New link](https://www.ferd-net.de/en/standards/zugferd/factur-x)