### PR TITLE
Add VAT exemption reason text and code to allowances and charges.

### DIFF
--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -45,6 +45,17 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	 */
 	protected String categoryCode;
 
+	/**
+	 * a simple human readable description
+	 */
+	protected String taxExemptionReason;
+	/***
+	 *
+	 * @param taxExemptionReasonCode, https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/
+	 * @return fluent setter
+	 */
+	protected String taxExemptionReasonCode;
+
 	/***
 	 * Bean connstructor
 	 */
@@ -204,6 +215,40 @@ public class Charge implements IZUGFeRDAllowanceCharge {
 	 */
 	public Charge setCategoryCode(String categoryCode) {
 		this.categoryCode = categoryCode;
+		return this;
+	}
+
+	/***
+	 *
+	 * @return e.g. intra-commnunity supply or small business
+	 */
+	@Override
+	public String getTaxExemptionReason() {
+		return taxExemptionReason;
+	}
+
+	/***
+	 *
+	 * @param taxExemptionReasonText String e.g. Kleinunternehmer gemäß §19 UStG https://github.com/ZUGFeRD/mustangproject/issues/463
+	 * @return fluent setter
+	 */
+	public Charge setTaxExemptionReason(String taxExemptionReasonText) {
+		this.taxExemptionReason = taxExemptionReasonText;
+		return this;
+	}
+
+	@Override
+	public String getTaxExemptionReasonCode() {
+		return taxExemptionReasonCode;
+	}
+
+	/***
+	 *
+	 * @param taxExemptionReasonCode, https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/
+	 * @return fluent setter
+	 */
+	public Charge setTaxExemptionReasonCode(String taxExemptionReasonCode) {
+		this.taxExemptionReasonCode = taxExemptionReasonCode;
 		return this;
 	}
 }

--- a/library/src/main/java/org/mustangproject/Product.java
+++ b/library/src/main/java/org/mustangproject/Product.java
@@ -264,6 +264,7 @@ public class Product implements IZUGFeRDExportableProduct {
 	public Product setIntraCommunitySupply() {
 		isIntraCommunitySupply = true;
 		setVATPercent(BigDecimal.ZERO);
+		setTaxExemptionReasonCode("VATEX-EU-IC");
 		setTaxExemptionReason("Intra-community supply");
 		setTaxCategoryCode("K");
 		return this;

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -33,13 +33,13 @@ public interface IZUGFeRDAllowanceCharge {
 	BigDecimal getTotalAmount(IAbsoluteValueProvider trans);
 
 	/***
-	 * returns a percentage, if relative abount, or null for absolute amounts
-	 * @return null or Percentage as Bigdecimal
+	 * returns a percentage, if relative amount, or null for absolute amounts
+	 * @return null or Percentage as BigDecimal
 	 */
 	default BigDecimal getPercent() {return null;}
 
 	/***
-	 * returns a basis the precentage is calculated from
+	 * returns a basis the percentage is calculated from
 	 * @return null or the basis
 	 */
 	default BigDecimal getBasisAmount() {return null;}
@@ -72,7 +72,19 @@ public interface IZUGFeRDAllowanceCharge {
 
 	/***
 	 * is this in reality a charge and now allowance
-	 * @return true if amnount to be treated negative
+	 * @return true if amount to be treated negative
 	 */
 	public boolean isCharge();
+
+	/***
+	 * the the reason (text) why this allowance/charge is tax free
+	 * @return the reason text
+	 */
+	public String getTaxExemptionReason();
+
+	/***
+	 * the the reason code why this allowance/charge is tax free
+	 * @return the reason code
+	 */
+	public String getTaxExemptionReasonCode();
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -835,11 +835,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				final boolean displayExemptionReason = CATEGORY_CODES_WITH_EXEMPTION_REASON.contains(amountCategoryCode);
 				if (getProfile() != Profiles.getByName("Minimum")) {
 					String exemptionReasonTextXML = "";
-					if ((displayExemptionReason) && (amount.getVatExemptionReasonText() != null)) {
+					if (displayExemptionReason && amount.getVatExemptionReasonText() != null) {
 						exemptionReasonTextXML = "<ram:ExemptionReason>" + XMLTools.encodeXML(amount.getVatExemptionReasonText()) + "</ram:ExemptionReason>";
 					}
 					String exemptionReasonCodeXML = "";
-					if (amount.getVatExemptionReasonCode() != null) {
+					if (displayExemptionReason && amount.getVatExemptionReasonCode() != null) {
 						exemptionReasonCodeXML = "<ram:ExemptionReasonCode>" + XMLTools.encodeXML(amount.getVatExemptionReasonCode()) + "</ram:ExemptionReasonCode>";
 					}
 
@@ -872,6 +872,16 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		if ((trans.getZFCharges() != null) && (trans.getZFCharges().length > 0)) {
 			if ((profile == Profiles.getByName("XRechnung")) || (profile == Profiles.getByName("EN16931")) || (profile == Profiles.getByName("EXTENDED"))) {
 				for (IZUGFeRDAllowanceCharge charge : trans.getZFCharges()) {
+					final boolean displayExemptionReason = CATEGORY_CODES_WITH_EXEMPTION_REASON.contains(charge.getCategoryCode());
+					String exemptionReasonTextXML = "";
+					if (displayExemptionReason && charge.getTaxExemptionReason() != null) {
+						exemptionReasonTextXML = "<ram:ExemptionReason>" + XMLTools.encodeXML(charge.getTaxExemptionReason()) + "</ram:ExemptionReason>";
+					}
+					String exemptionReasonCodeXML = "";
+					if (displayExemptionReason && charge.getTaxExemptionReasonCode() != null) {
+						exemptionReasonCodeXML = "<ram:ExemptionReasonCode>" + XMLTools.encodeXML(charge.getTaxExemptionReasonCode()) + "</ram:ExemptionReasonCode>";
+					}
+
 					xml += "<ram:SpecifiedTradeAllowanceCharge>" +
 						"<ram:ChargeIndicator>" +
 						"<udt:Indicator>true</udt:Indicator>" +
@@ -891,7 +901,9 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					}
 					xml += "<ram:CategoryTradeTax>" +
 						"<ram:TypeCode>VAT</ram:TypeCode>" +
-						"<ram:CategoryCode>" + charge.getCategoryCode() + "</ram:CategoryCode>";
+						exemptionReasonTextXML +
+						"<ram:CategoryCode>" + charge.getCategoryCode() + "</ram:CategoryCode>" +
+						exemptionReasonCodeXML;
 					if (charge.getTaxPercent() != null && !charge.getCategoryCode().equals(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE)) {
 						xml += "<ram:RateApplicablePercent>" + vatFormat(charge.getTaxPercent()) + "</ram:RateApplicablePercent>";
 					}
@@ -922,6 +934,16 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		if ((trans.getZFAllowances() != null) && (trans.getZFAllowances().length > 0)) {
 			if ((profile == Profiles.getByName("XRechnung")) || (profile == Profiles.getByName("EN16931")) || (profile == Profiles.getByName("EXTENDED"))) {
 				for (IZUGFeRDAllowanceCharge allowance : trans.getZFAllowances()) {
+					final boolean displayExemptionReason = CATEGORY_CODES_WITH_EXEMPTION_REASON.contains(allowance.getCategoryCode());
+					String exemptionReasonTextXML = "";
+					if (displayExemptionReason && allowance.getTaxExemptionReason() != null) {
+						exemptionReasonTextXML = "<ram:ExemptionReason>" + XMLTools.encodeXML(allowance.getTaxExemptionReason()) + "</ram:ExemptionReason>";
+					}
+					String exemptionReasonCodeXML = "";
+					if (displayExemptionReason && allowance.getTaxExemptionReasonCode() != null) {
+						exemptionReasonCodeXML = "<ram:ExemptionReasonCode>" + XMLTools.encodeXML(allowance.getTaxExemptionReasonCode()) + "</ram:ExemptionReasonCode>";
+					}
+
 					xml += "<ram:SpecifiedTradeAllowanceCharge>" +
 						"<ram:ChargeIndicator>" +
 						"<udt:Indicator>false</udt:Indicator>" +
@@ -940,8 +962,10 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 						xml += "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
 					}
 					xml += "<ram:CategoryTradeTax>" +
-						"<ram:TypeCode>VAT</ram:TypeCode>" +
-						"<ram:CategoryCode>" + allowance.getCategoryCode() + "</ram:CategoryCode>";
+							"<ram:TypeCode>VAT</ram:TypeCode>" +
+							exemptionReasonTextXML +
+							"<ram:CategoryCode>" + allowance.getCategoryCode() + "</ram:CategoryCode>" +
+							exemptionReasonCodeXML;
 					if (allowance.getTaxPercent() != null && !allowance.getCategoryCode().equals(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE)) {
 						xml += "<ram:RateApplicablePercent>" + vatFormat(allowance.getTaxPercent()) + "</ram:RateApplicablePercent>";
 					}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -1176,6 +1176,9 @@ public class ZUGFeRDInvoiceImporter {
 				String reason = null;
 				String reasonCode = null;
 				String taxPercent = null;
+				String taxExemptionReason = null;
+				String categoryCode = null;
+				String taxExemptionReasonCode = null;
 				for (int chargeChildIndex = 0; chargeChildIndex < chargeNodeChilds.getLength(); chargeChildIndex++) {
 					String chargeChildName = chargeNodeChilds.item(chargeChildIndex).getLocalName();
 					if (chargeChildName != null) {
@@ -1210,8 +1213,17 @@ public class ZUGFeRDInvoiceImporter {
 							NodeList taxChilds = chargeNodeChilds.item(chargeChildIndex).getChildNodes();
 							for (int taxChildIndex = 0; taxChildIndex < taxChilds.getLength(); taxChildIndex++) {
 								String taxItemName = taxChilds.item(taxChildIndex).getLocalName();
-								if ((taxItemName != null) && (taxItemName.equals("RateApplicablePercent") || taxItemName.equals("ApplicablePercent") || taxItemName.equals("Percent"))) {
+								if (taxItemName != null && (taxItemName.equals("RateApplicablePercent") || taxItemName.equals("ApplicablePercent") || taxItemName.equals("Percent"))) {
 									taxPercent = XMLTools.trimOrNull(taxChilds.item(taxChildIndex));
+								}
+								if (taxItemName != null && (taxItemName.equals("ExemptionReason") || taxItemName.equals("TaxExemptionReason"))) {
+									taxExemptionReason = XMLTools.trimOrNull(taxChilds.item(taxChildIndex));
+								}
+								if (taxItemName != null && (taxItemName.equals("CategoryCode") || taxItemName.equals("ID"))) {
+									categoryCode = XMLTools.trimOrNull(taxChilds.item(taxChildIndex));
+								}
+								if (taxItemName != null && (taxItemName.equals("ExemptionReasonCode") || taxItemName.equals("TaxExemptionReasonCode"))) {
+									taxExemptionReasonCode = XMLTools.trimOrNull(taxChilds.item(taxChildIndex));
 								}
 							}
 						}
@@ -1232,6 +1244,15 @@ public class ZUGFeRDInvoiceImporter {
 					if (basisAmount != null) {
 						c.setBasisAmount(new BigDecimal(basisAmount));
 					}
+					if (taxExemptionReason != null) {
+						c.setTaxExemptionReason(taxExemptionReason);
+					}
+					if (categoryCode != null) {
+						c.setCategoryCode(categoryCode);
+					}
+					if (taxExemptionReasonCode != null) {
+						c.setTaxExemptionReasonCode(taxExemptionReasonCode);
+					}
 					zpp.addCharge(c);
 				} else {
 					Allowance a = new Allowance(new BigDecimal(chargeAmount));
@@ -1246,6 +1267,15 @@ public class ZUGFeRDInvoiceImporter {
 					}
 					if (basisAmount != null) {
 						a.setBasisAmount(new BigDecimal(basisAmount));
+					}
+					if (taxExemptionReason != null) {
+						a.setTaxExemptionReason(taxExemptionReason);
+					}
+					if (categoryCode != null) {
+						a.setCategoryCode(categoryCode);
+					}
+					if (taxExemptionReasonCode != null) {
+						a.setTaxExemptionReasonCode(taxExemptionReasonCode);
 					}
 					zpp.addAllowance(a);
 				}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
@@ -25,7 +25,9 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 	private String reason;
 	private String reasonCode;
 	private BigDecimal taxPercent;
-	boolean isCharge=true;
+	private boolean isCharge=true;
+	private String taxExemptionReason;
+	private String taxExemptionReasonCode;
 
 	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
@@ -52,6 +54,16 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 		return isCharge;
 	}
 
+	@Override
+	public String getTaxExemptionReason() {
+		return taxExemptionReason;
+	}
+
+	@Override
+	public String getTaxExemptionReasonCode() {
+		return taxExemptionReasonCode;
+	}
+
 	public IZUGFeRDAllowanceChargeImpl setAllowance() {
 		isCharge = false;
 		return this;
@@ -74,6 +86,16 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge {
 
 	public IZUGFeRDAllowanceChargeImpl setTaxPercent(BigDecimal taxPercent) {
 		this.taxPercent = taxPercent;
+		return this;
+	}
+
+	public IZUGFeRDAllowanceChargeImpl setTaxExemptionReason(String taxExemptionReasonText) {
+		this.taxExemptionReason = taxExemptionReasonText;
+		return this;
+	}
+
+	public IZUGFeRDAllowanceChargeImpl setTaxExemptionReasonCode(String taxExemptionReasonCode) {
+		this.taxExemptionReasonCode = taxExemptionReasonCode;
 		return this;
 	}
 }

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -41,6 +41,7 @@ import junit.framework.TestCase;
 
 import org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants;
 import org.mustangproject.ZUGFeRD.model.EventTimeCodeTypeConstants;
+import org.mustangproject.ZUGFeRD.model.TaxCategoryCodeTypeConstants;
 
 import javax.xml.xpath.XPathExpressionException;
 
@@ -63,6 +64,7 @@ public class ZF2PushTest extends TestCase {
 	final String TARGET_INTRACOMMUNITYSUPPLYMANUALPDF = "./target/testout-ZF2PushIntraCommunitySupplyManual.pdf";
 	final String TARGET_INTRACOMMUNITYSUPPLYPDF = "./target/testout-ZF2PushIntraCommunitySupply.pdf";
 	final String TARGET_REVERSECHARGEPDF = "./target/testout-ZF2PushReverseCharge.pdf";
+	final String TARGET_ALLOWANCES_TAXES = "./target/testout-ZF2PushAllowancesTaxes.pdf";
 
 	public void testPushExport() {
 		/***
@@ -969,5 +971,62 @@ public class ZF2PushTest extends TestCase {
 		assertFalse(theXML.contains("<ram:ContractReferencedDocument"));
 		assertFalse(theXML.contains("<ram:DespatchAdviceReferencedDocument"));
 		assertFalse(theXML.contains("<ram:InvoiceReferencedDocument"));
+	}
+
+	public void testDocumentLevelAllowanceVatRateByCategory() {
+		TradeParty sender = new TradeParty("Test Seller", "Seller Street 1", "10000", "Test City", "DE").setID("SELLER-001").addTaxID("4711").addVATID("DE0815");
+		TradeParty recipient = new TradeParty("Test Buyer", "Buyer Street 1", "10000", "Test City", "FR").addVATID("FR555444333222111");
+		String number = "INV-BR-O-06";
+		BigDecimal itemAmount = new BigDecimal("100.00");
+
+		Invoice invoice = new Invoice()
+			.setDueDate(new java.util.Date()).setIssueDate(new java.util.Date()).setDeliveryDate(new java.util.Date())
+			.setSender(sender)
+			.setRecipient(recipient)
+			.setDeliveryAddress(recipient)
+			.setNumber(number)
+			.addItem(new org.mustangproject.Item(new org.mustangproject.Product("Test item", "", "C62", java.math.BigDecimal.ZERO).setIntraCommunitySupply(), itemAmount, new java.math.BigDecimal("1.0")));
+
+		Allowance allowance1 = new Allowance(new BigDecimal("10.00"));
+		allowance1.setReason("Discount");
+		allowance1.setCategoryCode(TaxCategoryCodeTypeConstants.INTRACOMMUNITY);
+		allowance1.setTaxPercent(BigDecimal.ZERO);
+		allowance1.setTaxExemptionReasonCode("VATEX-EU-IC");
+		allowance1.setTaxExemptionReason(invoice.getZFItems()[0].getProduct().getTaxExemptionReason());
+		invoice.addAllowance(allowance1);
+
+		Allowance allowance2 = new Allowance(new BigDecimal("5.00"));
+		allowance2.setReason("another discount");
+		allowance2.setCategoryCode(TaxCategoryCodeTypeConstants.INTRACOMMUNITY);
+		allowance2.setTaxPercent(BigDecimal.ZERO);
+		allowance2.setTaxExemptionReasonCode("VATEX-EU-IC");
+		allowance2.setTaxExemptionReason(invoice.getZFItems()[0].getProduct().getTaxExemptionReason());
+		invoice.addAllowance(allowance2);
+
+		try {
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
+			ze.ignorePDFAErrors().load(SOURCE_PDF);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
+
+			ze.setTransaction(invoice);
+			ze.export(TARGET_ALLOWANCES_TAXES);
+
+			ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_ALLOWANCES_TAXES);
+			try {
+				Invoice i = zii.extractInvoice();
+
+
+			} catch (XPathExpressionException e) {
+				fail("XPathExpressionException should not be raised");
+			} catch (ParseException e) {
+				fail("ParseException should not be raised");
+				/* a parseException would also be fired if the calculated grand total does not
+				match the read grand total */
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+			fail("IOException should not be raised");
+		}
 	}
 }

--- a/validator/src/test/java/org/mustangproject/validator/LibraryTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/LibraryTest.java
@@ -356,4 +356,28 @@ public class LibraryTest extends ResourceCase {
 			.isEqualTo(0);
 	}
 
+	public void testAllowancesTaxes() {
+		File tempFile = new File("../library/target/testout-ZF2PushAllowancesTaxes.pdf");
+		assertTrue(tempFile.exists());
+		ZUGFeRDValidator zfv = new ZUGFeRDValidator();
+
+		String res = zfv.validate(tempFile.getAbsolutePath());
+
+		assertThat(res).valueByXPath("/validation/pdf/summary/@status")
+			.isEqualTo("valid");
+
+		assertThat(res).valueByXPath("/validation/xml/summary/@status")
+			.isEqualTo("valid");
+
+		assertThat(res).valueByXPath("/validation/summary/@status")
+			.isEqualTo("valid");
+
+		assertThat(res).valueByXPath("count(//error)")
+			.asInt()
+			.isEqualTo(0);
+
+		assertThat(res).valueByXPath("count(//warning)")
+			.asInt()
+			.isEqualTo(0);
+	}
 }


### PR DESCRIPTION
Created a test to reproduce the warning.
Added taxExemptionReason / taxExemptionReasonCode to Charge classes and interface.
Enhanced ZUGFeRD2Pullprovider to write these new values.
Enhanced ZUGFeRDInvoiceImporter to read the new elements.
Assure, that setTaxExemptionReasonCode is also set on Product when Product::setIntraCommunitySupply() is used.