### PR TITLE
Fix #1126 IncludedNote SubjectCode ACB, INV

### DIFF
--- a/library/src/main/java/org/mustangproject/IncludedNote.java
+++ b/library/src/main/java/org/mustangproject/IncludedNote.java
@@ -72,6 +72,14 @@ public class IncludedNote {
 		return new IncludedNote(content, SubjectCode.PMD);
 	}
 	
+	public static IncludedNote additionalInformationNote(String content) {
+		return new IncludedNote(content, SubjectCode.ACB);
+	}
+	
+	public static IncludedNote invoiceInstructionNote(String content) {
+		return new IncludedNote(content, SubjectCode.INV);
+	}
+	
 	public static IncludedNote unspecifiedNote(String content) {
 		return new IncludedNote(content, null);
 	}

--- a/library/src/main/java/org/mustangproject/SubjectCode.java
+++ b/library/src/main/java/org/mustangproject/SubjectCode.java
@@ -53,7 +53,14 @@ public enum SubjectCode {
 	/**
 	 * Payment term
 	 */
-	AAB 
-
+	AAB,
+	/**
+	 * Additional information
+	 */
+	ACB,
+	/**
+	 * Invoice instruction
+	 */
+	INV
 
 }


### PR DESCRIPTION
This PR extends the existing BT‑21 (SubjectCode) enum by adding the following values:

INV – invoice-related information
ACB – general / accounting-related header information

Fix for #1126 