### PR TITLE
Fix 1145 - BR-O-06 — do not emit VAT rate for document-level allowance with category O

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -942,7 +942,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					xml += "<ram:CategoryTradeTax>" +
 						"<ram:TypeCode>VAT</ram:TypeCode>" +
 						"<ram:CategoryCode>" + allowance.getCategoryCode() + "</ram:CategoryCode>";
-					if (allowance.getTaxPercent() != null) {
+					if (allowance.getTaxPercent() != null && !allowance.getCategoryCode().equals(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE)) {
 						xml += "<ram:RateApplicablePercent>" + vatFormat(allowance.getTaxPercent()) + "</ram:RateApplicablePercent>";
 					}
 					xml += "</ram:CategoryTradeTax>" +

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -325,6 +325,61 @@ public class XRTest extends TestCase {
 			.isEqualTo(2);
 	}
 
+	/**
+	 * BR-O-06: a document-level allowance with VAT category O must not carry RateApplicablePercent.
+	 * BR-AE-06: a document-level allowance with VAT category AE must carry RateApplicablePercent = 0.
+	 */
+	public void testDocumentLevelAllowanceVatRateByCategory() {
+		TradeParty recipient = new TradeParty("Test Buyer", "Buyer Street 1", "10000", "Test City", "DE");
+		String orgname = "Test Seller";
+		String number = "INV-BR-O-06";
+		BigDecimal itemAmount = new BigDecimal("100.00");
+
+		Invoice invoice = new Invoice()
+			.setDueDate(new java.util.Date()).setIssueDate(new java.util.Date()).setDeliveryDate(new java.util.Date())
+			.setSender(new TradeParty(orgname, "Seller Street 1", "10000", "Test City", "DE")
+				.setID("SELLER-001").addTaxID("DE000000000"))
+			.setRecipient(recipient)
+			.setNumber(number)
+			.addItem(new org.mustangproject.Item(
+				new org.mustangproject.Product("Test item", "", "C62", java.math.BigDecimal.ZERO)
+					.setTaxCategoryCode(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE)
+					.setTaxExemptionReason("Not subject to VAT"),
+				itemAmount, new java.math.BigDecimal("1.0")));
+
+		// document-level allowance with category O — must NOT produce RateApplicablePercent (BR-O-06)
+		Allowance allowanceO = new Allowance(new BigDecimal("10.00"));
+		allowanceO.setReason("Discount");
+		allowanceO.setCategoryCode(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE);
+		allowanceO.setTaxPercent(BigDecimal.ZERO);
+		invoice.addAllowance(allowanceO);
+
+		// document-level allowance with category AE — MUST produce RateApplicablePercent = 0 (BR-AE-06)
+		Allowance allowanceAE = new Allowance(new BigDecimal("5.00"));
+		allowanceAE.setReason("Reverse charge discount");
+		allowanceAE.setCategoryCode(TaxCategoryCodeTypeConstants.REVERSECHARGE);
+		allowanceAE.setTaxPercent(BigDecimal.ZERO);
+		invoice.addAllowance(allowanceAE);
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("EN16931"));
+		zf2p.generateXML(invoice);
+		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
+
+		// Count RateApplicablePercent inside SpecifiedTradeAllowanceCharge nodes only
+		assertThat(theXML)
+			// The O-category allowance CategoryTradeTax must have no RateApplicablePercent
+			.valueByXPath("count(//*[local-name()='SpecifiedTradeAllowanceCharge'][.//*[local-name()='CategoryCode' and text()='O']]//*[local-name()='RateApplicablePercent'])")
+			.asInt()
+			.isEqualTo(0);
+
+		// The AE-category allowance CategoryTradeTax must have exactly one RateApplicablePercent
+		assertThat(theXML)
+			.valueByXPath("count(//*[local-name()='SpecifiedTradeAllowanceCharge'][.//*[local-name()='CategoryCode' and text()='AE']]//*[local-name()='RateApplicablePercent'])")
+			.asInt()
+			.isEqualTo(1);
+	}
+
 	private org.mustangproject.Invoice createInvoice(TradeParty recipient) {
 		String orgname = "Test company";
 		String number = "123";


### PR DESCRIPTION

## Summary

Document-level allowances (BG-20) with VAT category `O` ("Not subject to VAT") emitted
`ram:RateApplicablePercent`, violating EN16931 rule BR-O-06. The document-level **charge**
branch already guarded this correctly; the **allowance** branch did not.

## Fix

One-line guard added to the allowance branch in `ZUGFeRD2PullProvider`, mirroring the
existing charge branch:

```java
// before
if (allowance.getTaxPercent() != null) {

// after
if (allowance.getTaxPercent() != null && !allowance.getCategoryCode().equals(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE)) {
```

Category `AE` (reverse charge) is unaffected — BR-AE-06 requires `RateApplicablePercent = 0`
and Mustang already emits it correctly.

## Normative source

`FACTUR-X_EN16931.sch`, rule BR-O-06:
```xml
<assert test="not(ram:RateApplicablePercent)">
  [BR-O-06]-A Document level allowance (BG-20) where VAT category code (BT-95) is
  "Not subject to VAT" shall not contain a Document level allowance VAT rate (BT-96).
</assert>
```

Fixes #1145

## Test

Added a test case in `XRTest` asserting that a document-level allowance with
`categoryCode = "O"` produces no `RateApplicablePercent` in the generated XML.
