### PR TITLE
FIX: GROUP lines without LineTotalAmount cause LineCalculator NPE

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/LineCalculator.java
@@ -105,7 +105,12 @@ public class LineCalculator {
 			.subtract(allowanceItemTotal.setScale(2, RoundingMode.HALF_UP))
 			.setScale(2, RoundingMode.HALF_UP);
 		if (BigDecimal.ZERO.setScale(2).equals(itemTotalNetAmount) && "GROUP".equals(currentItem.getLineStatusReasonCode())) {
-			itemTotalNetAmount = currentItem.getLineTotalAmount();
+			// GROUP lines may omit the optional LineTotalAmount. Keep the calculated
+			// zero in that case; assigning null causes the VAT calculation below to fail.
+			BigDecimal groupLineTotalAmount = currentItem.getLineTotalAmount();
+			if (groupLineTotalAmount != null) {
+				itemTotalNetAmount = groupLineTotalAmount;
+			}
 		}
 		itemTotalVATAmount = itemTotalNetAmount.multiply(multiplicator);
 	}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -654,4 +654,21 @@ public class CalculationTest extends ResourceCase {
 		assertEquals(BigDecimal.valueOf(32.74), calculator.getItemTotalNetAmount());
 	}
 
+	/**
+	 * A GROUP line may omit the optional LineTotalAmount. It must still have a
+	 * calculable zero amount rather than turning the calculated value into null.
+	 * This reproduces the former issue_96_subtotals_ex4 validator crash.
+	 */
+	@Test
+	public void testGroupLineWithoutLineTotalAmountDoesNotThrow() {
+		final Product product = new Product("Group", "", "H87", BigDecimal.valueOf(19));
+		final Item groupLine = new Item(product, BigDecimal.ZERO, BigDecimal.ZERO)
+			.setLineStatusReasonCode("GROUP");
+
+		final LineCalculator calculator = groupLine.getCalculation();
+
+		assertEquals(BigDecimal.ZERO.setScale(2), calculator.getItemTotalNetAmount());
+		assertEquals(0, calculator.getItemTotalVATAmount().compareTo(BigDecimal.ZERO));
+	}
+
 }


### PR DESCRIPTION
# NullPointerException validating a Factur-X EXTENDED GROUP line without `LineTotalAmount`

## Summary

Mustang 2.24.1-SNAPSHOT throws a `NullPointerException` while validating a Factur-X EXTENDED CII invoice containing `GROUP` sub-invoice lines without an explicit `LineTotalAmount`.

The value is optional for the affected GROUP line. The validator must not abort; it should return a normal validation result.

## Reproduction

The regression test added in this change reproduces the failing state without requiring external files:

```bash
mvn -B -pl library -Dtest=CalculationTest#testGroupLineWithoutLineTotalAmountDoesNotThrow test
```

Before the fix, it fails with:

```text
java.lang.NullPointerException: Cannot invoke "java.math.BigDecimal.multiply(java.math.BigDecimal)" because "this.itemTotalNetAmount" is null
    at org.mustangproject.ZUGFeRD.LineCalculator.<init>(LineCalculator.java:110)
```

The original AWV fixture is `issue_96_subtotals_ex4.xml` (Factur-X EXTENDED, profile `urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended`). The failure is reproducible with the AWV-generated `ZF_250` Schematron overlay, so it is not caused by GEFEG Schematron/XSLT.

## Root cause

`LineCalculator` first calculates a zero net amount for the GROUP line. It then unconditionally replaces that amount with `currentItem.getLineTotalAmount()` when the status is `GROUP`.

`LineTotalAmount` is optional and returns `null` for this input. The next statement calculates VAT using `itemTotalNetAmount.multiply(...)`, causing the exception.

## Proposed and applied fix

Only replace the calculated amount when an explicit group `LineTotalAmount` is present. Otherwise, retain the calculated zero amount.

```java
BigDecimal groupLineTotalAmount = currentItem.getLineTotalAmount();
if (groupLineTotalAmount != null) {
    itemTotalNetAmount = groupLineTotalAmount;
}
```

This preserves the existing behaviour for GROUP lines that do provide a total and prevents the validator abort for GROUP lines that do not.

## Verification

```bash
mvn -B -pl library -Dtest=CalculationTest test
mvn -B -pl Mustang-CLI -am package -DskipTests
```

Results after the fix:

- The new regression test passes.
- The complete `CalculationTest` class passes (20 tests).
- The original AWV XML validates successfully with the locally built Mustang CLI and the AWV `ZF_250` overlay; the previous `NullPointerException` is absent.

## Follow-up

The original input still produces hierarchy warnings because GROUP lines without an explicit total cannot be compared to the sum of their DETAIL children. This is separate from the crash. A possible follow-up is to skip that comparison when `LineTotalAmount` is absent, but that would change validation semantics and should be decided separately.
