### PR TITLE
Fix UBL AllowanceCharge import: dead header XPath, missing percent/basisAmount aliases, dropped per-unit-price allowances

### DIFF
--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -106,6 +106,55 @@ public class Item implements IZUGFeRDExportableItem {
 			// PriceAmount with currencyID and  BaseQuantity with unitCode
 			icnm.getAsBigDecimal("PriceAmount").ifPresent(this::setPrice);
 			icnm.getAsBigDecimal("BaseQuantity").ifPresent(this::setBasisQuantity);
+
+			// ubl equivalent of CII's GrossPriceProductTradePrice/AppliedTradeAllowanceCharge:
+			// a per-unit price allowance/charge nested under cac:Price
+			icnm.getAsNodeMap("AllowanceCharge").ifPresent(priceAtacNodes -> {
+				String chargeIndicator = priceAtacNodes.getAsStringOrNull("ChargeIndicator");
+				String percentString = priceAtacNodes.getAsStringOrNull("MultiplierFactorNumeric");
+				String basisAmountString = priceAtacNodes.getAsStringOrNull("BaseAmount");
+				String reason = priceAtacNodes.getAsStringOrNull("AllowanceChargeReason");
+				String reasonCode = priceAtacNodes.getAsStringOrNull("AllowanceChargeReasonCode");
+				if ((chargeIndicator != null) && priceAtacNodes.getAsBigDecimal("Amount").isPresent()) {
+					BigDecimal actual = priceAtacNodes.getAsBigDecimal("Amount").get();
+					if (chargeIndicator.equalsIgnoreCase("true")) {
+						Charge izac = new Charge();
+						izac.setTotalAmount(actual);
+						if (percentString != null) {
+							izac.setPercent(new BigDecimal(percentString));
+						}
+						if (basisAmountString != null) {
+							izac.setBasisAmount(new BigDecimal(basisAmountString));
+						}
+						if (reason != null) {
+							izac.setReason(reason);
+						}
+						if (reasonCode != null) {
+							izac.setReasonCode(reasonCode);
+						}
+						product.addCharge(izac);
+						setPrice(getPrice().subtract(actual)); // the gross price affects the net price, which is read,
+						// so if we do not ignore charges|allowances we have to re-compensate the net price
+					} else {
+						Allowance izac = new Allowance();
+						izac.setTotalAmount(actual);
+						if (percentString != null) {
+							izac.setPercent(new BigDecimal(percentString));
+						}
+						if (basisAmountString != null) {
+							izac.setBasisAmount(new BigDecimal(basisAmountString));
+						}
+						if (reason != null) {
+							izac.setReason(reason);
+						}
+						if (reasonCode != null) {
+							izac.setReasonCode(reasonCode);
+						}
+						product.addAllowance(izac);
+						setPrice(getPrice().add(actual));
+					}
+				}
+			});
 		});
 
 		itemMap.getNode(new String[]{"InvoicedQuantity", "CreditedQuantity"}).ifPresent(icn -> {
@@ -228,6 +277,7 @@ public class Item implements IZUGFeRDExportableItem {
 					String amountString = stac.getAsStringOrNull("ActualAmount");
 					String basisAmountString = stac.getAsStringOrNull("BasisAmount");
 					String reason = stac.getAsStringOrNull("Reason");
+					String reasonCode = stac.getAsStringOrNull("ReasonCode");
 					Charge izac = new Charge();
 					if (isChargeString.equalsIgnoreCase("false")) {
 						izac = new Allowance();
@@ -245,6 +295,9 @@ public class Item implements IZUGFeRDExportableItem {
 					}
 					if (reason != null) {
 						izac.setReason(reason);
+					}
+					if (reasonCode != null) {
+						izac.setReasonCode(reasonCode);
 					}
 
 					if (isChargeString.equalsIgnoreCase("false")) {
@@ -280,6 +333,7 @@ public class Item implements IZUGFeRDExportableItem {
 			String percentString = stac.getAsStringOrNull("MultiplierFactorNumeric");
 			String amountString = stac.getAsStringOrNull("Amount");
 			String reason = stac.getAsStringOrNull("AllowanceChargeReason");
+			String reasonCode = stac.getAsStringOrNull("AllowanceChargeReasonCode");
 			Charge izac = new Charge();
 			if (isChargeString.equalsIgnoreCase("false")) {
 				izac = new Allowance();
@@ -294,6 +348,9 @@ public class Item implements IZUGFeRDExportableItem {
 			}
 			if (reason != null) {
 				izac.setReason(reason);
+			}
+			if (reasonCode != null) {
+				izac.setReasonCode(reasonCode);
 			}
 
 			if (isChargeString.equalsIgnoreCase("false")) {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -1169,13 +1169,14 @@ public class ZUGFeRDInvoiceImporter {
 			// be read,
 			// so the invoice remains arithmetically correct
 			// -> parse document level charges+allowances
-			xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedTradeAllowanceCharge\"]|/*[local-name()=\"AllowanceCharge\"]");//CII and UBL
+			xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedTradeAllowanceCharge\"]|/*[local-name()=\"Invoice\" or local-name()=\"CreditNote\"]/*[local-name()=\"AllowanceCharge\"]");//CII and UBL
 			NodeList chargeNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
 			for (int i = 0; i < chargeNodes.getLength(); i++) {
 				NodeList chargeNodeChilds = chargeNodes.item(i).getChildNodes();
 				boolean isCharge = true;
 				String chargeAmount = null;
 				String basisAmount = null;
+				String percent = null;
 				String reason = null;
 				String reasonCode = null;
 				String taxPercent = null;
@@ -1206,8 +1207,10 @@ public class ZUGFeRDInvoiceImporter {
 
 						} else if (chargeChildName.equals("ActualAmount") || chargeChildName.equals("Amount")) {
 							chargeAmount = XMLTools.trimOrNull(chargeNodeChilds.item(chargeChildIndex));
-						} else if (chargeChildName.equals("BasisAmount")) {
+						} else if (chargeChildName.equals("BasisAmount") || chargeChildName.equals("BaseAmount")) {
 							basisAmount = XMLTools.trimOrNull(chargeNodeChilds.item(chargeChildIndex));
+						} else if (chargeChildName.equals("CalculationPercent") || chargeChildName.equals("MultiplierFactorNumeric")) {
+							percent = XMLTools.trimOrNull(chargeNodeChilds.item(chargeChildIndex));
 						} else if (chargeChildName.equals("Reason") || chargeChildName.equals("AllowanceChargeReason")) {
 							reason = XMLTools.trimOrNull(chargeNodeChilds.item(chargeChildIndex));
 						} else if (chargeChildName.equals("ReasonCode") || chargeChildName.equals("AllowanceChargeReasonCode")) {
@@ -1234,7 +1237,13 @@ public class ZUGFeRDInvoiceImporter {
 				}
 
 				if (isCharge) {
-					Charge c = new Charge(new BigDecimal(chargeAmount));
+					Charge c = new Charge();
+					if (chargeAmount != null) {
+						c.setTotalAmount(new BigDecimal(chargeAmount));
+					}
+					if (percent != null) {
+						c.setPercent(new BigDecimal(percent));
+					}
 					if (reason != null) {
 						c.setReason(reason);
 					}
@@ -1258,7 +1267,13 @@ public class ZUGFeRDInvoiceImporter {
 					}
 					zpp.addCharge(c);
 				} else {
-					Allowance a = new Allowance(new BigDecimal(chargeAmount));
+					Allowance a = new Allowance();
+					if (chargeAmount != null) {
+						a.setTotalAmount(new BigDecimal(chargeAmount));
+					}
+					if (percent != null) {
+						a.setPercent(new BigDecimal(percent));
+					}
 					if (reason != null) {
 						a.setReason(reason);
 					}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/AllowanceChargeUBLRoundTripTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/AllowanceChargeUBLRoundTripTest.java
@@ -1,0 +1,215 @@
+/**
+ * *********************************************************************
+ * <p>
+ * Use is subject to license terms.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * <p>
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * **********************************************************************
+ */
+package org.mustangproject.ZUGFeRD;
+
+import org.mustangproject.Allowance;
+import org.mustangproject.CII.CIIToUBL;
+import org.mustangproject.Charge;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.TradeParty;
+import org.mustangproject.ZUGFeRD.model.TaxCategoryCodeTypeConstants;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Date;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/***
+ * End-to-end round-trip test for AllowanceCharge handling across the real production pipeline:
+ * mustangproject CII export -&gt; com.helger.en16931.cii2ubl.CIIToUBL23Converter (UBL) -&gt;
+ * ZUGFeRDInvoiceImporter (back into the internal model) -&gt; ZUGFeRD2PullProvider (CII again).
+ * <p>
+ * This exercises header-level amount-based and percent-only allowances/charges, line-level
+ * (BT-136/BT-141 style) allowances, and per-unit-price allowances nested under
+ * GrossPriceProductTradePrice/cac:Price - i.e. all of the cases fixed for UBL AllowanceCharge import.
+ */
+public class AllowanceChargeUBLRoundTripTest extends ResourceCase {
+
+	public void testHeaderAndLineAllowanceChargeSurviveCIIToUBLToCIIRoundTrip() throws Exception {
+
+		BigDecimal price = new BigDecimal("100.00");
+		BigDecimal qty = BigDecimal.ONE;
+
+		BigDecimal headerChargeAmount = new BigDecimal("12.50");
+		BigDecimal headerAllowancePercent = new BigDecimal("5.00");
+		BigDecimal headerAllowanceBasis = new BigDecimal("100.00");
+
+		BigDecimal lineAllowanceAmount = new BigDecimal("2.00");
+		BigDecimal perUnitAllowanceAmount = new BigDecimal("1.00");
+
+		Product product = new Product("Testprodukt", "", "H87", new BigDecimal("19"));
+		// Bug 4 case: per-unit-price allowance, exported under GrossPriceProductTradePrice/AppliedTradeAllowanceCharge (CII)
+		// and cac:Price/cac:AllowanceCharge (UBL)
+		product.addAllowance(new Allowance(perUnitAllowanceAmount));
+
+		Item item = new Item(product, price, qty)
+			// Bug 3 case: genuine line-level allowance, SpecifiedLineTradeSettlement/SpecifiedTradeAllowanceCharge (CII)
+			// and a direct-child cac:AllowanceCharge under cac:InvoiceLine (UBL)
+			.addAllowance(new Allowance(lineAllowanceAmount).setReason("line discount").setReasonCode("95"));
+
+		Invoice invoice = new Invoice()
+			.setCurrency("EUR")
+			.setIssueDate(new Date())
+			.setDueDate(new Date())
+			.setDeliveryDate(new Date())
+			.setNumber("RT-1")
+			.setSender(new TradeParty("Test company", "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
+			.setRecipient(new TradeParty("Franz Mueller", "teststr.12", "55232", "Entenhausen", "DE"))
+			.addItem(item)
+			// Bug 2 amount-based case, with reason/reasonCode/taxPercent/categoryCode
+			.addCharge(new Charge(headerChargeAmount).setReason("Handling").setReasonCode("FC")
+				.setTaxPercent(new BigDecimal("19")).setCategoryCode(TaxCategoryCodeTypeConstants.STANDARDRATE))
+			// Bug 2 percent-only case (no ActualAmount at all) - this used to throw NumberFormatException on import
+			.addAllowance(new Allowance().setPercent(headerAllowancePercent).setBasisAmount(headerAllowanceBasis)
+				.setReason("Loyalty discount").setReasonCode("95")
+				.setTaxPercent(new BigDecimal("19")).setCategoryCode(TaxCategoryCodeTypeConstants.STANDARDRATE));
+
+		// 1. mustangproject: Invoice -> CII XML
+		ZUGFeRD2PullProvider originalProvider = new ZUGFeRD2PullProvider();
+		originalProvider.setProfile(Profiles.getByName("EXTENDED"));
+		originalProvider.generateXML(invoice);
+		byte[] originalCiiXml = originalProvider.getXML();
+
+		File ciiFile = File.createTempFile("AllowanceChargeRoundTrip-", "-cii.xml");
+		ciiFile.deleteOnExit();
+		Files.write(ciiFile.toPath(), originalCiiXml);
+
+		// 2. com.helger.en16931.cii2ubl.CIIToUBL23Converter: CII -> UBL (the real downstream pipeline, not mustang's own UBL exporter)
+		File ublFile = File.createTempFile("AllowanceChargeRoundTrip-", "-ubl.xml");
+		ublFile.deleteOnExit();
+		new CIIToUBL().convert(ciiFile, ublFile);
+		assertTrue("CIIToUBL23Converter should have produced a non-empty UBL file", ublFile.length() > 0);
+
+		// 3. ZUGFeRDInvoiceImporter: UBL -> internal model (this is what Bugs 1-4 were fixed in)
+		ZUGFeRDInvoiceImporter importer = new ZUGFeRDInvoiceImporter(new FileInputStream(ublFile));
+		Invoice reimported = importer.extractInvoice();
+
+		// 4. ZUGFeRD2PullProvider: internal model -> CII XML again
+		ZUGFeRD2PullProvider finalProvider = new ZUGFeRD2PullProvider();
+		finalProvider.setProfile(Profiles.getByName("EXTENDED"));
+		finalProvider.generateXML(reimported);
+		byte[] finalCiiXml = finalProvider.getXML();
+
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setNamespaceAware(true);
+		Document finalDoc = dbf.newDocumentBuilder().parse(new java.io.ByteArrayInputStream(finalCiiXml));
+
+		XPath xpath = XPathFactory.newInstance().newXPath();
+
+		// --- header level: amount-based charge ---
+		NodeList headerCharges = (NodeList) xpath.evaluate(
+			"//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedTradeAllowanceCharge\"]",
+			finalDoc, XPathConstants.NODESET);
+		Node headerCharge = findByIndicator(headerCharges, true);
+		assertNotNull("header charge (amount-based) should survive the round trip", headerCharge);
+		assertDecimalEquals(headerChargeAmount, childDecimal(headerCharge, "ActualAmount"));
+		assertEquals("Handling", childText(headerCharge, "Reason"));
+		assertEquals("FC", childText(headerCharge, "ReasonCode"));
+		Node headerChargeTax = child(headerCharge, "CategoryTradeTax");
+		assertNotNull(headerChargeTax);
+		assertEquals(TaxCategoryCodeTypeConstants.STANDARDRATE, childText(headerChargeTax, "CategoryCode"));
+		assertDecimalEquals(new BigDecimal("19"), childDecimal(headerChargeTax, "RateApplicablePercent"));
+
+		// --- header level: percent-only allowance (the case that used to crash on import) ---
+		Node headerAllowance = findByIndicator(headerCharges, false);
+		assertNotNull("header allowance (percent-only) should survive the round trip", headerAllowance);
+		assertDecimalEquals(headerAllowancePercent, childDecimal(headerAllowance, "CalculationPercent"));
+		assertDecimalEquals(headerAllowanceBasis, childDecimal(headerAllowance, "BasisAmount"));
+		assertNotNull("ActualAmount must have been computed from percent+basis, not crashed", childDecimal(headerAllowance, "ActualAmount"));
+		assertEquals("Loyalty discount", childText(headerAllowance, "Reason"));
+		assertEquals("95", childText(headerAllowance, "ReasonCode"));
+		Node headerAllowanceTax = child(headerAllowance, "CategoryTradeTax");
+		assertNotNull(headerAllowanceTax);
+		assertEquals(TaxCategoryCodeTypeConstants.STANDARDRATE, childText(headerAllowanceTax, "CategoryCode"));
+		assertDecimalEquals(new BigDecimal("19"), childDecimal(headerAllowanceTax, "RateApplicablePercent"));
+
+		// --- line level: genuine line-level allowance (BT-141 style, direct child of InvoiceLine in UBL) ---
+		NodeList lineAllowances = (NodeList) xpath.evaluate(
+			"//*[local-name()=\"SpecifiedLineTradeSettlement\"]/*[local-name()=\"SpecifiedTradeAllowanceCharge\"]",
+			finalDoc, XPathConstants.NODESET);
+		assertEquals(1, lineAllowances.getLength());
+		Node lineAllowance = lineAllowances.item(0);
+		assertEquals("false", childText(child(lineAllowance, "ChargeIndicator"), "Indicator"));
+		assertDecimalEquals(lineAllowanceAmount, childDecimal(lineAllowance, "ActualAmount"));
+		assertEquals("line discount", childText(lineAllowance, "Reason"));
+		assertEquals("95", childText(lineAllowance, "ReasonCode"));
+
+		// --- line level: per-unit-price allowance (Bug 4 case, nested under GrossPriceProductTradePrice / cac:Price) ---
+		NodeList perUnitAllowances = (NodeList) xpath.evaluate(
+			"//*[local-name()=\"GrossPriceProductTradePrice\"]/*[local-name()=\"AppliedTradeAllowanceCharge\"]",
+			finalDoc, XPathConstants.NODESET);
+		assertEquals(1, perUnitAllowances.getLength());
+		Node perUnitAllowance = perUnitAllowances.item(0);
+		assertEquals("false", childText(child(perUnitAllowance, "ChargeIndicator"), "Indicator"));
+		assertDecimalEquals(perUnitAllowanceAmount, childDecimal(perUnitAllowance, "ActualAmount"));
+	}
+
+	private static void assertDecimalEquals(BigDecimal expected, BigDecimal actual) {
+		assertNotNull("expected a numeric value but found none", actual);
+		assertTrue("expected " + expected + " but was " + actual, expected.compareTo(actual) == 0);
+	}
+
+	private static Node findByIndicator(NodeList nodes, boolean isCharge) {
+		String expected = isCharge ? "true" : "false";
+		for (int i = 0; i < nodes.getLength(); i++) {
+			Node candidate = nodes.item(i);
+			Node indicatorParent = child(candidate, "ChargeIndicator");
+			if (indicatorParent != null && expected.equalsIgnoreCase(childText(indicatorParent, "Indicator"))) {
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	private static Node child(Node parent, String localName) {
+		if (parent == null) {
+			return null;
+		}
+		NodeList children = parent.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node c = children.item(i);
+			if (localName.equals(c.getLocalName())) {
+				return c;
+			}
+		}
+		return null;
+	}
+
+	private static String childText(Node parent, String localName) {
+		Node c = child(parent, localName);
+		return c == null ? null : c.getTextContent().trim();
+	}
+
+	private static BigDecimal childDecimal(Node parent, String localName) {
+		String text = childText(parent, localName);
+		return text == null ? null : new BigDecimal(text);
+	}
+}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
@@ -550,6 +550,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 				"    \"itemAllowances\" : [ {\n" +
 				"      \"totalAmount\" : 0.1,\n" +
 				"      \"taxPercent\" : 0,\n" +
+				"      \"reasonCode\" : \"95\",\n" +
 				"      \"categoryCode\" : \"S\"\n" +
 				"    } ],\n" +
 				"    \"value\" : 3.0,\n" +
@@ -602,6 +603,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 				"      \"totalAmount\" : 1.0,\n" +
 				"      \"taxPercent\" : 0,\n" +
 				"      \"reason\" : \"AnotherReason\",\n" +
+				"      \"reasonCode\" : \"ABK\",\n" +
 				"      \"categoryCode\" : \"S\"\n" +
 				"    } ],\n" +
 				"    \"value\" : 3.0,\n" +
@@ -633,6 +635,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 				"      \"totalAmount\" : 1.0,\n" +
 				"      \"taxPercent\" : 0,\n" +
 				"      \"reason\" : \"Yet another reason\",\n" +
+				"      \"reasonCode\" : \"ABK\",\n" +
 				"      \"categoryCode\" : \"S\"\n" +
 				"    } ],\n" +
 				"    \"value\" : 3.0,\n" +


### PR DESCRIPTION
## Summary

  `ZUGFeRDInvoiceImporter` silently dropped or mis-read `AllowanceCharge` data when importing UBL (as opposed to CII) invoices. Four issues,   verified against source and fixed:

  1. **Header-level AllowanceCharge XPath was dead code for UBL.**
     The fallback branch `/*[local-name()="AllowanceCharge"]` uses a single leading slash, which only matches a document root literally named `AllowanceCharge` — impossible, since the UBL root is `Invoice`/`CreditNote`. Fixed to `/*[local-name()="Invoice" or local-name()="CreditNote"]/*[local-name()="AllowanceCharge"]`, scoped to a direct child of the root so it doesn't also pick up line-level `AllowanceCharge` nested deeper in `InvoiceLine`/`Price`.

  2. **Header-level `basisAmount`/`percent` only recognized CII names.**
     `basisAmount` matched `BasisAmount` only (missing UBL's `BaseAmount`), and `percent` wasn't read at all — for either syntax. Worse, `Charge`/`Allowance` were always constructed with `new Charge(new BigDecimal(chargeAmount))`, so a percent-only charge/allowance (no `ActualAmount`/`Amount`) threw `NumberFormatException` on import. Fixed by aliasing `CalculationPercent`/`MultiplierFactorNumeric` and  `BasisAmount`/`BaseAmount`, and switching to a no-arg constructor with conditional `setTotalAmount`/`setPercent`/`setBasisAmount` (mirroring the pattern already used for line-level parsing).

  3. **Line-level `ReasonCode` was never read**, for either CII or UBL  `AllowanceCharge`. Added the alias in both blocks.

  4. **UBL per-unit-price allowances/charges nested under `cac:Price/cac:AllowanceCharge` were not parsed at all** — the CII equivalent (`GrossPriceProductTradePrice/AppliedTradeAllowanceCharge`) was handled, but nothing recognized the UBL nesting. Confirmed via this repo's own UBL exporter output (`testout-ZF2PushItemChargesAllowances.ubl.xml`): exporting an invoice with item-level charges to UBL and re-importing it lost the charges entirely. Added the missing branch, mirroring the existing CII handling (including the net/gross price compensation).

  ## Round-trip verification

  Added `AllowanceChargeUBLRoundTripTest`, which exercises the real downstream pipeline end-to-end: builds an `Invoice` with a header charge (amount-based), a header allowance (percent-only, no amount — the case that used to crash), a line-level allowance, and a per-unit-price allowance; exports to CII; converts to UBL via `com.helger.en16931.cii2ubl.CIIToUBL23Converter` (not mustang's own UBL exporter); re-imports via the fixed `ZUGFeRDInvoiceImporter`; re-exports to CII; and asserts all fields (amount, basisAmount, percent, reason, reasonCode, categoryCode, taxPercent, chargeIndicator) match the original input.

  ## Out of scope

  `cbc:ID` on `AllowanceCharge`, `PrepaidIndicator`, `SequenceNumeric`, and `AccountingCostCode` have no home in `Charge`/`Allowance`/`Item` and aren't used by any EN16931 CII profile for allowance/charge round-trip, so they were intentionally not added to the model.

  ## Test plan

  - [x] `AllowanceChargeUBLRoundTripTest` (new) passes
  - [x] Full library test suite passes (174 tests)
  - [x] Full multi-module suite passes (215 tests: library + validator)