### PR TITLE
Fix #987: show only the matching BIC per IBAN

### DIFF
--- a/library/src/main/resources/stylesheets/cii-xr.xsl
+++ b/library/src/main/resources/stylesheets/cii-xr.xsl
@@ -1376,10 +1376,10 @@
             <xr:Payment_service_provider_identifier>
                 <xsl:attribute name="xr:id" select="'BT-86'"/>
                 <xsl:attribute name="xr:src"
-                               select="'/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'"/>
+                               select="'../ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'"/>
                 <xsl:call-template name="distinct-bt-86">
                     <xsl:with-param name="bic-values"
-                                    select="distinct-values(/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID)"/>
+                                    select="distinct-values(../ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID)"/>
                 </xsl:call-template>
             </xr:Payment_service_provider_identifier>
         </xsl:variable>

--- a/library/src/main/resources/stylesheets/cio-xr.xsl
+++ b/library/src/main/resources/stylesheets/cio-xr.xsl
@@ -1179,9 +1179,9 @@
          <xsl:apply-templates mode="BT-85" select="./ram:AccountName"/>
          <xr:Payment_service_provider_identifier>
             <xsl:attribute name="xr:id" select="'BT-86'"/>
-            <xsl:attribute name="xr:src" select="'/rsm:SCRDMCCBDACIOMessageStructure/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'"/>            
+            <xsl:attribute name="xr:src" select="'../ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'"/>            
             <xsl:call-template name="distinct-bt-86">
-               <xsl:with-param name="bic-values" select="distinct-values(/rsm:SCRDMCCBDACIOMessageStructure/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID)"/>
+               <xsl:with-param name="bic-values" select="distinct-values(../ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID)"/>
             </xsl:call-template>
          </xr:Payment_service_provider_identifier>
       </xsl:variable>

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/VisualizationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/VisualizationTest.java
@@ -47,6 +47,37 @@ public class VisualizationTest extends ResourceCase {
 		this.runZUGFeRDVisualization("factur-x-extended.xml", "factur-x-vis-extended.de.html", Language.DE);
 	}
 
+	public void testCIIVisualizationMultiplePaymentMeansBIC() {
+		File CIIinputFile = getResourceAsFile("multiple-payment-means.cii.xml");
+		String result = null;
+		try {
+			ZUGFeRDVisualizer zvi = new ZUGFeRDVisualizer();
+			result = zvi.visualize(CIIinputFile.getAbsolutePath(), Language.EN);
+		} catch (UnsupportedOperationException e) {
+			fail("UnsupportedOperationException should not happen: " + e.getMessage());
+		} catch (IllegalArgumentException e) {
+			fail("IllegalArgumentException should not happen: " + e.getMessage());
+		} catch (TransformerException e) {
+			fail("TransformerException should not happen: " + e.getMessage());
+		} catch (IOException e) {
+			fail("IOException should not happen: " + e.getMessage());
+		} catch (ParserConfigurationException e) {
+			fail("ParserConfigurationException should not happen: " + e.getMessage());
+		}
+
+		assertNotNull(result);
+		// regression for https://github.com/ZUGFeRD/mustangproject/issues/987:
+		// BICs from other payment means must not be concatenated onto this one
+		assertFalse(result.contains("COBADEFF760;HYVEDEMM419"));
+		assertFalse(result.contains("HYVEDEMM419;OBKLDEMXXXX"));
+		assertFalse(result.contains("OBKLDEMXXXX;SOLADEST600"));
+		// each BIC must still be present, paired with its own IBAN
+		assertTrue(result.contains("COBADEFF760"));
+		assertTrue(result.contains("HYVEDEMM419"));
+		assertTrue(result.contains("OBKLDEMXXXX"));
+		assertTrue(result.contains("SOLADEST600"));
+	}
+
 	public void testUBLCreditNoteVisualizationBasic() {
 		this.runZUGFeRDVisualization("ubl-creditnote.xml", "factur-x-vis-ubl-creditnote.en.html", Language.EN);
 	}

--- a/library/src/test/resources/multiple-payment-means.cii.xml
+++ b/library/src/test/resources/multiple-payment-means.cii.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">  
+  <rsm:ExchangedDocumentContext> 
+    <ram:GuidelineSpecifiedDocumentContextParameter> 
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID> 
+    </ram:GuidelineSpecifiedDocumentContextParameter> 
+  </rsm:ExchangedDocumentContext>  
+  <rsm:ExchangedDocument> 
+    <ram:ID>RE-20201121/987</ram:ID>  
+    <ram:TypeCode>380</ram:TypeCode>  
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20201121</udt:DateTimeString>
+    </ram:IssueDateTime> 
+  </rsm:ExchangedDocument>  
+  <rsm:SupplyChainTradeTransaction> 
+    <ram:IncludedSupplyChainTradeLineItem> 
+      <ram:AssociatedDocumentLineDocument> 
+        <ram:LineID>1</ram:LineID> 
+      </ram:AssociatedDocumentLineDocument>  
+      <ram:SpecifiedTradeProduct> 
+        <ram:Name>Design (hours)</ram:Name>  
+        <ram:Description>Of a sample invoice</ram:Description> 
+      </ram:SpecifiedTradeProduct>  
+      <ram:SpecifiedLineTradeAgreement> 
+        <ram:GrossPriceProductTradePrice> 
+          <ram:ChargeAmount>160.0000</ram:ChargeAmount>  
+          <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity> 
+        </ram:GrossPriceProductTradePrice>  
+        <ram:NetPriceProductTradePrice> 
+          <ram:ChargeAmount>160.0000</ram:ChargeAmount>  
+          <ram:BasisQuantity unitCode="HUR">1.0000</ram:BasisQuantity> 
+        </ram:NetPriceProductTradePrice> 
+      </ram:SpecifiedLineTradeAgreement>  
+      <ram:SpecifiedLineTradeDelivery> 
+        <ram:BilledQuantity unitCode="HUR">1.0000</ram:BilledQuantity> 
+      </ram:SpecifiedLineTradeDelivery>  
+      <ram:SpecifiedLineTradeSettlement> 
+        <ram:ApplicableTradeTax> 
+          <ram:TypeCode>VAT</ram:TypeCode>  
+          <ram:CategoryCode>S</ram:CategoryCode>  
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent> 
+        </ram:ApplicableTradeTax>  
+        <ram:SpecifiedTradeSettlementLineMonetarySummation> 
+          <ram:LineTotalAmount>160.00</ram:LineTotalAmount> 
+        </ram:SpecifiedTradeSettlementLineMonetarySummation> 
+      </ram:SpecifiedLineTradeSettlement> 
+    </ram:IncludedSupplyChainTradeLineItem>  
+    <ram:ApplicableHeaderTradeAgreement> 
+      <ram:BuyerReference>AB321</ram:BuyerReference>  
+      <ram:SellerTradeParty> 
+        <ram:Name>Bei Spiel GmbH</ram:Name>  
+        <ram:PostalTradeAddress> 
+          <ram:PostcodeCode>12345</ram:PostcodeCode>  
+          <ram:LineOne>Ecke 12</ram:LineOne>  
+          <ram:CityName>Stadthausen</ram:CityName>  
+          <ram:CountryID>DE</ram:CountryID> 
+        </ram:PostalTradeAddress>  
+        <ram:SpecifiedTaxRegistration> 
+          <ram:ID schemeID="VA">DE136695976</ram:ID> 
+        </ram:SpecifiedTaxRegistration> 
+      </ram:SellerTradeParty>  
+      <ram:BuyerTradeParty> 
+        <ram:ID>2</ram:ID>  
+        <ram:Name>Theodor Est</ram:Name>  
+        <ram:PostalTradeAddress> 
+          <ram:PostcodeCode>88802</ram:PostcodeCode>  
+          <ram:LineOne>Bahnstr. 42</ram:LineOne>  
+          <ram:CityName>Spielkreis</ram:CityName>  
+          <ram:CountryID>DE</ram:CountryID> 
+        </ram:PostalTradeAddress> 
+      </ram:BuyerTradeParty> 
+    </ram:ApplicableHeaderTradeAgreement>  
+    <ram:ApplicableHeaderTradeDelivery> 
+      <ram:ActualDeliverySupplyChainEvent> 
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20201110</udt:DateTimeString>
+        </ram:OccurrenceDateTime> 
+      </ram:ActualDeliverySupplyChainEvent> 
+    </ram:ApplicableHeaderTradeDelivery>  
+    <ram:ApplicableHeaderTradeSettlement> 
+      <ram:PaymentReference>21808570</ram:PaymentReference>  
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>  
+      <ram:SpecifiedTradeSettlementPaymentMeans> 
+        <ram:TypeCode>58</ram:TypeCode>  
+        <ram:Information>Zahlung durch Überweisung</ram:Information>  
+        <ram:PayeePartyCreditorFinancialAccount> 
+          <ram:IBANID>DE8576040061XXXXXXXXXX</ram:IBANID>  
+        </ram:PayeePartyCreditorFinancialAccount>  
+        <ram:PayeeSpecifiedCreditorFinancialInstitution> 
+          <ram:BICID>COBADEFF760</ram:BICID> 
+        </ram:PayeeSpecifiedCreditorFinancialInstitution> 
+      </ram:SpecifiedTradeSettlementPaymentMeans>  
+      <ram:SpecifiedTradeSettlementPaymentMeans> 
+        <ram:TypeCode>58</ram:TypeCode>  
+        <ram:Information>Zahlung durch Überweisung</ram:Information>  
+        <ram:PayeePartyCreditorFinancialAccount> 
+          <ram:IBANID>DE8176220073XXXXXXXXXX</ram:IBANID>  
+        </ram:PayeePartyCreditorFinancialAccount>  
+        <ram:PayeeSpecifiedCreditorFinancialInstitution> 
+          <ram:BICID>HYVEDEMM419</ram:BICID> 
+        </ram:PayeeSpecifiedCreditorFinancialInstitution> 
+      </ram:SpecifiedTradeSettlementPaymentMeans>  
+      <ram:SpecifiedTradeSettlementPaymentMeans> 
+        <ram:TypeCode>58</ram:TypeCode>  
+        <ram:Information>Zahlung durch Überweisung</ram:Information>  
+        <ram:PayeePartyCreditorFinancialAccount> 
+          <ram:IBANID>DE0670120700XXXXXXXXXX</ram:IBANID>  
+        </ram:PayeePartyCreditorFinancialAccount>  
+        <ram:PayeeSpecifiedCreditorFinancialInstitution> 
+          <ram:BICID>OBKLDEMXXXX</ram:BICID> 
+        </ram:PayeeSpecifiedCreditorFinancialInstitution> 
+      </ram:SpecifiedTradeSettlementPaymentMeans>  
+      <ram:SpecifiedTradeSettlementPaymentMeans> 
+        <ram:TypeCode>58</ram:TypeCode>  
+        <ram:Information>Zahlung durch Überweisung</ram:Information>  
+        <ram:PayeePartyCreditorFinancialAccount> 
+          <ram:IBANID>DE8960050101XXXXXXXXXX</ram:IBANID>  
+        </ram:PayeePartyCreditorFinancialAccount>  
+        <ram:PayeeSpecifiedCreditorFinancialInstitution> 
+          <ram:BICID>SOLADEST600</ram:BICID> 
+        </ram:PayeeSpecifiedCreditorFinancialInstitution> 
+      </ram:SpecifiedTradeSettlementPaymentMeans>  
+      <ram:ApplicableTradeTax> 
+        <ram:CalculatedAmount>30.40</ram:CalculatedAmount>  
+        <ram:TypeCode>VAT</ram:TypeCode>  
+        <ram:BasisAmount>160.00</ram:BasisAmount>  
+        <ram:CategoryCode>S</ram:CategoryCode>  
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent> 
+      </ram:ApplicableTradeTax>  
+      <ram:SpecifiedTradePaymentTerms> 
+        <ram:Description>Zahlbar ohne Abzug bis 12.12.2020</ram:Description>  
+        <ram:DueDateDateTime>
+          <udt:DateTimeString format="102">20201212</udt:DateTimeString>
+        </ram:DueDateDateTime> 
+      </ram:SpecifiedTradePaymentTerms>  
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation> 
+        <ram:LineTotalAmount>160.00</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>  
+        <ram:TaxBasisTotalAmount>160.00</ram:TaxBasisTotalAmount>  
+        <ram:TaxTotalAmount currencyID="EUR">30.40</ram:TaxTotalAmount>  
+        <ram:GrandTotalAmount>190.40</ram:GrandTotalAmount>  
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>  
+        <ram:DuePayableAmount>190.40</ram:DuePayableAmount> 
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation> 
+    </ram:ApplicableHeaderTradeSettlement> 
+  </rsm:SupplyChainTradeTransaction> 
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
Fixes #987

With multiple payment means, every IBAN showed all BICs joined with `;`.
The CII->XR mapping read BT-86 from a document-wide path; now it reads the
BIC from the sibling `PayeeSpecifiedCreditorFinancialInstitution` within the
same payment means, so each IBAN shows only its own BIC.

- cii-xr.xsl / cio-xr.xsl: scope BT-86 lookup per payment means
- VisualizationTest: regression test with multiple accounts