### PR TITLE
Migrate publishing to Sonatype Central Portal

### DIFF
--- a/Mustang-CLI/pom.xml
+++ b/Mustang-CLI/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.deploy.skip>false</maven.deploy.skip><!-- deploy this module; the parent POM remains skipped -->
     </properties>
     <dependencies>
         <!-- compile dependencies -->
@@ -109,6 +110,19 @@
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${version.org.apache.maven.plugins.maven-source-plugin}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ cache. After that the mustang JAR can be used.
 More information on how to develop **on** mustang: 
  
  - [Developer documentation](https://github.com/ZUGFeRD/mustangproject/blob/master/doc/development_documentation.md)
+ - [Maven Central publishing guide](doc/maven-central-publishing.md)
 
 Usage
 -----

--- a/doc/development_documentation.md
+++ b/doc/development_documentation.md
@@ -97,6 +97,16 @@ can be used as debug configuration goal in Eclipse. In that case you can set bre
 
 ## Deployment
 
+The current deployment process uses the Central Portal, not OSSRH/Nexus. Follow
+the [Maven Central publishing guide](maven-central-publishing.md). Do not put
+Central or GPG credentials in this repository.
+
+## Legacy OSSRH deployment (retired)
+
+The following information is retained only as historical context. Do not copy
+its OSSRH credentials, endpoints, or GitHub-token instructions into a current
+release setup.
+
 A section in Maven's settings.xml is needed, in Linux (and MacOS) that's at ~/.m2/settings.xml 
 
 As „servers“, enter the following

--- a/doc/maven-central-publishing.md
+++ b/doc/maven-central-publishing.md
@@ -1,0 +1,98 @@
+# Publishing Mustang to Maven Central
+
+This guide is for Mustang release maintainers. It documents the one-time
+Sonatype Central Portal setup and the release procedure for the
+`org.mustangproject` namespace. It deliberately does not include credentials,
+tokens, or passphrases.
+
+## One-time Central Portal setup
+
+1. Sign in to the [Central Portal](https://central.sonatype.com/) with the
+   GitHub account of a Mustang release maintainer. If an existing OSSRH
+   publisher account or namespace is shown, use it or request access from its
+   current owners before creating anything new.
+2. In **View Namespaces**, check whether `org.mustangproject` is already
+   verified. If it is not, add that namespace. The current Maven `groupId` is
+   `org.mustangproject`, so this is the namespace that must be authorised.
+3. Verify it through the domain owner of `mustangproject.org`: the Portal will
+   provide a verification key for a DNS TXT record. Add the record exactly as
+   requested, wait for DNS propagation, and only then select **Verify
+   Namespace**. The reverse of `mustangproject.org` is `org.mustangproject`.
+4. Grant every person who may release access in the Portal instead of sharing
+   a personal account or token. Re-check that the POM's developer names and
+   email addresses are current and approved for publication.
+5. Generate a Central Portal user token and keep it in the releaser's Maven
+   settings, not in Git, CI logs, or a GitHub issue:
+
+   ```xml
+   <settings>
+     <servers>
+       <server>
+         <id>central</id>
+         <username><!-- Central token username --></username>
+         <password><!-- Central token password --></password>
+       </server>
+     </servers>
+   </settings>
+   ```
+
+6. Confirm that the release GPG key configured in the root `pom.xml` is
+   available to the releaser, has not expired or been revoked, and its public
+   key is discoverable from a Central-supported public keyserver. Do not add a
+   private key or its passphrase to the repository.
+
+Central's current [namespace instructions](https://central.sonatype.org/register/namespace/)
+and [publishing requirements](https://central.sonatype.org/publish/requirements/)
+are authoritative. In particular, every published JAR needs sources,
+Javadoc, PGP signatures, checksums, and complete POM metadata.
+
+## What the POM configures
+
+The root POM uses Sonatype's `central-publishing-maven-plugin`, replacing the
+retired `nexus-staging-maven-plugin`. `mvn deploy` creates and uploads a
+bundle to the Central Portal using the Maven server id `central`.
+
+`autoPublish` is intentionally `false`: a release maintainer reviews the
+validated deployment in the Portal and explicitly selects **Publish**. Once
+the process is established and a protected CI release workflow is in place,
+the maintainers may choose to enable automatic publishing.
+
+The library, validator, and CLI all deploy their main artifacts. Source JARs
+are attached for each module, and the inherited Javadoc configuration attaches
+Javadoc JARs. The aggregator POM is deliberately not deployed.
+
+## Release checklist
+
+1. Start with a clean worktree and a current `master` branch. Build the
+   intended release locally:
+
+   ```shell
+   mvn clean verify
+   ```
+
+   Confirm that every module produces its main JAR, `-sources.jar`, and
+   `-javadoc.jar`.
+2. Ensure the Central Portal token is available under the Maven server id
+   `central`, and that GPG can sign with the configured release key. Use the
+   existing Maven release-plugin procedure:
+
+   ```shell
+   mvn release:clean
+   mvn release:prepare
+   mvn release:perform
+   ```
+
+   The final command runs `deploy`, uploads the release bundle, and waits for
+   Central validation. Do not retry a version that Central has already
+   accepted: releases on Maven Central are immutable.
+3. Open [Central deployments](https://central.sonatype.com/publishing/deployments),
+   inspect the validated `mustangproject-<version>` bundle, and select
+   **Publish**. If validation fails, fix the cause, increment the version, and
+   create a new release.
+4. After Central reports the deployment as published, verify the expected
+   artifacts in [Maven Central Search](https://central.sonatype.com/) before
+   announcing the GitHub release.
+
+For a first production publication, perform a signed release rehearsal with a
+new, disposable version and keep publication manual until the Portal validates
+the bundle successfully.

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -13,12 +13,12 @@
     <description>FOSS Java library to read, write and validate european electronic invoices and orders in the UN/CEFACT
         Cross Industry Invoice based formats Factur-X/ZUGFeRD, XRechnung and Order-X in your invoice PDFs.
     </description>
-    <url>http://www.mustangproject.org/</url>
+    <url>https://www.mustangproject.org/</url>
     <scm>
         <connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
-        <developerConnection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com/ZUGFeRD/mustangproject.git</developerConnection>
         <url>https://github.com/ZUGFeRD/mustangproject</url>
-        <tag>core-2.3.2</tag>
+        <tag>HEAD</tag>
     </scm>
     <repositories>
         <repository><!-- for jargs -->
@@ -32,20 +32,13 @@
             </snapshots>
         </repository>
     </repositories>
-    <distributionManagement>
-        <repository>
-            <id>internal.repo</id>
-            <name>Temporary Staging Repository</name>
-            <url>file://${project.build.directory}/mvn-repo</url>
-        </repository>
-    </distributionManagement>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
         <additionalparam>-Xdoclint:none</additionalparam>
         <!-- Skip error check for javadoc -->
         <maven.compiler.release>11</maven.compiler.release>
-        <maven.deploy.skip>true</maven.deploy.skip><!-- do deploy to maven central, parent project does not and inherits -->
+        <maven.deploy.skip>false</maven.deploy.skip><!-- deploy this library; the parent POM remains skipped -->
     </properties>
     <dependencies>
         <!-- compile dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,12 @@
 
     <description>Mustangproject is a java library and commandline tool to read, validate, write and convert EN16931 e-invoices, e.g. Factur-X and XRechnung (read and writing CII and reading also UBL).
     </description>
-    <url>http://www.mustangproject.org/</url>
+    <url>https://www.mustangproject.org/</url>
     <scm>
-        <connection>scm:git:git://github.com/dexecutor/dependent-tasks-executor.git</connection>
-        <developerConnection>scm:git:git@github.com:dexecutor/dexecutor.git</developerConnection>
-        <url>https://github.com/dexecutor/dependent-tasks-executor</url>
-        <tag>core-2.3.2</tag>
+        <connection>scm:git:https://github.com/ZUGFeRD/mustangproject.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/ZUGFeRD/mustangproject.git</developerConnection>
+        <url>https://github.com/ZUGFeRD/mustangproject</url>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>
@@ -48,8 +48,7 @@
             First the versions for plugins, then those for libraries.
          -->
         <version.org.apache.maven.plugins.maven-compiler-plugin>3.13.0</version.org.apache.maven.plugins.maven-compiler-plugin><!-- from 2.3.2, 3.13.0 -->
-        <version.org.apache.maven.plugins.maven-deploy-plugin>3.0.0-M1</version.org.apache.maven.plugins.maven-deploy-plugin><!-- from 3.0.0-M1 -->
-        <version.org.apache.maven.plugins.maven-gpg-plugin>1.6</version.org.apache.maven.plugins.maven-gpg-plugin><!-- from 1.6 -->
+        <version.org.apache.maven.plugins.maven-gpg-plugin>3.2.7</version.org.apache.maven.plugins.maven-gpg-plugin><!-- from 1.6 -->
         <version.org.apache.maven.plugins.maven-jar-plugin>3.4.2</version.org.apache.maven.plugins.maven-jar-plugin><!-- from 3.2.0, 3.4.2 -->
         <version.org.apache.maven.plugins.maven-javadoc-plugin>3.0.1</version.org.apache.maven.plugins.maven-javadoc-plugin><!-- from 3.0.1 -->
         <version.org.apache.maven.plugins.maven-release-plugin>2.5.3</version.org.apache.maven.plugins.maven-release-plugin><!-- from 2.5.3 -->
@@ -61,7 +60,7 @@
         <version.org.apache.maven.scm>1.9.5</version.org.apache.maven.scm>
         <version.org.codehaus.mojo>1.0.0</version.org.codehaus.mojo>
         <version.com.helger.maven>8.0.0</version.com.helger.maven>
-        <version.org.sonatype.plugins>1.7.0</version.org.sonatype.plugins>
+        <version.org.sonatype.central.central-publishing-maven-plugin>0.11.0</version.org.sonatype.central.central-publishing-maven-plugin>
 
         <version.ch.qos.logback>1.5.18</version.ch.qos.logback><!-- from 1.5.16 -->
         <version.com.fasterxml.jackson.core>2.22.1</version.com.fasterxml.jackson.core>
@@ -116,26 +115,32 @@
                 <version>${version.org.apache.maven.plugins.maven-javadoc-plugin}</version>
                 <configuration>
                     <excludePackageNames>org.mustangproject.ZUGFeRD.model.*</excludePackageNames>
+                    <!-- Existing API Javadoc has diagnostics on newer JDKs. Central
+                         requires an attached Javadoc archive; retain it while the
+                         documentation is improved independently. -->
+                    <failOnError>false</failOnError>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>${version.org.apache.maven.plugins.maven-deploy-plugin}</version>
-                <configuration>
-                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
+            <!-- Replaces the retired OSSRH/Nexus staging plugin. A release is uploaded
+                 as a Central Portal bundle by mvn deploy; it is published manually. -->
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${version.org.sonatype.plugins}</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>${version.org.sonatype.central.central-publishing-maven-plugin}</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <deploymentName>mustangproject-${project.version}</deploymentName>
+                    <autoPublish>false</autoPublish>
                 </configuration>
             </plugin>
             <plugin>
@@ -146,29 +151,14 @@
                     <runOrder>alphabetical</runOrder>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>${version.org.apache.maven.plugins.maven-source-plugin}</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                    </execution>
-                </executions>
-            </plugin>
-
         </plugins>
     </build>
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>central</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
-        </repository>
     </distributionManagement>
     <mailingLists>
         <mailingList>


### PR DESCRIPTION
## Description of Changes

This patch migrates Mustangproject’s release configuration from the retired
OSSRH/Nexus staging workflow to the Sonatype Central Portal.

Mustang artifacts are already consumed through Maven Central; this change makes
the project’s publishing setup current, documented, and ready for future
releases. It also improves artifact completeness for downstream tools and
automated CI/CD dependency resolution.

## Key Modifications

- Replaced the deprecated Nexus staging plugin and OSSRH release endpoint with
  Sonatype’s `central-publishing-maven-plugin`.
- Added the required Central Portal server id (`central`) and kept publishing
  manual until a validated deployment is explicitly approved in the Portal.
- Corrected published SCM metadata to point to `ZUGFeRD/mustangproject`.
- Ensured library, validator, and CLI builds attach source and Javadoc JARs.
- Updated deployment behaviour so all intended modules are included.
- Added maintainer documentation covering:
  - Central Portal account and namespace verification for `org.mustangproject`
  - DNS TXT verification for `mustangproject.org`
  - token and GPG-signing prerequisites
  - release, validation, and manual publication steps
- Marked the previous OSSRH deployment instructions as retired.

## Validation

- `mvn clean verify -DskipTests`
- Confirmed main, sources, and Javadoc JARs are generated for library,
  validator, and CLI.

Related: #1157, #1161

Feedback on the release workflow and any repository-specific adjustments is
very welcome.