### PR TITLE
Avoid NPE by checking zi.getXMP() is not null.

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
@@ -127,7 +127,13 @@ public class PDFValidator extends Validator {
 		final ZUGFeRDImporter zi = new ZUGFeRDImporter();
 		zi.doIgnoreCalculationErrors();//of course the calculation will still be schematron checked
 		zi.setInputStream(inputStream);
-		final String xmp = zi.getXMP().substring(zi.getXMP().indexOf('<'));
+
+		String xmp;
+		if (zi.getXMP() == null) {
+			xmp = null;
+		} else {
+			xmp = zi.getXMP().substring(zi.getXMP().indexOf('<'));
+		}
 
 		final Document docXMP;
 


### PR DESCRIPTION
Related to #1108  / #1076.