### PR TITLE
Emit line-level BT-137/BT-138 for EN16931 and XRechnung profiles

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,7 @@
 
 2.24.x
 =======
+- #925  Emit line-level CalculationPercent (BT-138) and BasisAmount (BT-137) for the EN16931 and XRechnung profiles, using the caller-supplied Allowance/Charge basis amount.
 - #1171 Removed deprecated methods Item::getAllowances() Item::getCharges() and their last usage in ZUGFeRD2PullProvider.
 - #228  Support LogisticsServiceCharges (Zuschläge für Versand & Verpackung)
 - #1174 Fix UBL AllowanceCharge import, add missing percent/basisAmount aliases, dropped per-unit-price allowances

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -308,17 +308,23 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 	protected String getItemTotalAllowanceChargeStr(IZUGFeRDAllowanceCharge allowance, IAbsoluteValueProvider item) {
 		String percentage = "";
 		String chargeIndicator = "false";
-		if ((allowance.getPercent() != null) && (profile == Profiles.getByName("Extended"))) {
-			percentage = "<ram:CalculationPercent>" + vatFormat(allowance.getPercent()) + "</ram:CalculationPercent>";
-			// BT-137/BT-142: BasisAmount = the value the percentage is applied to = line subtotal (price/basisQty)*qty
-			percentage += "<ram:BasisAmount>" + currencyFormat(item.getValue().multiply(item.getQuantity())) + "</ram:BasisAmount>";
+		boolean isEN16931 = (profile == Profiles.getByName("XRechnung")) || (profile == Profiles.getByName("EN16931"));
+		if (isEN16931 || (profile == Profiles.getByName("Extended"))) {
+			if (allowance.getPercent() != null) {
+				percentage += "<ram:CalculationPercent>" + vatFormat(allowance.getPercent()) + "</ram:CalculationPercent>";
+			}
+			if (allowance.getBasisAmount() != null) {
+				percentage += "<ram:BasisAmount>" + currencyFormat(allowance.getBasisAmount()) + "</ram:BasisAmount>";
+			} else if (allowance.getPercent() != null) {
+				// BT-137/BT-142: fall back to the line subtotal (price/basisQty)*qty when the caller did not supply BasisAmount
+				percentage += "<ram:BasisAmount>" + currencyFormat(item.getValue().multiply(item.getQuantity())) + "</ram:BasisAmount>";
+			}
 		}
 		if (allowance.isCharge()) {
 			chargeIndicator = "true";
 		}
 
 		String reason = "";
-		boolean isEN16931=(profile == Profiles.getByName("XRechnung")) || (profile == Profiles.getByName("EN16931"));
 		if ((allowance.getReason() != null) && (profile == Profiles.getByName("Extended") || isEN16931)) {
 			reason = "<ram:Reason>" + XMLTools.encodeXML(allowance.getReason()) + "</ram:Reason>";
 		}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -342,6 +342,100 @@ public class ZF2PushTest extends TestCase {
 
 
 	/***
+	 * BT-137 (BasisAmount) and BT-138 (CalculationPercent) must be serialized at line level
+	 * for the EN16931 and XRechnung profiles, using the caller-supplied values, and must appear
+	 * before ActualAmount.
+	 */
+	public void testItemAllowanceChargePercentBasisExport() {
+		Invoice invoice = new Invoice().setNumber("1").setIssueDate(new Date()).setDueDate(new Date())
+			.setSender(new TradeParty("Seller", "Street", "12345", "City", "DE").addVATID("DE123456789"))
+			.setRecipient(new TradeParty("Buyer", "Street", "12345", "City", "DE"))
+			.addItem(new Item(new Product("Item", "", "C62", new BigDecimal("19")), new BigDecimal("80.00"), new BigDecimal("5"))
+				.addAllowance(new Allowance(new BigDecimal("40.00"))
+					.setPercent(new BigDecimal("10.00"))
+					.setBasisAmount(new BigDecimal("400.00"))
+					.setReasonCode("95").setReason("Volume discount"))
+				.addCharge(new Charge(new BigDecimal("20.00"))
+					.setPercent(new BigDecimal("5.00"))
+					.setBasisAmount(new BigDecimal("400.00"))
+					.setReasonCode("ABK").setReason("Handling")));
+
+		for (String profileName : new String[]{"EN16931", "XRechnung"}) {
+			ZUGFeRD2PullProvider pp = new ZUGFeRD2PullProvider();
+			pp.setProfile(Profiles.getByName(profileName));
+			pp.generateXML(invoice);
+			String theXML = new String(pp.getXML(), StandardCharsets.UTF_8);
+
+			assertTrue(profileName + ": missing line-level allowance CalculationPercent",
+				theXML.contains("<ram:CalculationPercent>10.00</ram:CalculationPercent>"));
+			assertTrue(profileName + ": missing line-level charge CalculationPercent",
+				theXML.contains("<ram:CalculationPercent>5.00</ram:CalculationPercent>"));
+			assertTrue(profileName + ": BasisAmount must use the caller-supplied value, not a derivation",
+				theXML.contains("<ram:BasisAmount>400.00</ram:BasisAmount>"));
+
+			int percentIdx = theXML.indexOf("<ram:CalculationPercent>10.00");
+			int basisIdx = theXML.indexOf("<ram:BasisAmount>400.00", percentIdx);
+			int actualIdx = theXML.indexOf("<ram:ActualAmount>40.00", percentIdx);
+			assertTrue(profileName + ": CalculationPercent/BasisAmount must precede ActualAmount",
+				percentIdx >= 0 && basisIdx > percentIdx && actualIdx > basisIdx);
+		}
+	}
+
+
+	/***
+	 * A line-level allowance without percent/basis must not emit empty CalculationPercent/BasisAmount.
+	 */
+	public void testItemAllowanceWithoutPercentBasisExport() {
+		Invoice invoice = new Invoice().setNumber("1").setIssueDate(new Date()).setDueDate(new Date())
+			.setSender(new TradeParty("Seller", "Street", "12345", "City", "DE").addVATID("DE123456789"))
+			.setRecipient(new TradeParty("Buyer", "Street", "12345", "City", "DE"))
+			.addItem(new Item(new Product("Item", "", "C62", new BigDecimal("19")), new BigDecimal("80.00"), new BigDecimal("5"))
+				.addAllowance(new Allowance(new BigDecimal("40.00")).setReasonCode("95").setReason("Volume discount")));
+
+		ZUGFeRD2PullProvider pp = new ZUGFeRD2PullProvider();
+		pp.setProfile(Profiles.getByName("EN16931"));
+		pp.generateXML(invoice);
+		String theXML = new String(pp.getXML(), StandardCharsets.UTF_8);
+
+		int start = theXML.indexOf("<ram:SpecifiedTradeAllowanceCharge>");
+		int end = theXML.indexOf("</ram:SpecifiedTradeAllowanceCharge>", start);
+		String allowanceCharge = theXML.substring(start, end);
+		assertTrue(allowanceCharge.contains("<ram:ActualAmount>40.00</ram:ActualAmount>"));
+		assertFalse("no CalculationPercent expected when percent is unset",
+			allowanceCharge.contains("<ram:CalculationPercent>"));
+		assertFalse("no BasisAmount expected in the item allowance when basis is unset",
+			allowanceCharge.contains("<ram:BasisAmount>"));
+	}
+
+
+	/***
+	 * When a line-level allowance has a percent but no explicit basis, BasisAmount (BT-137) is
+	 * derived from the line subtotal (price/basisQuantity * quantity) for the EN16931 profile.
+	 */
+	public void testItemAllowancePercentOnlyDerivesBasisExport() {
+		Invoice invoice = new Invoice().setNumber("1").setIssueDate(new Date()).setDueDate(new Date())
+			.setSender(new TradeParty("Seller", "Street", "12345", "City", "DE").addVATID("DE123456789"))
+			.setRecipient(new TradeParty("Buyer", "Street", "12345", "City", "DE"))
+			.addItem(new Item(new Product("Item", "", "C62", new BigDecimal("19")), new BigDecimal("80.00"), new BigDecimal("5"))
+				.addAllowance(new Allowance(new BigDecimal("40.00"))
+					.setPercent(new BigDecimal("10.00"))
+					.setReasonCode("95").setReason("Volume discount")));
+
+		ZUGFeRD2PullProvider pp = new ZUGFeRD2PullProvider();
+		pp.setProfile(Profiles.getByName("EN16931"));
+		pp.generateXML(invoice);
+		String theXML = new String(pp.getXML(), StandardCharsets.UTF_8);
+
+		int start = theXML.indexOf("<ram:SpecifiedTradeAllowanceCharge>");
+		int end = theXML.indexOf("</ram:SpecifiedTradeAllowanceCharge>", start);
+		String allowanceCharge = theXML.substring(start, end);
+		assertTrue(allowanceCharge.contains("<ram:CalculationPercent>10.00</ram:CalculationPercent>"));
+		// basis not supplied by the caller -> derived from 80.00 * 5
+		assertTrue(allowanceCharge.contains("<ram:BasisAmount>400.00</ram:BasisAmount>"));
+	}
+
+
+	/***
 	 * you can activate intra community suppliy on item level
 	 */
 	public void testIntraCommunitySupplyItemExport() {

--- a/validator/src/test/java/org/mustangproject/validator/LineAllowanceChargeValidationTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/LineAllowanceChargeValidationTest.java
@@ -1,0 +1,93 @@
+package org.mustangproject.validator;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Date;
+
+import javax.xml.transform.Source;
+
+import org.mustangproject.Allowance;
+import org.mustangproject.BankDetails;
+import org.mustangproject.Charge;
+import org.mustangproject.Contact;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.TradeParty;
+import org.mustangproject.ZUGFeRD.Profiles;
+import org.mustangproject.ZUGFeRD.ZUGFeRD2PullProvider;
+import org.xmlunit.builder.Input;
+import org.xmlunit.xpath.JAXPXPathEngine;
+import org.xmlunit.xpath.XPathEngine;
+
+import junit.framework.TestCase;
+
+/**
+ * End-to-end integration test for #925: a generated EN16931/XRechnung invoice carrying a
+ * line-level allowance and charge with CalculationPercent (BT-138) / BasisAmount (BT-137) must
+ * (a) contain those elements at line level and (b) still pass Schematron/EN16931 validation.
+ */
+public class LineAllowanceChargeValidationTest extends TestCase {
+
+	private String generate(String profileName) {
+		Invoice invoice = new Invoice()
+			.setNumber("471102")
+			.setReferenceNumber("AB321")
+			.setIssueDate(new Date()).setDueDate(new Date()).setDeliveryDate(new Date())
+			.setSender(new TradeParty("Bei Spiel GmbH", "Ecke 12", "12345", "Stadthausen", "DE")
+				.addVATID("DE136695976").setEmail("seller@example.org")
+				.setContact(new Contact("Max Mustermann", "(555) 12 34-56", "seller@example.org"))
+				.addBankDetails(new BankDetails("DE88200800000970375700", "COBADEFFXXX").setAccountName("Max Mustermann")))
+			.setRecipient(new TradeParty("Theodor Est", "Bahnstr. 42", "88802", "Spielkreis", "DE")
+				.addVATID("DE999999999").setEmail("buyer@example.org"))
+			.addItem(new Item(new Product("Design", "Sample product", "HUR", new BigDecimal("19")),
+				new BigDecimal("100.00"), new BigDecimal("10"))
+				.addAllowance(new Allowance(new BigDecimal("100.00"))
+					.setPercent(new BigDecimal("10.00"))
+					.setBasisAmount(new BigDecimal("1000.00"))
+					.setReasonCode("95").setReason("Volume discount"))
+				.addCharge(new Charge(new BigDecimal("50.00"))
+					.setPercent(new BigDecimal("5.00"))
+					.setBasisAmount(new BigDecimal("1000.00"))
+					.setReasonCode("ABK").setReason("Handling")));
+
+		ZUGFeRD2PullProvider pp = new ZUGFeRD2PullProvider();
+		pp.setProfile(Profiles.getByName(profileName));
+		pp.generateXML(invoice);
+		return new String(pp.getXML(), StandardCharsets.UTF_8);
+	}
+
+	private String validate(String xml) throws Exception {
+		File tempFile = File.createTempFile("line-allowance-charge", ".xml");
+		tempFile.deleteOnExit();
+		Files.write(tempFile.toPath(), xml.getBytes(StandardCharsets.UTF_8));
+
+		final ValidationContext ctx = new ValidationContext(null);
+		final XMLValidator xv = new XMLValidator(ctx);
+		xv.setFilename(tempFile.getAbsolutePath());
+		xv.validate();
+		return xv.getXMLResult();
+	}
+
+	public void testLineAllowanceChargePercentBasisValidates() throws Exception {
+		final XPathEngine xpath = new JAXPXPathEngine();
+		for (String profileName : new String[]{"EN16931", "XRechnung"}) {
+			String xml = generate(profileName);
+
+			assertTrue(profileName + ": expected line-level CalculationPercent 10.00",
+				xml.contains("<ram:CalculationPercent>10.00</ram:CalculationPercent>"));
+			assertTrue(profileName + ": expected line-level CalculationPercent 5.00",
+				xml.contains("<ram:CalculationPercent>5.00</ram:CalculationPercent>"));
+			assertTrue(profileName + ": expected caller-supplied line-level BasisAmount 1000.00",
+				xml.contains("<ram:BasisAmount>1000.00</ram:BasisAmount>"));
+
+			String result = validate(xml);
+			Source source = Input.fromString("<validation>" + result + "</validation>").build();
+			String status = xpath.evaluate("/validation/summary/@status", source);
+			assertEquals(profileName + ": Schematron validation must remain valid.\n" + result,
+				"valid", status);
+		}
+	}
+}


### PR DESCRIPTION
## What this adds

Line-level allowances and charges (EN16931 groups **BG-27 / BG-28**) can now emit their **percentage (BT-138)** and **basis amount (BT-137)** in the **EN16931** and **XRechnung** profiles — not just `Extended`.

Previously these two elements were written only for the `Extended` profile, and even then the basis was recalculated as `value × quantity` instead of using the value you actually set. As a result, EN16931/XRechnung output silently dropped `CalculationPercent` and `BasisAmount`, so the machine-readable XML didn't match the human-readable invoice.

This mirrors the document-level fix already merged in #1034 (BT-100 / BT-101).

## How you use it

Set `setPercent(...)` and `setBasisAmount(...)` on a line-level `Allowance` or `Charge`, as you already can today:

```java
Item item = new Item(new Product("Item", "", "C62", new BigDecimal("19")),
                     new BigDecimal("80.00"), new BigDecimal("5"))
    .addAllowance(new Allowance(new BigDecimal("40.00"))
        .setPercent(new BigDecimal("10.00"))
        .setBasisAmount(new BigDecimal("400.00"))
        .setReasonCode("95")
        .setReason("Volume discount"));
```

## What you get in the output

For the `EN16931` and `XRechnung` profiles, the line now includes both elements, in the schema-required order (`CalculationPercent` and `BasisAmount` **before** `ActualAmount`):

```xml
<ram:SpecifiedTradeAllowanceCharge>
  <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
  <ram:CalculationPercent>10.00</ram:CalculationPercent>   <!-- BT-138 -->
  <ram:BasisAmount>400.00</ram:BasisAmount>                <!-- BT-137 -->
  <ram:ActualAmount>40.00</ram:ActualAmount>               <!-- BT-136 -->
  <ram:ReasonCode>95</ram:ReasonCode>                      <!-- BT-140 -->
  <ram:Reason>Volume discount</ram:Reason>                 <!-- BT-139 -->
</ram:SpecifiedTradeAllowanceCharge>
```

Behaviour details:
- `BasisAmount` uses the value you pass to `setBasisAmount(...)`.
- If you set a percent but omit the basis, it falls back to the previous `value × quantity` derivation (so existing behaviour is preserved).
- If you set neither, nothing extra is emitted — no empty elements.

## Tests

- `ZF2PushTest` — provider-level tests for all three branches (percent, caller-supplied basis, derived basis) plus a regression for the no-percent/no-basis case and an element-ordering check.
- `LineAllowanceChargeValidationTest` (validator module) — end-to-end test that generates a real EN16931 **and** XRechnung invoice and confirms it both carries the elements and still passes Schematron validation.

Refs #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)