### PR TITLE
Support TypeCodes 130 and 916 for AdditionalReferencedDocuments

### DIFF
--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -11,7 +11,7 @@ import java.math.RoundingMode;
 
 /***
  * Absolute and relative charges for document and item level
- * 
+ *
  * <xs:complexType name="TradeAllowanceChargeType">
  *   <xs:sequence>
  *     <xs:element name="ChargeIndicator" type="udt:IndicatorType"/>

--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -40,13 +40,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public class Invoice implements IExportableTransaction {
 
 	protected boolean testIndicator;
-	protected String documentName = null, documentCode = null, number = null, ownOrganisationFullPlaintextInfo = null, referenceNumber = null, shipToOrganisationID = null, shipToOrganisationName = null, shipToStreet = null, shipToZIP = null, shipToLocation = null, shipToCountry = null, buyerOrderReferencedDocumentID = null, buyerOrderReferencedDocumentIssueDateTime = null, ownForeignOrganisationID = null, ownOrganisationName = null, currency = null, paymentTermDescription = null;
+	protected String documentName = null, documentCode = null, number = null, ownOrganisationFullPlaintextInfo = null, referenceNumber = null, shipToOrganisationID = null, shipToOrganisationName = null, shipToStreet = null, shipToZIP = null, shipToLocation = null, shipToCountry = null, buyerOrderReferencedDocumentID = null, ownForeignOrganisationID = null, ownOrganisationName = null, currency = null, paymentTermDescription = null;
 	protected String deliveryTypeCode;
-	protected Date issueDate = null, dueDate = null, deliveryDate = null;
+	protected Date issueDate = null, dueDate = null, deliveryDate = null, buyerOrderReferencedDocumentIssueDateTime = null;
 	protected TradeParty sender = null, recipient = null, deliveryAddress = null, endCustomerDeliveryAddress = null, payee = null, invoicer = null, invoicee = null;
 	protected ArrayList<CashDiscount> cashDiscounts = null;
 	@JsonDeserialize(contentAs = Item.class)
-	protected ArrayList<IZUGFeRDExportableItem> ZFItems = null;
+	protected List<IZUGFeRDExportableItem> zfItems = null;
 	protected ArrayList<String> notes = null;
 	private List<IncludedNote> includedNotes = null;
 	protected String sellerOrderReferencedDocumentID;
@@ -56,17 +56,18 @@ public class Invoice implements IExportableTransaction {
 	protected BigDecimal totalPrepaidAmount = null;
 	protected Date detailedDeliveryDateStart = null;
 	protected Date detailedDeliveryPeriodEnd = null;
-	protected IReferencedDocument tenderReference = null;
-	protected IReferencedDocument objectIdentifierReference = null;
+	protected IReferencedDocument tenderReference; // TypeCode 50
+	protected IReferencedDocument objectIdentifierReferencedDocument; // TypeCode 130
+	protected IReferencedDocument relatedReferenceDocument; // TypeCode 916
 
-	protected ArrayList<IZUGFeRDAllowanceCharge> Allowances = new ArrayList<>(), Charges = new ArrayList<>();
+	protected ArrayList<IZUGFeRDAllowanceCharge> allowances = new ArrayList<>(), charges = new ArrayList<>();
 	protected ArrayList<IZUGFeRDLogisticsServiceCharge> logisticsServiceCharges = new ArrayList<>();
 	protected ArrayList<IZUGFeRDPaymentTerms> paymentTerms = new ArrayList<>();
 
 	protected String invoiceReferencedDocumentID = null;
 	protected Date invoiceReferencedIssueDate;
 	// New field for storing Invoiced Object Identifier (BG-3)
-	protected ArrayList<ReferencedDocument> invoiceReferencedDocuments = null;
+	protected List<ReferencedDocument> invoiceReferencedDocuments = null;
 
 	protected String specifiedProcuringProjectID = null;
 	protected String specifiedProcuringProjectName = null;
@@ -79,7 +80,7 @@ public class Invoice implements IExportableTransaction {
 	private String paymentReference; // Remittance information / Verwendungszweck, BT-83
 	private String businessProcessId;
 	public Invoice() {
-		ZFItems = new ArrayList<>();
+		zfItems = new ArrayList<>();
 		cashDiscounts = new ArrayList<>();
 		setCurrency("EUR");
 	}
@@ -177,8 +178,8 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setTenderReferencedDocument(ReferencedDocument dr) {
-		dr.setTypeCode("50");//50 is fixed for tender documents
-		tenderReference=dr;
+		dr.setTypeCode("50"); // 50 is fixed for tender documents, Price/sales catalogue response
+		tenderReference = dr;
 		return this;
 	}
 
@@ -187,8 +188,9 @@ public class Invoice implements IExportableTransaction {
 	 * @param ID the key ID of the tender
 	 * @return fluent setter
 	 */
+	@JsonIgnore
 	public Invoice setTenderReferencedDocument(String ID) {
-		ReferencedDocument dr=new ReferencedDocument(ID);
+		ReferencedDocument dr = new ReferencedDocument(ID);
 		setTenderReferencedDocument(dr);
 		return this;
 	}
@@ -201,34 +203,73 @@ public class Invoice implements IExportableTransaction {
 	 *
 	 */
 	public IReferencedDocument getObjectIdentifierReferencedDocument() {
-		return objectIdentifierReference;
+		return objectIdentifierReferencedDocument;
 	}
 
 
 	/** BT-18 */
 	public Invoice setObjectIdentifierReferencedDocument(ReferencedDocument dr) {
-		dr.setTypeCode("130");//50 is fixed for tender documents
-		objectIdentifierReference=dr;
+		dr.setTypeCode("130"); // Rechnungsdatenblatt
+		objectIdentifierReferencedDocument = dr;
 		return this;
 	}
 
+	@JsonIgnore
 	public Invoice setObjectIdentifierReferencedDocument(String id) {
-		ReferencedDocument dr=new ReferencedDocument(id);
+		ReferencedDocument dr = new ReferencedDocument(id);
 		setObjectIdentifierReferencedDocument(dr);
 		return this;
 	}
+
+	@JsonIgnore
 	public Invoice setObjectIdentifierReferencedDocument(String id, String referenceTypeCode) {
 	    ReferencedDocument dr = new ReferencedDocument(id);
 	    dr.setReferenceTypeCode(referenceTypeCode);
 	    return setObjectIdentifierReferencedDocument(dr);
 	}
-	
+
+	@JsonIgnore
 	public Invoice setObjectIdentifierReferencedDocument(String id, String referenceTypeCode, Date issueDate) {
 	    ReferencedDocument dr = new ReferencedDocument(id);
 	    dr.setReferenceTypeCode(referenceTypeCode);
 	    dr.setFormattedIssueDateTime(issueDate);
 	    return setObjectIdentifierReferencedDocument(dr);
 	}
+
+	@Override
+	public IReferencedDocument getRelatedReferencedDocument() {
+		return relatedReferenceDocument;
+	}
+
+
+	public Invoice setRelatedReferencedDocument(ReferencedDocument dr) {
+		dr.setTypeCode("916"); // Referenzpapier
+		relatedReferenceDocument = dr;
+		return this;
+	}
+
+	@JsonIgnore
+	public Invoice setRelatedReferencedDocument(String id) {
+		ReferencedDocument dr = new ReferencedDocument(id);
+		setRelatedReferencedDocument(dr);
+		return this;
+	}
+
+	@JsonIgnore
+	public Invoice setRelatedReferencedDocument(String id, String referenceTypeCode) {
+	    ReferencedDocument dr = new ReferencedDocument(id);
+	    dr.setReferenceTypeCode(referenceTypeCode);
+	    return setRelatedReferencedDocument(dr);
+	}
+
+	@JsonIgnore
+	public Invoice setRelatedReferencedDocument(String id, String referenceTypeCode, Date issueDate) {
+	    ReferencedDocument dr = new ReferencedDocument(id);
+	    dr.setReferenceTypeCode(referenceTypeCode);
+	    dr.setFormattedIssueDateTime(issueDate);
+	    return setRelatedReferencedDocument(dr);
+	}
+
 
 	public Invoice setNumber(String number) {
 		this.number = number;
@@ -341,6 +382,7 @@ public class Invoice implements IExportableTransaction {
 		return this;
 	}
 
+	@Override
 	public String getDeliveryTypeCode() {
 		return deliveryTypeCode;
 	}
@@ -402,7 +444,7 @@ public class Invoice implements IExportableTransaction {
 	}
 
 	@Override
-	public String getBuyerOrderReferencedDocumentIssueDateTime() {
+	public Date getBuyerOrderReferencedDocumentIssueDateTime() {
 		return buyerOrderReferencedDocumentIssueDateTime;
 	}
 
@@ -423,11 +465,11 @@ public class Invoice implements IExportableTransaction {
 	}
 
 	/***
-	 * when the order (or whatever reference in BuyerOrderReferencedDocumentID) was issued (@todo switch to date?)
+	 * when the order (or whatever reference in BuyerOrderReferencedDocumentID) was issued
 	 * @param buyerOrderReferencedDocumentIssueDateTime  IssueDateTime in format CCYY-MM-DDTHH:MM:SS
 	 * @return fluent setter
 	 */
-	public Invoice setBuyerOrderReferencedDocumentIssueDateTime(String buyerOrderReferencedDocumentIssueDateTime) {
+	public Invoice setBuyerOrderReferencedDocumentIssueDateTime(Date buyerOrderReferencedDocumentIssueDateTime) {
 		this.buyerOrderReferencedDocumentIssueDateTime = buyerOrderReferencedDocumentIssueDateTime;
 		return this;
 	}
@@ -438,11 +480,10 @@ public class Invoice implements IExportableTransaction {
 	}
 
 
-	@Deprecated
 	/***
 	 * @deprecated use TradeParty::addTaxID instead
-	 * @see TradeParty
 	 */
+	@Deprecated
 	public Invoice setOwnTaxID(String ownTaxID) {
 		sender.addTaxID(ownTaxID);
 		return this;
@@ -453,11 +494,11 @@ public class Invoice implements IExportableTransaction {
 		return getSender().getVATID();
 	}
 
-	@Deprecated
 	/***
 	 * @deprecated use TradeParty::addVATID instead
 	 * @see TradeParty
 	 */
+	@Deprecated
 	public Invoice setOwnVATID(String ownVATID) {
 		sender.addVATID(ownVATID);
 		return this;
@@ -469,11 +510,11 @@ public class Invoice implements IExportableTransaction {
 	}
 
 
-	@Deprecated
 	/***
 	 * @deprecated use TradeParty instead
 	 * @see TradeParty
 	 */
+	@Deprecated
 	public Invoice setOwnForeignOrganisationID(String ownForeignOrganisationID) {
 		this.ownForeignOrganisationID = ownForeignOrganisationID;
 		return this;
@@ -485,11 +526,11 @@ public class Invoice implements IExportableTransaction {
 	}
 
 
-	@Deprecated
 	/***
 	 * @deprecated use senders' TradeParty's name instead
 	 * @see TradeParty
 	 */
+	@Deprecated
 	public Invoice setOwnOrganisationName(String ownOrganisationName) {
 		this.ownOrganisationName = ownOrganisationName;
 		return this;
@@ -617,19 +658,6 @@ public class Invoice implements IExportableTransaction {
 		 return this;
 	}
 
-	/***
-	 * sets a named sender contact
-	 * @deprecated use setSender
-	 * @see Contact
-	 * @param ownContact the sender contact
-	 * @return fluent setter
-	 */
-	@Deprecated
-	public Invoice setOwnContact(Contact ownContact) {
-		this.sender.setContact(ownContact);
-		return this;
-	}
-
 	@Override
 	public TradeParty getRecipient() {
 		return recipient;
@@ -656,21 +684,20 @@ public class Invoice implements IExportableTransaction {
 	 */
 	public Invoice setSender(TradeParty sender) {
 		this.sender = sender;
-		if ((sender.getBankDetails() != null) && (sender.getBankDetails().size() > 0)) {
+		if (sender.getBankDetails() != null && !sender.getBankDetails().isEmpty()) {
 			// convert bankdetails
-
 		}
 		return this;
 	}
 
 	// Getter for BG-3
 	@Override
-	public ArrayList<ReferencedDocument> getInvoiceReferencedDocuments() {
+	public List<ReferencedDocument> getInvoiceReferencedDocuments() {
 		return invoiceReferencedDocuments;
 	}
 
 	// Setter for BG-3
-	public void setInvoiceReferencedDocuments(ArrayList<ReferencedDocument> invoiceReferencedDocuments) {
+	public void setInvoiceReferencedDocuments(List<ReferencedDocument> invoiceReferencedDocuments) {
 		this.invoiceReferencedDocuments = invoiceReferencedDocuments;
 	}
 
@@ -685,10 +712,10 @@ public class Invoice implements IExportableTransaction {
 
 	@Override
 	public IZUGFeRDAllowanceCharge[] getZFAllowances() {
-		if (Allowances.isEmpty()) {
+		if (allowances.isEmpty()) {
 			return null;
 		} else {
-			return Allowances.toArray(new IZUGFeRDAllowanceCharge[0]);
+			return allowances.toArray(new IZUGFeRDAllowanceCharge[0]);
 		}
 	}
 
@@ -698,17 +725,17 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setZFAllowances(Allowance[] iza) {
-		Allowances=new ArrayList<>(Arrays.asList(iza));
+		allowances = new ArrayList<>(Arrays.asList(iza));
 		return this;
 	}
 
 
 	@Override
 	public IZUGFeRDAllowanceCharge[] getZFCharges() {
-		if (Charges.isEmpty()) {
+		if (charges.isEmpty()) {
 			return null;
 		} else {
-			return Charges.toArray(new IZUGFeRDAllowanceCharge[0]);
+			return charges.toArray(new IZUGFeRDAllowanceCharge[0]);
 		}
 	}
 
@@ -718,8 +745,8 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setZFCharges(Charge[] iza) {
-		Charges=new ArrayList<>();
-		Charges.addAll(Arrays.asList(iza));
+		charges=new ArrayList<>();
+		charges.addAll(Arrays.asList(iza));
 		return this;
 	}
 
@@ -794,6 +821,7 @@ public class Invoice implements IExportableTransaction {
 	}
 
 
+	@Override
 	public String getPaymentReference() {
 		return paymentReference;
 	}
@@ -886,11 +914,11 @@ public class Invoice implements IExportableTransaction {
 
 	@Override
 	public IZUGFeRDExportableItem[] getZFItems() {
-		return ZFItems.toArray(new IZUGFeRDExportableItem[0]);
+		return zfItems.toArray(new IZUGFeRDExportableItem[0]);
 	}
 
-	public void setZFItems(ArrayList<IZUGFeRDExportableItem> ims) {
-		ZFItems = ims;
+	public void setZFItems(List<IZUGFeRDExportableItem> ims) {
+		zfItems = ims;
 	}
 
 	/**
@@ -902,7 +930,7 @@ public class Invoice implements IExportableTransaction {
 	 * @see Item
 	 */
 	public Invoice addItem(IZUGFeRDExportableItem item) {
-		ZFItems.add(item);
+		zfItems.add(item);
 		return this;
 	}
 
@@ -930,7 +958,7 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice addCharge(IZUGFeRDAllowanceCharge izac) {
-		Charges.add(izac);
+		charges.add(izac);
 		return this;
 	}
 
@@ -952,7 +980,7 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice addAllowance(IZUGFeRDAllowanceCharge izac) {
-		Allowances.add(izac);
+		allowances.add(izac);
 		return this;
 	}
 
@@ -1218,6 +1246,7 @@ public class Invoice implements IExportableTransaction {
 		return this;
 	}
 
+	@Override
 	public String getCreditorReferenceID() {
 		return creditorReferenceID;
 	}

--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -36,8 +36,8 @@ public class Item implements IZUGFeRDExportableItem {
 	protected ArrayList<String> notes = null;
 	protected ArrayList<ReferencedDocument> referencedDocuments = null;
 	protected ArrayList<ReferencedDocument> additionalReference = null;
-	protected ArrayList<IZUGFeRDAllowanceCharge> Allowances = new ArrayList<>();
-	protected ArrayList<IZUGFeRDAllowanceCharge> Charges = new ArrayList<>();
+	protected ArrayList<IZUGFeRDAllowanceCharge> allowances = new ArrayList<>();
+	protected ArrayList<IZUGFeRDAllowanceCharge> charges = new ArrayList<>();
 	protected List<IncludedNote> includedNotes = null;
 	protected String accountingReference;
 	protected String parentLineID = null;
@@ -170,7 +170,7 @@ public class Item implements IZUGFeRDExportableItem {
 		itemMap.getAsNodeMap("OrderLineReference")
 			// ubl
 			.flatMap(bordNodes -> bordNodes.getAsString("LineID"))
-			.ifPresent(this::addReferencedLineID);
+			.ifPresent(this::addBuyerOrderReferencedDocumentLineID);
 
 		itemMap.getAsString("ID")
 			.ifPresent(this::setId);
@@ -181,7 +181,7 @@ public class Item implements IZUGFeRDExportableItem {
 		itemMap.getAsString("AccountingCost")
 			.ifPresent(this::setAccountingReference);
 
-		if (product==null) { // CII
+		if (product == null) { // CII
 			if (itemMap.getNode("SpecifiedTradeProduct").isPresent()) {
 				product = new Product(itemMap.getNode("SpecifiedTradeProduct").get());
 			} else {
@@ -193,7 +193,7 @@ public class Item implements IZUGFeRDExportableItem {
 		itemMap.getAsNodeMap("SpecifiedLineTradeAgreement", "SpecifiedSupplyChainTradeAgreement").ifPresent(icnm -> {
 			icnm.getAsNodeMap("BuyerOrderReferencedDocument")
 				.flatMap(bordNodes -> bordNodes.getAsString("LineID"))
-				.ifPresent(this::addReferencedLineID);
+				.ifPresent(this::addBuyerOrderReferencedDocumentLineID);
 
 			icnm.getAsNodeMap("BuyerOrderReferencedDocument")
 				.flatMap(bordNodes -> bordNodes.getAsString("IssuerAssignedID"))
@@ -203,7 +203,7 @@ public class Item implements IZUGFeRDExportableItem {
 				npptpNodes.getAsBigDecimal("ChargeAmount").ifPresent(this::setPrice);
 				npptpNodes.getAsBigDecimal("BasisQuantity").ifPresent(this::setBasisQuantity);
 			});
-			icnm.getAsNodeMap("GrossPriceProductTradePrice").ifPresent(gpptpNodes -> {
+			icnm.getAsNodeMap("GrossPriceProductTradePrice").ifPresent(gpptpNodes ->
 				gpptpNodes.getAsNodeMap("AppliedTradeAllowanceCharge").ifPresent(gpptpAtacNodes -> {
 
 						/** mustang attributes differences between net and gross price to the product */
@@ -220,8 +220,8 @@ public class Item implements IZUGFeRDExportableItem {
 							}
 
 						}
-					});
-				});
+					})
+				);
 			icnm.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).
 				forEach(this::addReferencedDocument);
 		});
@@ -239,7 +239,7 @@ public class Item implements IZUGFeRDExportableItem {
 				}
 			});
 
-		itemMap.getAsNodeMap("SpecifiedLineTradeDelivery").ifPresent(icnm -> {
+		itemMap.getAsNodeMap("SpecifiedLineTradeDelivery").ifPresent(icnm ->
 			icnm.getAsNodeMap("DeliveryNoteReferencedDocument").ifPresent(dn -> {
 				dn.getAsString("IssuerAssignedID")
 					.ifPresent(this::setDeliveryNoteReferencedDocumentID);
@@ -252,8 +252,8 @@ public class Item implements IZUGFeRDExportableItem {
 					.map(XMLTools::getNodeValue)
 					.map(XMLTools::tryDate)
 					.ifPresent(this::setDeliveryNoteReferencedDocumentDate);
-			});
-		});
+			})
+		);
 
 		itemMap.getAsNodeMap("SpecifiedLineTradeSettlement", "SpecifiedSupplyChainTradeSettlement").ifPresent(icnm -> {
 			icnm.getAsNodeMap("ApplicableTradeTax")
@@ -269,7 +269,7 @@ public class Item implements IZUGFeRDExportableItem {
 				.flatMap(cnm -> cnm.getAsString("ExemptionReasonCode"))
 				.ifPresent(product::setTaxExemptionReasonCode);
 
-			icnm.getAllNodes("SpecifiedTradeAllowanceCharge").map(NodeMap::new).forEach(stac -> {
+			icnm.getAllNodes("SpecifiedTradeAllowanceCharge").map(NodeMap::new).forEach(stac ->
 				stac.getAsNodeMap("ChargeIndicator").ifPresent(ci -> {
 					String isChargeString = ci.getAsString("Indicator").get();
 					String percentString = stac.getAsStringOrNull("CalculationPercent");
@@ -304,9 +304,8 @@ public class Item implements IZUGFeRDExportableItem {
 					} else {
 						addCharge(izac);
 					}
-				});
-
-			});
+				})
+			);
 			if (recalcPrice && !BigDecimal.ZERO.equals(quantity)) {
 				icnm.getAsNodeMap("SpecifiedTradeSettlementLineMonetarySummation")
 					.flatMap(cnm -> cnm.getAsBigDecimal("LineTotalAmount"))
@@ -365,7 +364,7 @@ public class Item implements IZUGFeRDExportableItem {
 		});
 
 		itemMap.getAsNodeMap("AssociatedDocumentLineDocument").ifPresent(adld -> {
-			List<IncludedNote> includedNotes = new ArrayList<>();
+			List<IncludedNote> in = new ArrayList<>();
 			adld.getAllNodes("IncludedNote").forEach(item -> {
 				String subjectCode = "";
 				String content = null;
@@ -383,16 +382,16 @@ public class Item implements IZUGFeRDExportableItem {
 				boolean foundCode = false;
 				for (SubjectCode code : SubjectCode.values()) {
 					if (code.toString().equals(subjectCode)) {
-						includedNotes.add(new IncludedNote(content, code));
+						in.add(new IncludedNote(content, code));
 						foundCode = true;
 						break;
 					}
 				}
 				if (!foundCode) {
-					includedNotes.add(new IncludedNote(content, null));
+					in.add(new IncludedNote(content, null));
 				}
 			});
-			addNotes(includedNotes);
+			addNotes(in);
 		});
 	}
 
@@ -433,11 +432,6 @@ public class Item implements IZUGFeRDExportableItem {
 		return this;
 	}
 
-	@Deprecated(since = "2.14.0")
-	public Item addReferencedLineID(String s) {
-		return addBuyerOrderReferencedDocumentLineID(s);
-	}
-
 	@Override
 	public String getBuyerOrderReferencedDocumentID() {
 		return buyerOrderReferencedDocumentID;
@@ -457,6 +451,7 @@ public class Item implements IZUGFeRDExportableItem {
 		return buyerOrderReferencedDocumentLineID;
 	}
 
+	@Override
 	public BigDecimal getLineTotalAmount() {
 		return lineTotalAmount;
 	}
@@ -507,6 +502,7 @@ public class Item implements IZUGFeRDExportableItem {
 		return this;
 	}
 
+	@Override
 	public String getId() {
 		return id;
 	}
@@ -550,38 +546,38 @@ public class Item implements IZUGFeRDExportableItem {
 
 	@Override
 	public IZUGFeRDAllowanceCharge[] getItemAllowances() {
-		if (Allowances.isEmpty()) {
+		if (allowances.isEmpty()) {
 			return null;
 		} else
-			return Allowances.toArray(new IZUGFeRDAllowanceCharge[0]);
+			return allowances.toArray(new IZUGFeRDAllowanceCharge[0]);
 	}
 
 	/***
 	 * jackson convenience method
 	 */
-	public void setItemAllowances(ArrayList<Allowance> theAllowances) {
+	public void setItemAllowances(List<Allowance> theAllowances) {
 		if (theAllowances != null) {
-			Allowances.clear();
-			Allowances.addAll(theAllowances);
+			allowances.clear();
+			allowances.addAll(theAllowances);
 		}
 	}
 
 	/***
 	 * jackson convenience method
 	 */
-	public void setItemCharges(ArrayList<Charge> theCharges) {
+	public void setItemCharges(List<Charge> theCharges) {
 		if (theCharges != null) {
-			Charges.clear();
-			Charges.addAll(theCharges);
+			charges.clear();
+			charges.addAll(theCharges);
 		}
 	}
 
 	@Override
 	public IZUGFeRDAllowanceCharge[] getItemCharges() {
-		if (Charges.isEmpty()) {
+		if (charges.isEmpty()) {
 			return null;
 		} else
-			return Charges.toArray(new IZUGFeRDAllowanceCharge[0]);
+			return charges.toArray(new IZUGFeRDAllowanceCharge[0]);
 	}
 
 
@@ -606,7 +602,7 @@ public class Item implements IZUGFeRDExportableItem {
 	 * @return fluent setter
 	 */
 	public Item addCharge(IZUGFeRDAllowanceCharge izac) {
-		Charges.add(izac);
+		charges.add(izac);
 		return this;
 	}
 
@@ -618,7 +614,7 @@ public class Item implements IZUGFeRDExportableItem {
 	 */
 	public Item addAllowance(IZUGFeRDAllowanceCharge izac) {
 
-		Allowances.add(izac);
+		allowances.add(izac);
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -31,7 +31,7 @@ package org.mustangproject.ZUGFeRD;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Date; 
+import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -238,6 +238,15 @@ public interface IExportableTransaction {
 	}
 
 	/**
+	 * Related Documents
+	 *
+	 * @return mandatory ID, optional Date
+	 */
+	default IReferencedDocument getRelatedReferencedDocument() {
+		return null;
+	}
+
+	/**
 	 * own name
 	 *
 	 * @return the sender's organisation name
@@ -361,7 +370,7 @@ public interface IExportableTransaction {
 	}
 
 	/**
-	 * get the rounding amount 
+	 * get the rounding amount
    * (only to be usef for NL whose currency requires a rounding to 5ct)
 	 *
 	 * @return the Bigdecimal
@@ -373,7 +382,7 @@ public interface IExportableTransaction {
 	/**
 	 * get BuyerReference (BT-10) an identifier assigned by the buyer and used
 	 * for internal routing. Used for the Leitweg-ID.
-	 * 
+	 *
 	 * @return the BuyerReference of this document
 	 */
 	default String getReferenceNumber() {
@@ -477,12 +486,12 @@ public interface IExportableTransaction {
 	default Date getInvoiceReferencedIssueDate() {
 		return null;
 	}
-	
+
 	/**
 	 * Getter for BG-3
 	 * @return list of documents
 	 */
-	default ArrayList<ReferencedDocument> getInvoiceReferencedDocuments() {
+	default List<ReferencedDocument> getInvoiceReferencedDocuments() {
 		return null;
 	}
 
@@ -492,7 +501,7 @@ public interface IExportableTransaction {
 	 *
 	 * @return the IssueDateTime in format CCYY-MM-DDTHH:MM:SS
 	 */
-	default String getBuyerOrderReferencedDocumentIssueDateTime() {
+	default Date getBuyerOrderReferencedDocumentIssueDateTime() {
 		return null;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -30,7 +30,6 @@ import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -339,7 +338,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 	protected TransactionCalculator createCalculator(IExportableTransaction trans) {
    		 return new TransactionCalculator(trans);
-	}	
+	}
 
 	@Override
 	public void generateXML(IExportableTransaction trans) {
@@ -559,11 +558,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "<ram:BasisQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit())
 					+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
 					+ "</ram:NetPriceProductTradePrice>");
-				  
+
                 if(currentItem.getLineSeller()!=null) {
                     xml.append("<ram:ItemSellerTradeParty>" + getTradePartyAsXML(currentItem.getLineSeller(), true, false) + "</ram:ItemSellerTradeParty>");
-    
-                }	            
+
+                }
 				xml.append("</ram:SpecifiedLineTradeAgreement>"
 					+ "<ram:SpecifiedLineTradeDelivery>"
 					+ "<ram:BilledQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
@@ -732,7 +731,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			xml.append("<ram:AdditionalReferencedDocument>"
 				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getObjectIdentifierReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
 				+ "<ram:TypeCode>130</ram:TypeCode>");
-			 // NEW: BT-18-1 scheme identifier
+		    String name = trans.getObjectIdentifierReferencedDocument().getName();
+		    if (name != null && !name.isEmpty()) {
+		        xml.append("<ram:Name>" + XMLTools.encodeXML(name) + "</ram:Name>");
+		    }
+		    // NEW: BT-18-1 scheme identifier
 		    String rtc = trans.getObjectIdentifierReferencedDocument().getReferenceTypeCode();
 		    if (rtc != null && !rtc.isEmpty()) {
 		        xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
@@ -746,8 +749,35 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			xml.append("<ram:AdditionalReferencedDocument>"
 				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getTenderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
 				+ "<ram:TypeCode>50</ram:TypeCode>");
+		    String name = trans.getTenderReferencedDocument().getName();
+		    if (name != null && !name.isEmpty()) {
+		        xml.append("<ram:Name>" + XMLTools.encodeXML(name) + "</ram:Name>");
+		    }
+		    // NEW: BT-18-1 scheme identifier
+		    String rtc = trans.getTenderReferencedDocument().getReferenceTypeCode();
+		    if (rtc != null && !rtc.isEmpty()) {
+		    	xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
+		    }
 			if (trans.getTenderReferencedDocument().getFormattedIssueDateTime()!=null) {
 				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getTenderReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
+			}
+			xml.append("</ram:AdditionalReferencedDocument>");
+		}
+		if (trans.getRelatedReferencedDocument() != null){
+			xml.append("<ram:AdditionalReferencedDocument>"
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getRelatedReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "<ram:TypeCode>916</ram:TypeCode>");
+		    String name = trans.getRelatedReferencedDocument().getName();
+		    if (name != null && !name.isEmpty()) {
+		        xml.append("<ram:Name>" + XMLTools.encodeXML(name) + "</ram:Name>");
+		    }
+		    // NEW: BT-18-1 scheme identifier
+		    String rtc = trans.getRelatedReferencedDocument().getReferenceTypeCode();
+		    if (rtc != null && !rtc.isEmpty()) {
+		    	xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
+		    }
+			if (trans.getRelatedReferencedDocument().getFormattedIssueDateTime()!=null) {
+				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getRelatedReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
 			}
 			xml.append("</ram:AdditionalReferencedDocument>");
 		}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -55,7 +55,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 	 * @return a ArrayList of FileAttachments, empty if none
 	 */
 	public List<FileAttachment> getFileAttachmentsPDF() {
-		return PDFAttachments;
+		return pdfAttachments;
 	}
 
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -16,10 +16,8 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
@@ -43,6 +41,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +61,7 @@ public class ZUGFeRDInvoiceImporter {
 	/**
 	 * map filenames of all embedded files in the respective PDF
 	 */
-	protected final ArrayList<FileAttachment> PDFAttachments = new ArrayList<>();
+	protected final ArrayList<FileAttachment> pdfAttachments = new ArrayList<>();
 	/**
 	 * if metadata has been found
 	 */
@@ -125,7 +124,7 @@ public class ZUGFeRDInvoiceImporter {
 	 * @return a ArrayList of FileAttachments, empty if none
 	 */
 	public List<FileAttachment> getFileAttachmentsPDF() {
-		return PDFAttachments;
+		return pdfAttachments;
 	}
 
 	/**
@@ -137,11 +136,10 @@ public class ZUGFeRDInvoiceImporter {
 		BufferedInputStream pdfStream = new BufferedInputStream(inStream);
 		byte[] pad = new byte[4];
 		pdfStream.mark(0);
-		pdfStream.read(pad);
+		int count = pdfStream.read(pad);
 		pdfStream.reset();
 		byte[] pdfSignature = {'%', 'P', 'D', 'F'};
-		if (Arrays.equals(pad, pdfSignature)) { // we have a pdf
-
+		if (count == 4 && Arrays.equals(pad, pdfSignature)) { // we have a pdf
 
 			try (PDDocument doc = Loader.loadPDF(IOUtils.toByteArray(pdfStream))) {
 				// PDDocumentInformation info = doc.getDocumentInformation();
@@ -233,10 +231,8 @@ public class ZUGFeRDInvoiceImporter {
 	 */
 	private void extractFiles(Map<String, PDComplexFileSpecification> names) throws IOException {
 		containsAXMLFileAttachment = false;
-		for (final String alias : names.keySet()) {
-
-			final PDComplexFileSpecification fileSpec = names.get(alias);
-			final String filename = fileSpec.getFilename();
+		for (final Entry<String, PDComplexFileSpecification> entry : names.entrySet()) {
+			final String filename = entry.getValue().getFilename();
 			if (filename.toUpperCase().endsWith(".XML")) {
 				containsAXMLFileAttachment = true;
 			}
@@ -244,7 +240,7 @@ public class ZUGFeRDInvoiceImporter {
 			 * filenames for invoice data (ZUGFeRD v1 and v2, Factur-X)
 			 */
 
-			final PDEmbeddedFile embeddedFile = fileSpec.getEmbeddedFile();
+			final PDEmbeddedFile embeddedFile = entry.getValue().getEmbeddedFile();
 			List<String> validFilenames = Arrays.asList(
 				"ZUGFeRD-invoice.xml",
 				"zugferd-invoice.xml",
@@ -275,7 +271,7 @@ public class ZUGFeRDInvoiceImporter {
 			if (filename.startsWith("additional_data")) {
 				additionalXMLs.put(filename, embeddedFile.toByteArray());
 			}
-			PDFAttachments.add(new FileAttachment(filename, embeddedFile.getSubtype(), "Data", embeddedFile.toByteArray()));
+			pdfAttachments.add(new FileAttachment(filename, embeddedFile.getSubtype(), "Data", embeddedFile.toByteArray()));
 		}
 	}
 
@@ -293,7 +289,7 @@ public class ZUGFeRDInvoiceImporter {
 
 		try {
 			setDocument();
-		} catch (ParserConfigurationException | SAXException e) {
+		} catch (ParseException e) {
 			LOGGER.error("Failed to parse XML", e);
 			throw new ZUGFeRDExportException(e);
 		}
@@ -344,12 +340,11 @@ public class ZUGFeRDInvoiceImporter {
 		} catch (Exception e) {
 			return false;
 		}
-		return  ((meta.contains("SpecifiedExchangedDocumentContext")
-			/* ZF1 */ || meta.contains("ExchangedDocumentContext") /* ZF2 */));
+		return meta.contains("SpecifiedExchangedDocumentContext") /* ZF1 */
+				|| meta.contains("ExchangedDocumentContext") /* ZF2 */;
 	}
 
-	private void setDocument() throws ParserConfigurationException, IOException, SAXException, ParseException {
-
+	private void setDocument() throws ParseException {
 		if (canParse()) {
 			// canParse() already parsed rawXML and assigned it to the `document` field
 			if (parseAutomatically) {
@@ -750,8 +745,6 @@ public class ZUGFeRDInvoiceImporter {
 		NodeList headerTradeAgreementNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
 		String buyerOrderIssuerAssignedID = null;
 		String sellerOrderIssuerAssignedID = null;
-		String additionalReferencedDocument = null;
-		Date additionalReferencedDocumentDate = null;
 
 		for (int i = 0; i < headerTradeAgreementNodes.getLength(); i++) {
 			// XMLTools.trimOrNull(nodes.item(i)))) {
@@ -788,46 +781,64 @@ public class ZUGFeRDInvoiceImporter {
 							}
 						}
 					}
+
 					int typeC = 0;
-					additionalReferencedDocument=null;
-					additionalReferencedDocumentDate=null;
+					String additionalReferencedDocumentID = null;
+					String additionalReferencedDocumentName = null;
+					String additionalReferencedDocumentReferenceTypeCode = null;
+					Date additionalReferencedDocumentDate = null;
 					//Reading BT-17
 					if (headerTradeAgreementChilds.item(agreementChildIndex).getLocalName().equals("AdditionalReferencedDocument")) {
 						NodeList additionalChilds = headerTradeAgreementChilds.item(agreementChildIndex).getChildNodes();
 						for (int additionalChildIndex = 0; additionalChildIndex < additionalChilds.getLength(); additionalChildIndex++) {
-
-							if ((additionalChilds.item(additionalChildIndex).getLocalName() != null)
-								&& additionalChilds.item(additionalChildIndex).getLocalName().equals("TypeCode")) {
-								typeC = Integer.parseInt(XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex)));
-							}
-
-								if ((additionalChilds.item(additionalChildIndex).getLocalName() != null)
-									&& (additionalChilds.item(additionalChildIndex).getLocalName().equals("IssuerAssignedID"))) {
-									additionalReferencedDocument = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
+							if (additionalChilds.item(additionalChildIndex).getLocalName() != null) {
+								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("TypeCode")) {
+									typeC = Integer.parseInt(XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex)));
 								}
-								if ((additionalChilds.item(additionalChildIndex).getLocalName() != null)
-									&& (additionalChilds.item(additionalChildIndex).getLocalName().equals("FormattedIssueDateTime"))) {
-
+								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("IssuerAssignedID")) {
+									additionalReferencedDocumentID = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
+								}
+								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("Name")) {
+									additionalReferencedDocumentName = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
+								}
+								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("ReferenceTypeCode")) {
+									additionalReferencedDocumentReferenceTypeCode = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
+								}
+								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("FormattedIssueDateTime")) {
 									NodeList FormattedIssueDateTimeChilds = additionalChilds.item(additionalChildIndex).getChildNodes();
 									for (int dateChildIndex = 0; dateChildIndex < FormattedIssueDateTimeChilds.getLength(); dateChildIndex++) {
 										if ((FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName() != null)
-											&& (FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName().equals("DateTimeString"))) {
+												&& (FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName().equals("DateTimeString"))) {
 											additionalReferencedDocumentDate = XMLTools.tryDate(FormattedIssueDateTimeChilds.item(dateChildIndex));
 										}
-
 									}
 								}
-
+							}
 						}
 						if (typeC == 50) {
-							if (additionalReferencedDocument != null){
-								if (additionalReferencedDocumentDate!=null) {
-									zpp.setTenderReferencedDocument(new ReferencedDocument(additionalReferencedDocument, additionalReferencedDocumentDate));
-								} else {
-									zpp.setTenderReferencedDocument(additionalReferencedDocument);
-								}
+							if (additionalReferencedDocumentID != null) {
+								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
+								referencedDocument.setName(additionalReferencedDocumentName);
+								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
+								referencedDocument.setFormattedIssueDateTime(additionalReferencedDocumentDate);
+								zpp.setTenderReferencedDocument(referencedDocument);
 							}
-
+						} else if (typeC == 130) {
+							if (additionalReferencedDocumentID != null){
+								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
+								referencedDocument.setName(additionalReferencedDocumentName);
+								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
+								referencedDocument.setFormattedIssueDateTime(additionalReferencedDocumentDate);
+								zpp.setObjectIdentifierReferencedDocument(referencedDocument);
+							}
+						} else if (typeC == 916) {
+							if (additionalReferencedDocumentID != null){
+								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
+								referencedDocument.setName(additionalReferencedDocumentName);
+								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
+								referencedDocument.setFormattedIssueDateTime(additionalReferencedDocumentDate);
+								zpp.setRelatedReferencedDocument(referencedDocument);
+							}
 						}
 					}
 				}
@@ -1436,6 +1447,7 @@ public class ZUGFeRDInvoiceImporter {
 							moreDetails += " and rounding amount "+tc.trans.getRoundingAmount().toPlainString();
 						}
 					} catch (Exception ignored) {
+						// ignore
 					}
 					throw new ArithmeticException("Payable total in XML is " + payableTotalFromXml + ", but calculated total is " + calculatedPayableTotal + moreDetails);
 				}
@@ -1467,10 +1479,10 @@ public class ZUGFeRDInvoiceImporter {
 		}
 		final String result;
 		try {
-			final Document document = getDocument();
+			final Document doc = getDocument();
 			final XPathFactory xpathFact = XPathFactory.newInstance();
 			final XPath xpath = xpathFact.newXPath();
-			result = xpath.evaluate(xpathStr, document);
+			result = xpath.evaluate(xpathStr, doc);
 		} catch (final XPathExpressionException e) {
 			LOGGER.error("Failed to evaluate XPath", e);
 			throw new ZUGFeRDExportException(e);

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
@@ -47,7 +47,11 @@ public class DeSerializationTest extends ResourceCase {
 	public void testJackson() throws JsonProcessingException {
 
 		ObjectMapper mapper = new ObjectMapper();
-		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty("some org", "teststr", "55232", "teststadt", "DE").addTaxID("taxID").addBankDetails(new BankDetails("DE3600000123456", "ABCDEFG1001").setAccountName("Donald Duck")).setEmail("info@company.com")).setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE4711").setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE"))).setNumber("0185").addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), new BigDecimal("1"), new BigDecimal(1.0)));
+		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
+				.setSender(new TradeParty("some org", "teststr", "55232", "teststadt", "DE").addTaxID("taxID").addBankDetails(new BankDetails("DE3600000123456", "ABCDEFG1001").setAccountName("Donald Duck")).setEmail("info@company.com").addVATID("DE0815"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE4711").setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE")))
+				.setNumber("0185")
+				.addItem(new Item(new Product("Testprodukt", "", "C62", new BigDecimal(19)), new BigDecimal("1"), new BigDecimal(1.0)));
 		String jsonArray = mapper.writeValueAsString(i);
 
 		// [{"stringValue":"a","intValue":1,"booleanValue":true},
@@ -99,9 +103,7 @@ public class DeSerializationTest extends ResourceCase {
 		CalculatedInvoice ci = new CalculatedInvoice();
 		try {
 			zii.extractInto(ci);
-		} catch (XPathExpressionException e) {
-			hasExceptions = true;
-		} catch (ParseException e) {
+		} catch (ParseException | XPathExpressionException e) {
 			hasExceptions = true;
 		}
 		ObjectMapper mapper = new ObjectMapper();
@@ -219,11 +221,7 @@ public class DeSerializationTest extends ResourceCase {
 			assertEquals(newInvoiceFromJSON.getAdditionalReferencedDocuments().length, 2);
 
 
-		} catch (IOException e) {
-			exText = e.getMessage();
-		} catch (XPathExpressionException e) {
-			exText = e.getMessage();
-		} catch (ParseException e) {
+		} catch (IOException | ParseException | XPathExpressionException e) {
 			exText = e.getMessage();
 		}
 		assertNull(exText);
@@ -327,13 +325,11 @@ public class DeSerializationTest extends ResourceCase {
 
 			assertEquals("Test_EeISI_100", i.getNumber());
 			assertEquals(newInvoiceFromJSON.getNumber(), i.getNumber());
+			assertNotNull(i.getObjectIdentifierReferencedDocument());
 
-		} catch (IOException e) {
+		} catch (IOException | ParseException | XPathExpressionException e) {
 			exText = e.getMessage();
-		} catch (XPathExpressionException e) {
-			exText = e.getMessage();
-		} catch (ParseException e) {
-			exText = e.getMessage();
+			e.printStackTrace();
 		}
 		assertNull(exText);
 
@@ -394,7 +390,7 @@ public class DeSerializationTest extends ResourceCase {
 		ObjectMapper mapper = new ObjectMapper();
 		boolean exceptions=false;
 		try {
-			Invoice newInvoiceFromJSON = mapper.readValue(json, Invoice.class);
+			mapper.readValue(json, Invoice.class);
 		} catch (JsonProcessingException e) {
 			exceptions=true;
 		}
@@ -429,13 +425,25 @@ public class DeSerializationTest extends ResourceCase {
 		String taxID = "9990815";
 
 		BigDecimal price = new BigDecimal(priceStr);
+
+		Charge charge = new Charge(new BigDecimal(0.5)).setReason("quick delivery charge");
+		charge.setTaxRateApplicablePercent(new BigDecimal(16));
+
+		Charge allowance = new Allowance(new BigDecimal(0.2)).setReason("discount");
+		allowance.setTaxRateApplicablePercent(new BigDecimal(16));
+
 		Invoice newInvoiceFromJSON = null;
 		boolean hasExceptions = false;
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 		String json = "";
 		try {
-			SchemedID gtin = new SchemedID("0160", "2001015001325");
 			SchemedID gln = new SchemedID("0088", "4304171000002");
+
+			SchemedID gtin = new SchemedID("0160", "2001015001325");
+			Item item = new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123").addBuyerOrderReferencedDocumentLineID("xxx").addNote("item level 1/1").setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15"));
+			Charge itemAllowance = new Allowance(new BigDecimal(0.02)).setReason("item discount");
+			itemAllowance.setTaxRateApplicablePercent(new BigDecimal(16));
+
 			Invoice i = new Invoice().setCurrency("CHF").addNote("document level 1/2").addNote("document level 2/2").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSellerOrderReferencedDocumentID("9384").setBuyerOrderReferencedDocumentID("28934")
 				.setDetailedDeliveryPeriod(new SimpleDateFormat("yyyyMMdd").parse(occurrenceFrom), new SimpleDateFormat("yyyyMMdd").parse(occurrenceTo))
@@ -444,17 +452,15 @@ public class DeSerializationTest extends ResourceCase {
 				.setContractReferencedDocument(contractID)
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addGlobalID(gln).setEmail("recipient@test.org").addVATID("DE4711")
 					.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE").setFax("++49555123456")).setAdditionalAddress("Hinterhaus 3"))
-				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123").addReferencedLineID("xxx").addNote("item level 1/1").addAllowance(new Allowance(new BigDecimal(0.02)).setReason("item discount").setTaxPercent(new BigDecimal(16))).setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15")))
-				.addCharge(new Charge(new BigDecimal(0.5)).setReason("quick delivery charge").setTaxPercent(new BigDecimal(16)))
-				.addAllowance(new Allowance(new BigDecimal(0.2)).setReason("discount").setTaxPercent(new BigDecimal(16)))
+				.addItem(item)
+				.addCharge(charge)
+				.addAllowance(allowance)
 				.addCashDiscount(new CashDiscount(new BigDecimal(2), 14))
 				.setDeliveryDate(sdf.parse("2020-11-02")).setNumber(number).setVATDueDateTypeCode(EventTimeCodeTypeConstants.PAYMENT_DATE);
 			ObjectMapper mapper = new ObjectMapper();
 			json = mapper.writeValueAsString(i);
 			newInvoiceFromJSON = mapper.readValue(json, Invoice.class);
-		} catch (ParseException e) {
-			hasExceptions = true;
-		} catch (JsonProcessingException e) {
+		} catch (JsonProcessingException | ParseException e) {
 			hasExceptions = true;
 		}
 		assertEquals(newInvoiceFromJSON.getBuyerOrderReferencedDocumentID(), "28934");

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -22,7 +22,6 @@
 package org.mustangproject.ZUGFeRD;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
@@ -30,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.mustangproject.*;
@@ -50,21 +48,21 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZF2PushTest extends TestCase {
-	final String TARGET_PDF = "./target/testout-MustangGnuaccountingBeispielRE-20201121_508.pdf";
-	final String TARGET_ALLOWANCESPDF = "./target/testout-ZF2PushAllowances.pdf";
-	final String TARGET_CREDITNOTEPDF = "./target/testout-ZF2PushCreditNote.pdf";
-	final String TARGET_CORRECTIONPDF = "./target/testout-ZF2PushCorrection.pdf";
-	final String TARGET_ITEMGROSS = "./target/testout-ZF2PushGross.pdf";
-	final String TARGET_ITEMCHARGESALLOWANCESPDF = "./target/testout-ZF2PushItemChargesAllowances.pdf";
-	final String TARGET_CHARGESALLOWANCESPDF = "./target/testout-ZF2PushChargesAllowances.pdf";
-	final String TARGET_RELATIVECHARGESALLOWANCESPDF = "./target/testout-ZF2PushRelativeChargesAllowances.pdf";
-	final String TARGET_ATTACHMENTSPDF = "./target/testout-ZF2PushAttachments.pdf";
-	final String TARGET_BANKPDF = "./target/testout-ZF2PushBank.pdf";
-	final String TARGET_PUSHEDGE = "./target/testout-ZF2PushEdge.pdf";
-	final String TARGET_INTRACOMMUNITYSUPPLYMANUALPDF = "./target/testout-ZF2PushIntraCommunitySupplyManual.pdf";
-	final String TARGET_INTRACOMMUNITYSUPPLYPDF = "./target/testout-ZF2PushIntraCommunitySupply.pdf";
-	final String TARGET_REVERSECHARGEPDF = "./target/testout-ZF2PushReverseCharge.pdf";
-	final String TARGET_ALLOWANCES_TAXES = "./target/testout-ZF2PushAllowancesTaxes.pdf";
+	private static final String TARGET_PDF = "./target/testout-MustangGnuaccountingBeispielRE-20201121_508.pdf";
+	private static final String TARGET_ALLOWANCESPDF = "./target/testout-ZF2PushAllowances.pdf";
+	private static final String TARGET_CREDITNOTEPDF = "./target/testout-ZF2PushCreditNote.pdf";
+	private static final String TARGET_CORRECTIONPDF = "./target/testout-ZF2PushCorrection.pdf";
+	private static final String TARGET_ITEMGROSS = "./target/testout-ZF2PushGross.pdf";
+	private static final String TARGET_ITEMCHARGESALLOWANCESPDF = "./target/testout-ZF2PushItemChargesAllowances.pdf";
+	private static final String TARGET_CHARGESALLOWANCESPDF = "./target/testout-ZF2PushChargesAllowances.pdf";
+	private static final String TARGET_RELATIVECHARGESALLOWANCESPDF = "./target/testout-ZF2PushRelativeChargesAllowances.pdf";
+	private static final String TARGET_ATTACHMENTSPDF = "./target/testout-ZF2PushAttachments.pdf";
+	private static final String TARGET_BANKPDF = "./target/testout-ZF2PushBank.pdf";
+	private static final String TARGET_PUSHEDGE = "./target/testout-ZF2PushEdge.pdf";
+	private static final String TARGET_INTRACOMMUNITYSUPPLYMANUALPDF = "./target/testout-ZF2PushIntraCommunitySupplyManual.pdf";
+	private static final String TARGET_INTRACOMMUNITYSUPPLYPDF = "./target/testout-ZF2PushIntraCommunitySupply.pdf";
+	private static final String TARGET_REVERSECHARGEPDF = "./target/testout-ZF2PushReverseCharge.pdf";
+	private static final String TARGET_ALLOWANCES_TAXES = "./target/testout-ZF2PushAllowancesTaxes.pdf";
 
 	public void testPushExport() {
 		/***
@@ -77,11 +75,9 @@ public class ZF2PushTest extends TestCase {
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
 
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20201121_508blanko.pdf");
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20201121_508blanko.pdf");
 
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors();
 			ze.load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
@@ -106,9 +102,7 @@ public class ZF2PushTest extends TestCase {
 		Invoice i = new Invoice();
 		try {
 			zii.extractInto(i);
-		} catch (XPathExpressionException e) {
-			throw new RuntimeException(e);
-		} catch (ParseException e) {
+		} catch (ParseException | XPathExpressionException e) {
 			throw new RuntimeException(e);
 		}
 
@@ -146,10 +140,8 @@ public class ZF2PushTest extends TestCase {
 		String taxID = "9990815";
 		String theNote = "oh lala";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors();
 			ze.load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
@@ -174,9 +166,7 @@ public class ZF2PushTest extends TestCase {
 		Invoice i = null;
 		try {
 			i = zii.extractInvoice();
-		} catch (XPathExpressionException e) {
-			throw new RuntimeException(e);
-		} catch (ParseException e) {
+		} catch (ParseException | XPathExpressionException e) {
 			throw new RuntimeException(e);
 		}
 
@@ -209,10 +199,8 @@ public class ZF2PushTest extends TestCase {
 		String priceStr = "1.00";
 		String taxID = "9990815";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
 
@@ -234,12 +222,8 @@ public class ZF2PushTest extends TestCase {
 
 			assertEquals(IBAN, read.getSender().getBankDetails().get(0).getIBAN());
 			ze.export(TARGET_BANKPDF);
-		} catch (IOException e) {
+		} catch (IOException | ParseException | XPathExpressionException e) {
 			fail("IOException should not be raised");
-		} catch (XPathExpressionException e) {
-			fail("XPathException should not be raised");
-		} catch (ParseException e) {
-			fail("ParseException should not be raised");
 		}
 	}
 	public void testGross() {
@@ -248,13 +232,10 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProfile(Profiles.getByName("Extended"));
-
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 			//	ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr", "55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
 			//					.addItem(new Item(new Product("Testprodukt", "", "H84", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)))));
@@ -265,7 +246,6 @@ public class ZF2PushTest extends TestCase {
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")
 					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
 				.setNumber(number)
-
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)).addAllowance(new Allowance(new BigDecimal("0.1"))), price, qty));
 			ze.setTransaction(i);
 
@@ -294,7 +274,7 @@ public class ZF2PushTest extends TestCase {
 
 			ObjectMapper mapper = new ObjectMapper();
 
-			String jsonArray = mapper.writeValueAsString(ci);
+			mapper.writeValueAsString(ci);
 
 			// Reading ZUGFeRD
 			assertEquals(new BigDecimal("34.51"), ci.getDuePayable());
@@ -312,13 +292,13 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
-			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+		Charge charge = new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AReason");
+		charge.setTaxRateApplicablePercent(new BigDecimal(19));
 
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProfile(Profiles.getByName("Extended"));
-
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 			//	ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr", "55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
 			//					.addItem(new Item(new Product("Testprodukt", "", "H84", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)))));
@@ -328,7 +308,7 @@ public class ZF2PushTest extends TestCase {
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")
 					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
 				.setNumber(number)
-				.addCharge(new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AReason").setTaxPercent(new BigDecimal(19)))
+				.addCharge(charge)
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)).addAllowance(new Allowance(new BigDecimal("0.1")).setReasonCode("95")))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)).setReason("In love with salesperson")))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(2.0)).addCharge(new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AnotherReason")))
@@ -370,10 +350,8 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 			//	ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setSender(new TradeParty(orgname,"teststr", "55232","teststadt","DE")).setOwnTaxID("4711").setOwnVATID("DE0815").setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")).setNumber(number)
@@ -427,10 +405,8 @@ public class ZF2PushTest extends TestCase {
 
 		String taxID = "9990815";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors();
 			ze.load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
@@ -450,12 +426,9 @@ public class ZF2PushTest extends TestCase {
 			fail("IOException should not be raised");
 		}
 		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_INTRACOMMUNITYSUPPLYMANUALPDF);
-		Invoice i = null;
 		try {
-			i = zii.extractInvoice();
-		} catch (XPathExpressionException e) {
-			throw new RuntimeException(e);
-		} catch (ParseException e) {
+			zii.extractInvoice();
+		} catch (ParseException | XPathExpressionException e) {
 			throw new RuntimeException(e);
 		}
 
@@ -483,10 +456,8 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("extended");
 
@@ -534,13 +505,17 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
-			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
+		Charge charge = new Charge(new BigDecimal(0.5)).setReasonCode("ABK");
+		charge.setTaxRateApplicablePercent(new BigDecimal(19));
+
+		Charge allowance = new Allowance(new BigDecimal(0.2)).setReasonCode("95");
+		allowance.setTaxRateApplicablePercent(new BigDecimal(19));
+
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
-
 			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
@@ -548,8 +523,8 @@ public class ZF2PushTest extends TestCase {
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
-				.addCharge(new Charge(new BigDecimal(0.5)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK"))
-				.addAllowance(new Allowance(new BigDecimal(0.2)).setTaxPercent(new BigDecimal(19)).setReasonCode("95"))
+				.addCharge(charge)
+				.addAllowance(allowance)
 			);
 			String theXML = new String(ze.getProvider().getXML(), StandardCharsets.UTF_8);
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
@@ -588,12 +563,19 @@ public class ZF2PushTest extends TestCase {
 		String priceStr = "1.00";
 		String taxID = "9990815";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+
+		Charge charge = new Charge(new BigDecimal(0.5)).setReason("quick delivery charge");
+		charge.setTaxRateApplicablePercent(new BigDecimal(16));
+
+		Charge allowance = new Allowance(new BigDecimal(0.2)).setReason("discount");
+		allowance.setTaxRateApplicablePercent(new BigDecimal(16));
+
+		Charge itemAllowance = new Allowance(new BigDecimal(0.02)).setReason("item discount");
+		itemAllowance.setTaxRateApplicablePercent(new BigDecimal(16));
+
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
 
 			SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
@@ -614,16 +596,17 @@ public class ZF2PushTest extends TestCase {
 						.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE").setFax("++49555123456")).setAdditionalAddress("Hinterhaus 3"))
 					.setInvoicer( new TradeParty("Abweichender Rechnungssteller", "Teststr.12", "04711", "Entenhausen", "DE") )
 					.setInvoicee( new TradeParty("Abweichender Rechnungsempfänger", "Teststr.42", "00815", "Entenhausen", "DE") )
-					.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123").
-						addAdditionalReference(dr2).addBuyerOrderReferencedDocumentID("orderId").addBuyerOrderReferencedDocumentLineID("xxx").addReferencedLineID("xxx")
-						.addNote("item level 1/1").addAllowance(new Allowance(new BigDecimal(0.02)).setReason("item discount").setTaxPercent(new BigDecimal(16))).setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15"))
+					.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123")
+						.addAdditionalReference(dr2).addBuyerOrderReferencedDocumentID("orderId").addBuyerOrderReferencedDocumentLineID("xxx")
+						.addNote("item level 1/1")
+						.addAllowance(itemAllowance).setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15"))
 						.setDeliveryNoteReferencedDocumentID("deliverynote123")
 						.setDeliveryNoteReferencedDocumentLineID("deliverypos456")
 						.setDeliveryNoteReferencedDocumentDate(new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026"))
 						.setAccountingReference("#11111#2222#xxxx#")
 					)
-					.addCharge(new Charge(new BigDecimal(0.5)).setReason("quick delivery charge").setTaxPercent(new BigDecimal(16)))
-					.addAllowance(new Allowance(new BigDecimal(0.2)).setReason("discount").setTaxPercent(new BigDecimal(16)))
+					.addCharge(charge)
+					.addAllowance(allowance)
 					.addCashDiscount(new CashDiscount(new BigDecimal(2), 14))
 					.setTenderReferencedDocument(dr1)
 					.setDeliveryDate(sdf.parse("2020-11-02")).setNumber(number).setVATDueDateTypeCode(EventTimeCodeTypeConstants.PAYMENT_DATE)
@@ -717,20 +700,25 @@ public class ZF2PushTest extends TestCase {
 		String orgname = "Test company";
 		String number = "123";
 		BigDecimal qty = new BigDecimal("20");
-		try {
+
+		Charge allowance = new Allowance(new BigDecimal(600));
+		allowance.setTaxRateApplicablePercent(new BigDecimal(19));
+
+		Item item = new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)).addAllowance(new Allowance(BigDecimal.ONE)), new BigDecimal(500.0), qty);
+		Charge itemAllowance = new Allowance(new BigDecimal(300));
+		allowance.setTaxRateApplicablePercent(new BigDecimal(19));
+		item.addAllowance(itemAllowance);
+
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
-
 			ze.setTransaction(new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
 				.setNumber(number)
-				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)).addAllowance(new Allowance(BigDecimal.ONE)), new BigDecimal(500.0), qty).addAllowance(new Allowance(new BigDecimal(300)).setTaxPercent(new BigDecimal(19))))
-				.addAllowance(new Allowance(new BigDecimal(600)).setTaxPercent(new BigDecimal(19)))
+				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)).addAllowance(new Allowance(BigDecimal.ONE)), new BigDecimal(500.0), qty).addAllowance(new Allowance(new BigDecimal(300))).setTax(new BigDecimal(19)))
+				.addAllowance(allowance)
 				.addLogisticServiceCharge(new LogisticsServiceCharge().setAppliedAmount(BigDecimal.valueOf(25)))
 			);
 			String theXML = new String(ze.getProvider().getXML(), StandardCharsets.UTF_8);
@@ -763,16 +751,19 @@ public class ZF2PushTest extends TestCase {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
+
+		Charge charge = new Charge().setPercent(new BigDecimal(50)).setBasisAmount(price).setReasonCode("ABK").setReason("Verschiedenes");
+		charge.setTaxRateApplicablePercent(new BigDecimal(19));
+
+		Charge allowance = new Allowance().setPercent(new BigDecimal(50)).setReasonCode("95").setReason("Mengenrabatt");
+		allowance.setTaxRateApplicablePercent(new BigDecimal(19));
+
 		LogisticsServiceCharge logisticsServiceCharge = new LogisticsServiceCharge().setDescription("Frachtkosten").setAppliedAmount(BigDecimal.valueOf(25));
 		logisticsServiceCharge.setTaxRateApplicablePercent(new BigDecimal(19));
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
-
 			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
@@ -780,8 +771,8 @@ public class ZF2PushTest extends TestCase {
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
-						.addCharge(new Charge().setPercent(new BigDecimal(50)).setBasisAmount(price).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK").setReason("Verschiedenes"))
-						.addAllowance(new Allowance().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19)).setReasonCode("95").setReason("Mengenrabatt"))
+						.addCharge(charge)
+						.addAllowance(allowance)
 						.addLogisticServiceCharge(logisticsServiceCharge)
 			);
 			String theXML = new String(ze.getProvider().getXML(), StandardCharsets.UTF_8);
@@ -818,11 +809,8 @@ public class ZF2PushTest extends TestCase {
 		String priceStr = "1.00";
 		BigDecimal price = new BigDecimal(priceStr);
 		BigDecimal qty = new BigDecimal(-1.0);
-		try {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
 			// no due date, since we are not expecting money
@@ -871,10 +859,8 @@ public class ZF2PushTest extends TestCase {
 		String priceStr = "1.00";
 		BigDecimal price = new BigDecimal(priceStr);
 		BigDecimal qty = new BigDecimal(1.0);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
 			Invoice i = new Invoice().setIssueDate(new Date()).setDueDate(new Date()).setDetailedDeliveryPeriod(new Date(), new Date()).setDeliveryDate(new Date())
@@ -984,8 +970,6 @@ public class ZF2PushTest extends TestCase {
 	public void testExemptionReasonNotWrittenToLineLevelForEN16931Profile() {
 		String orgname = "Test company";
 		String number = "123";
-		BigDecimal price = new BigDecimal(1.0);
-		BigDecimal qty = new BigDecimal(1.0);
 		final String exemptionReason = "Kleinunternehmer gemäß §19 UStG";
 		final String exemptionReasonCode = "VATEX-EU-I";
 
@@ -1037,34 +1021,30 @@ public class ZF2PushTest extends TestCase {
 
 		Allowance allowance1 = new Allowance(new BigDecimal("10.00"));
 		allowance1.setReason("Discount");
-		allowance1.setCategoryCode(TaxCategoryCodeTypeConstants.INTRACOMMUNITY);
-		allowance1.setTaxPercent(BigDecimal.ZERO);
+		allowance1.setTaxCategoryCode(TaxCategoryCodeTypeConstants.INTRACOMMUNITY);
+		allowance1.setTaxRateApplicablePercent(BigDecimal.ZERO);
 		allowance1.setTaxExemptionReasonCode("VATEX-EU-IC");
 		allowance1.setTaxExemptionReason(invoice.getZFItems()[0].getProduct().getTaxExemptionReason());
 		invoice.addAllowance(allowance1);
 
 		Allowance allowance2 = new Allowance(new BigDecimal("5.00"));
 		allowance2.setReason("another discount");
-		allowance2.setCategoryCode(TaxCategoryCodeTypeConstants.INTRACOMMUNITY);
-		allowance2.setTaxPercent(BigDecimal.ZERO);
+		allowance2.setTaxCategoryCode(TaxCategoryCodeTypeConstants.INTRACOMMUNITY);
+		allowance2.setTaxRateApplicablePercent(BigDecimal.ZERO);
 		allowance2.setTaxExemptionReasonCode("VATEX-EU-IC");
 		allowance2.setTaxExemptionReason(invoice.getZFItems()[0].getProduct().getTaxExemptionReason());
 		invoice.addAllowance(allowance2);
 
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("extended"));
-
 			ze.setTransaction(invoice);
 			ze.export(TARGET_ALLOWANCES_TAXES);
 
 			ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_ALLOWANCES_TAXES);
 			try {
-				Invoice i = zii.extractInvoice();
-
-
+				zii.extractInvoice();
 			} catch (XPathExpressionException e) {
 				fail("XPathExpressionException should not be raised");
 			} catch (ParseException e) {

--- a/library/src/test/resources/not_validating_full_invoice_based_onTest_EeISI_300_CENfullmodel.cii.xml
+++ b/library/src/test/resources/not_validating_full_invoice_based_onTest_EeISI_300_CENfullmodel.cii.xml
@@ -112,6 +112,11 @@
                     <ram:LineTotalAmount>1000.00</ram:LineTotalAmount>
                 </ram:SpecifiedTradeSettlementLineMonetarySummation>
                 <ram:AdditionalReferencedDocument>
+                    <ram:IssuerAssignedID>Price/sales catalogue response</ram:IssuerAssignedID>
+                    <ram:TypeCode>50</ram:TypeCode>
+                    <ram:ReferenceTypeCode />
+                </ram:AdditionalReferencedDocument>
+                <ram:AdditionalReferencedDocument>
                     <ram:IssuerAssignedID>Line object identifier</ram:IssuerAssignedID>
                     <ram:TypeCode>130</ram:TypeCode>
                     <ram:ReferenceTypeCode />


### PR DESCRIPTION
Relates to #982.

Including elimination of warnings like
- removing trailing whitespaces
- naming of fields / variables
- removal of deprecated methods no longer used.