### PR TITLE
Add maven-checkstyle-plugin with a basic configuration.

### DIFF
--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/FileChecker.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/FileChecker.java
@@ -25,7 +25,7 @@ import org.mustangproject.ZUGFeRD.ZUGFeRDImporter;
 public class FileChecker {
 	String filename;
 	StatRun thisRun;
-	boolean isPDF = false;
+	boolean isPDF;
 
 	public FileChecker(String filename, StatRun statistics) {
 		this.filename = filename;
@@ -36,7 +36,7 @@ public class FileChecker {
 			int extIndex = filename.lastIndexOf(".");
 			if (extIndex >= 0) {
 				extension = filename.substring(extIndex).toLowerCase();
-				isPDF = extension.equals(".pdf");// alternative check for PDF: File starts with %PDF-
+				isPDF = extension.equals(".pdf"); // alternative check for PDF: File starts with %PDF-
 				if (isPDF) {
 					thisRun.incPDFCount();
 				}

--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/Main.java
@@ -18,22 +18,44 @@
  *********************************************************************** */
 package org.mustangproject.commandline;
 
-import org.apache.commons.cli.*;
-import org.apache.commons.io.FilenameUtils;
-import org.mustangproject.CII.CIIToUBL;
-import org.mustangproject.EStandard;
-import org.mustangproject.FileAttachment;
-import org.mustangproject.ZUGFeRD.*;
-import org.mustangproject.validator.ZUGFeRDValidator;
-import org.slf4j.LoggerFactory;
-
-import javax.xml.transform.TransformerException;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+
+import javax.xml.transform.TransformerException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.UnrecognizedOptionException;
+import org.apache.commons.io.FilenameUtils;
+import org.mustangproject.EStandard;
+import org.mustangproject.FileAttachment;
+import org.mustangproject.CII.CIIToUBL;
+import org.mustangproject.ZUGFeRD.DXExporterFromA1;
+import org.mustangproject.ZUGFeRD.IZUGFeRDExporter;
+import org.mustangproject.ZUGFeRD.OXExporterFromA1;
+import org.mustangproject.ZUGFeRD.Profile;
+import org.mustangproject.ZUGFeRD.Profiles;
+import org.mustangproject.ZUGFeRD.ValidationLogVisualizer;
+import org.mustangproject.ZUGFeRD.XMLUpgrader;
+import org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA1;
+import org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromPDFA;
+import org.mustangproject.ZUGFeRD.ZUGFeRDImporter;
+import org.mustangproject.ZUGFeRD.ZUGFeRDVisualizer;
+import org.mustangproject.validator.ZUGFeRDValidator;
+import org.slf4j.LoggerFactory;
 
 public class Main {
 	private static org.slf4j.Logger LOGGER; // log output
@@ -52,7 +74,7 @@ public class Main {
 				+ "                It will start once a blank line has been entered.\n" + "\n"
 				+ "        Additional parameter for both count operations\n"
 				+ "        [-i, --ignorefileextension]     Check for all files (*.*) instead of PDF files only (*.pdf) in metrics, ignore PDF/A input file errors in combine\n"
-				+ "        [--disable-file-logging]		disable logging to file.\n"
+				+ "        [--disable-file-logging]     disable logging to file.\n"
 				+ "        --action extract   extract Factur-X PDF to XML file\n"
 				+ "                Additional parameters (optional - user will be prompted if not defined)\n"
 				+ "                [--source <filename>]: set input PDF file\n"
@@ -90,15 +112,13 @@ public class Main {
 				+ "        --action validateExpectInvalid  validate directory recursively expecting negative results \n"
 				+ "                [--no-notices]: refrain from reporting notices\n"
 				+ "                Additional parameters (user will be prompted if not defined)\n"
-				+ "					-d, --directory to check recursively\n"
-				+ "                Additional parameters (optional)\n"
-				+ "					--exclude: comma-separated list of filenames to ignore\n"
+				+ "                -d, --directory to check recursively\n"
+				+ "                --exclude: comma-separated list of filenames to ignore\n"
 				+ "        --action validateExpectValid  validate directory recursively expecting positive results \n"
 				+ "                [--no-notices]: refrain from reporting notices\n"
 				+ "                Additional parameters (user will be prompted if not defined)\n"
-				+ "					-d, --directory to check recursively \n"
-				+ "                Additional parameters (user will be prompted if not defined)\n"
-				+ "					--exclude: comma-separated list of filenames to ignore\n"
+				+ "                -d, --directory to check recursively \n"
+				+ "                --exclude: comma-separated list of filenames to ignore\n"
 				+ "        --action visualize  convert XML to HTML \n"
 				+ "                [--language <lang>]: set output lang (en, fr or de)\n"
 				+ "                [--source <filename>]: set input XML file\n"
@@ -134,7 +154,7 @@ public class Main {
 			// for a more sophisticated dialogue maybe https://github.com/mabe02/lanterna/
 			// could be taken into account
 			System.out.print(prompt + " (default: " + defaultValue + ")");
-			if ((!firstInput) && (pattern.length() > 0)) {
+			if ((!firstInput) && (!pattern.isEmpty())) {
 				System.out.print("\n(allowed pattern: " + pattern + ")");
 
 			}
@@ -278,7 +298,7 @@ public class Main {
 	 * @throws IOException
 	 * @throws TransformerException
 	 */
-	private static void performUBL(String xmlName, String outName) throws IOException, TransformerException {
+	private static void performUBL(String xmlName, String outName) throws IOException {
 
 		// Get params from user if not already defined
 		if (xmlName == null) {
@@ -389,7 +409,7 @@ public class Main {
 				// Retrieve all options
 				action = cmd.getOptionValue("action");
 				String directoryName = cmd.getOptionValue("directory");
-				boolean filesFromStdIn = cmd.hasOption("listfromstdin");// ((Number)cmdLine.getParsedOptionValue("integer-option")).intValue();
+				boolean filesFromStdIn = cmd.hasOption("listfromstdin"); // ((Number)cmdLine.getParsedOptionValue("integer-option")).intValue();
 				boolean ignoreFileExt = cmd.hasOption("ignorefileextension");
 				boolean noAttachments = cmd.hasOption("no-additional-attachments");
 				boolean helpRequested = cmd.hasOption("help") || ((action != null) && (action.equals("help")));
@@ -415,19 +435,14 @@ public class Main {
 				 * setting system property to disable FILE appender and
 				 * suppress creation of files and folders.
 				 */
-				System.setProperty("FILE_APPENDER_ENABLED", ((Boolean) (disableFileLogging == false)).toString());
+				System.setProperty("FILE_APPENDER_ENABLED", disableFileLogging ? Boolean.TRUE.toString() : Boolean.FALSE.toString() );
 
 				LOGGER = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 
 				if (helpRequested) {
 					printHelp();
 					optionsRecognized = true;
-				} /*
-					 * else if ((action!=null)&&(action.equals("license"))) {
-					 * printLicense();
-					 * optionsRecognized=true;
-					 * }
-					 */ else if ((action != null) && (action.equals("metrics"))) {
+				} else if ((action != null) && (action.equals("metrics"))) {
 					performMetrics(directoryName, filesFromStdIn, ignoreFileExt);
 					optionsRecognized = true;
 				} else if ((action != null) && (action.equals("combine"))) {
@@ -486,7 +501,7 @@ public class Main {
 			sourceName = getFilenameFromUser("Source PDF or XML", "invoice.pdf", "pdf|xml", true, false);
 		}
 		ZUGFeRDValidator zfv = new ZUGFeRDValidator();
-		if ((logAppend != null) && (logAppend.length() > 0)) {
+		if ((logAppend != null) && (!logAppend.isEmpty())) {
 			zfv.setLogAppend(logAppend);
 		}
 		if (noNotices) {
@@ -595,16 +610,17 @@ public class Main {
 	}
 
 	private static void performCombine(String pdfName, String xmlName, String outName, String format, String zfVersion,
-			String zfProfile, Boolean ignoreInputErrors, String[] attachmentFilenames,
-			ArrayList<FileAttachment> attachments, Boolean noAttachments) throws Exception {
+			String zfProfile, boolean ignoreInputErrors, String[] attachmentFilenames,
+			ArrayList<FileAttachment> attachments, boolean noAttachments) throws Exception {
 		/*
 		 * ZUGFeRDExporter ze= new ZUGFeRDExporterFromA1Factory()
 		 * .setProducer("toecount") .setCreator(System.getProperty("user.name"))
 		 * .loadFromPDFA1("invoice.pdf");
 		 */
+		IZUGFeRDExporter ze = null;
 		try {
-			int zfIntVersion = ZUGFeRDExporterFromA3.DefaultZUGFeRDVersion;
-			Profile zfConformanceLevelProfile = Profiles.getByName("EXTENDED");
+			int zfIntVersion;
+			Profile zfConformanceLevelProfile;
 
 			if (pdfName == null) {
 				pdfName = getFilenameFromUser("Source PDF", "invoice.pdf", "pdf", true, false);
@@ -625,12 +641,11 @@ public class Main {
 			}
 
 			if (attachmentFilenames == null) {
-				byte attachmentContents[] = null;
+				byte[] attachmentContents = null;
 				String attachmentFilename, attachmentMime;
 				if (!noAttachments) {
-					attachmentFilename = getFilenameFromUser("Additional file attachments filename (empty for none)",
-							"", "pdf", true, false);
-					if (attachmentFilename.length() != 0) {
+					attachmentFilename = getFilenameFromUser("Additional file attachments filename (empty for none)", "", "pdf", true, false);
+					if (!attachmentFilename.isEmpty()) {
 						attachmentContents = Files.readAllBytes(Paths.get(attachmentFilename));
 						attachmentMime = Files.probeContentType(Paths.get(attachmentFilename));
 						attachments.add(
@@ -663,7 +678,7 @@ public class Main {
 
 			if (zfVersion == null) {
 				try {
-					zfVersion = getStringFromUser("Version (1 or 2)", "1", "1|2");// fx default version is 1
+					zfVersion = getStringFromUser("Version (1 or 2)", "1", "1|2"); // fx default version is 1
 				} catch (Exception e) {
 					LOGGER.error(e.getMessage(), e);
 				}
@@ -698,21 +713,17 @@ public class Main {
 			ensureFileExists(xmlName);
 			ensureFileNotExists(outName);
 
-			if ((("fx".equals(format))) && (zfIntVersion > 1)) {
-				throw new Exception("Factur-X is only available in version 1 (roughly corresponding to ZF2)");
-			}
-
-			EStandard standard = EStandard.facturx;
+			EStandard standard = EStandard.FACTUR_X;
 			if ("zf".equals(format)) {
-				standard = EStandard.zugferd;
+				standard = EStandard.ZUGFERD;
 			}
 			if ("da".equals(format)) {
-				standard = EStandard.despatchadvice;
+				standard = EStandard.DELIVER_X;
 
 				zfConformanceLevelProfile = Profiles.getByName(standard, "PILOT", 1);
-			} else if (((("zf".equals(format))) && (zfIntVersion == 1)) || ("ox".equals(format))) {
+			} else if (("zf".equals(format) && zfIntVersion == 1) || ("ox".equals(format))) {
 				if ("ox".equals(format)) {
-					standard = EStandard.orderx;
+					standard = EStandard.ORDER_X;
 				}
 				if (zfProfile.equals("b")) {
 					zfConformanceLevelProfile = Profiles.getByName(standard, "BASIC", zfIntVersion);
@@ -747,7 +758,6 @@ public class Main {
 				throw new Exception(String.format("Unknown version '%i'", zfIntVersion));
 			}
 
-			IZUGFeRDExporter ze = null;
 			// All params are good! continue...
 			if (format.equals("ox")) {
 				ze = new OXExporterFromA1();
@@ -761,7 +771,7 @@ public class Main {
 				}
 			} else {
 				if (format.equals("fx")) {
-					zfIntVersion = 2;// actually we are talking of generation, not version
+					zfIntVersion = 2; // actually we are talking of generation, not version
 					// so even if someone correctly requested factur-x 1 internally we call it
 					// zugferd 2 :-(
 				}
@@ -795,10 +805,14 @@ public class Main {
 				LOGGER.error(e.getMessage(), e);
 			}
 			System.err.println(e.getMessage());
+		} finally {
+			if ( ze != null ) {
+				ze.close();
+			}
 		}
 	}
 
-	private static void performMetrics(String directoryName, Boolean filesFromStdIn, Boolean ignoreFileExt)
+	private static void performMetrics(String directoryName, boolean filesFromStdIn, boolean ignoreFileExt)
 			throws IOException {
 
 		StatRun sr = new StatRun();
@@ -824,7 +838,7 @@ public class Main {
 		if (filesFromStdIn) {
 			BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
 			String s;
-			while ((s = in.readLine()) != null && s.length() != 0) {
+			while ((s = in.readLine()) != null && !s.isEmpty()) {
 				FileChecker fc = new FileChecker(s, sr);
 
 				fc.checkForZUGFeRD();
@@ -900,11 +914,10 @@ public class Main {
 		if (!intoPDF) {
 
 			try {
-				ExportResource("/xrechnung-viewer.css");
-				ExportResource("/xrechnung-viewer.js");
+				exportResource("/xrechnung-viewer.css");
+				exportResource("/xrechnung-viewer.js");
 
-				System.out
-						.println("xrechnung-viewer.css and xrechnung-viewer.js written as well (to local working dir)");
+				System.out.println("xrechnung-viewer.css and xrechnung-viewer.js written as well (to local working dir)");
 			} catch (Exception e) {
 				LOGGER.error(e.getMessage(), e);
 			}
@@ -920,9 +933,9 @@ public class Main {
 	 * @throws Exception e.g. if the specified resource does not exist at the
 	 *                   specified location
 	 */
-	static public String ExportResource(String resourceName) throws Exception {
+	private static String exportResource(String resourceName) throws Exception {
 		String jarFolder;
-		try (InputStream stream = Main.class.getResourceAsStream(resourceName)) {// note that each / is a directory down
+		try (InputStream stream = Main.class.getResourceAsStream(resourceName)) { // note that each / is a directory down
 																					// in the "jar tree" been the jar
 																					// the root of the tree
 			if (stream == null) {
@@ -954,9 +967,10 @@ public class Main {
 		}
 	}
 
-	private static Boolean fileExists(String fileName) {
-		if (fileName == null)
+	private static boolean fileExists(String fileName) {
+		if (fileName == null) {
 			return false;
+		}
 		File f = new File(fileName);
 		// "exists" also returns true for directories
 		return f.isFile();

--- a/Mustang-CLI/src/main/java/org/mustangproject/commandline/StatRun.java
+++ b/Mustang-CLI/src/main/java/org/mustangproject/commandline/StatRun.java
@@ -21,10 +21,10 @@ package org.mustangproject.commandline;
 import java.math.BigDecimal;
 
 public class StatRun {
-	private int pdfCount = 0;
-	private int horseCount = 0;
-	private int fileCount = 0;
-	private int dirCount = 0;
+	private int pdfCount;
+	private int horseCount;
+	private int fileCount;
+	private int dirCount;
 	private BigDecimal total = BigDecimal.ZERO;
 	private boolean checkFileExt = true;
 
@@ -74,11 +74,9 @@ public class StatRun {
 	 * @return english string with linefeeds detailling number of files, directories, number of pdfs and of zugferd files
 	 */
 	public String getSummaryLine() {
-
 		return "\r\n===================================================================\r\n" + String.format(
 				"Files:\t%d\tDirs:\t%d\tPDF:\t%d\tZUGFeRD:\t%d\tTotal:\t%s\r\n",
 				getFileCount(), getDirCount(), getPDFCount(), getZUGFeRDCount(), total.toString());
-
 	}
 
 	/**
@@ -91,8 +89,7 @@ public class StatRun {
 	}
 
 	public void incTotal(BigDecimal delta) {
-		total=total.add(delta);
-		
+		total = total.add(delta);
 	}
 
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+  "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/configuration_1_2.dtd">
+<module name="Checker">
+	<property name="charset" value="UTF-8"/>
+	<property name="fileExtensions" value="java"/>
+
+
+	<module name="RegexpSingleline">
+		<property name="format" value="\s+$"/>
+		<property name="minimum" value="0"/>
+		<property name="maximum" value="0"/>
+		<property name="message" value="Line has trailing whitespaces."/>
+	</module>
+
+	<module name="TreeWalker">
+		<!--
+			Imports Checks: https://checkstyle.sourceforge.io/checks/imports/index.html
+		 -->
+		<module name="AvoidStarImport"/>
+		<module name="IllegalImport"/>
+		<module name="RedundantImport"/>
+		<module name="UnusedImports"/>
+		<!-- 
+			Block Checks: https://checkstyle.sourceforge.io/checks/blocks/index.html
+		-->
+		<module name="LeftCurly"/>
+		<module name="NeedBraces"/>
+		<module name="RightCurly"/>
+		<!--
+			Coding Checks https://checkstyle.sourceforge.io/checks/coding/index.html
+		 -->
+		<module name="AvoidDoubleBraceInitialization"/>
+		<module name="DeclarationOrder"/>
+		<module name="DefaultComesLast"/>
+		<module name="EmptyStatement"/>
+		<module name="ExplicitInitialization"/>
+		<module name="FallThrough"/>
+		<module name="OneStatementPerLine"/>
+		<module name="UnnecessarySemicolonAfterOuterTypeDeclaration"/>
+		<module name="UnnecessarySemicolonAfterTypeMemberDeclaration"/>
+		<module name="UnnecessarySemicolonInEnumeration"/>
+		<module name="UnnecessarySemicolonInTryWithResources"/>
+		<module name="UnusedLocalVariable"/>
+
+		<!--
+			Whitespace Checks: https://checkstyle.sourceforge.io/checks/whitespace/index.html
+		 -->
+		<module name="SingleSpaceSeparator"/>
+		<module name="WhitespaceAfter"/>
+		<module name="WhitespaceAround"/>
+		<!--
+			Design Checks: https://checkstyle.sourceforge.io/checks/design/index.html
+		-->
+		<module name="FinalClass"/>
+
+		<!-- Miscellaneous -->
+		<module name="ArrayTypeStyle"/>
+
+		<!--  Modifiers -->
+		<module name="ModifierOrder"/>
+		<module name="RedundantModifier"/>
+	</module>
+</module>

--- a/library/src/main/java/org/mustangproject/Allowance.java
+++ b/library/src/main/java/org/mustangproject/Allowance.java
@@ -35,11 +35,11 @@ public class Allowance extends Charge {
 
 	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
-		if(totalAmount != null) {
+		if (totalAmount != null) {
 			return totalAmount;
-		} else if (percent!=null) {
-			BigDecimal singlePrice=currentItem.getValue().multiply(BigDecimal.ONE.subtract(getPercent().divide(new BigDecimal(100), 18, RoundingMode.HALF_UP)));
-			BigDecimal singlePriceDiff=currentItem.getValue().subtract(singlePrice);
+		} else if (percent != null) {
+			BigDecimal singlePrice = currentItem.getValue().multiply(BigDecimal.ONE.subtract(getPercent().divide(new BigDecimal(100), 18, RoundingMode.HALF_UP)));
+			BigDecimal singlePriceDiff = currentItem.getValue().subtract(singlePrice);
 			return singlePriceDiff.multiply(currentItem.getQuantity());
 		} else {
 			throw new RuntimeException("percent must be set");

--- a/library/src/main/java/org/mustangproject/BankDetails.java
+++ b/library/src/main/java/org/mustangproject/BankDetails.java
@@ -18,11 +18,11 @@ public class BankDetails implements IZUGFeRDTradeSettlementPayment {
 	/**
 	 * BIC, I believe it's optional
 	 */
-	protected String BIC = null;
+	protected String BIC;
 	/**
 	 * the "name" of the bank account (holder)
 	 */
-	protected String accountName = null;
+	protected String accountName;
 	/**
 	 * payment means code
 	 */
@@ -143,7 +143,9 @@ public class BankDetails implements IZUGFeRDTradeSettlementPayment {
 	}
 
 	@Override
-	public String getPaymentMeansCode() { return paymentMeansCode; }
+	public String getPaymentMeansCode() {
+		return paymentMeansCode;
+	}
 
 	/**
 	 * set payment means information
@@ -157,5 +159,7 @@ public class BankDetails implements IZUGFeRDTradeSettlementPayment {
 	}
 
 	@Override
-	public String getPaymentMeansInformation() { return paymentMeansInformation; }
+	public String getPaymentMeansInformation() {
+		return paymentMeansInformation;
+	}
 }

--- a/library/src/main/java/org/mustangproject/CII/CIIToUBL.java
+++ b/library/src/main/java/org/mustangproject/CII/CIIToUBL.java
@@ -39,10 +39,9 @@ public class CIIToUBL {
 		}
 		final Serializable aUBL = cc.convertCIItoUBL(input, occurred);
 		if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.invoice_23.InvoiceType) {
-			UBL23Marshaller.invoice ().setFormattedOutput (true).write((oasis.names.specification.ubl.schema.xsd.invoice_23.InvoiceType)aUBL, output);
-		}
-		else if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_23.CreditNoteType)	{
-		   UBL23Marshaller.creditNote ().setFormattedOutput (true).write((oasis.names.specification.ubl.schema.xsd.creditnote_23.CreditNoteType) aUBL, output);
+			UBL23Marshaller.invoice().setFormattedOutput(true).write((oasis.names.specification.ubl.schema.xsd.invoice_23.InvoiceType) aUBL, output);
+		} else if (aUBL instanceof oasis.names.specification.ubl.schema.xsd.creditnote_23.CreditNoteType) {
+		   UBL23Marshaller.creditNote().setFormattedOutput(true).write((oasis.names.specification.ubl.schema.xsd.creditnote_23.CreditNoteType) aUBL, output);
 		}
 	}
 }

--- a/library/src/main/java/org/mustangproject/CalculatedInvoice.java
+++ b/library/src/main/java/org/mustangproject/CalculatedInvoice.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.mustangproject.ZUGFeRD.TransactionCalculator;
 import org.mustangproject.ZUGFeRD.VATAmount;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -22,41 +20,43 @@ import java.math.BigDecimal;
  */
 public class CalculatedInvoice extends Invoice implements Serializable {
 
+	private static final long serialVersionUID = 1L;
+
 	/***
 	 * de factor the total net amount
 	 */
-	protected BigDecimal lineTotalAmount=null;
+	protected BigDecimal lineTotalAmount;
 	/**
 	 * still to be paid
 	 */
-	protected BigDecimal duePayable=null;
+	protected BigDecimal duePayable;
 	/**
 	 * originally to be paid (without prepayments)
 	 */
-	protected BigDecimal grandTotal=null;
+	protected BigDecimal grandTotal;
 	/**
 	 * the net amount upon which value added taxes are applied
 	 */
-	protected BigDecimal taxBasis=null;
+	protected BigDecimal taxBasis;
 	/**
 	 * the total sum of value added taxes
 	 */
-	protected BigDecimal VATtotal=null;
-	protected TransactionCalculator tc=null;
+	protected BigDecimal VATtotal;
+	protected TransactionCalculator tc;
 
-    public void calculate() {
-		tc=new TransactionCalculator(this);
-        grandTotal=tc.getGrandTotal();
-		lineTotalAmount=tc.getValue();
-		duePayable=tc.getDuePayable();
-		taxBasis= tc.getTaxBasis();
-		VATtotal=BigDecimal.ZERO;
+	public void calculate() {
+		tc = new TransactionCalculator(this);
+		grandTotal = tc.getGrandTotal();
+		lineTotalAmount = tc.getValue();
+		duePayable = tc.getDuePayable();
+		taxBasis = tc.getTaxBasis();
+		VATtotal = BigDecimal.ZERO;
 		for (VATAmount vam:getCalculation().getTaxDetails()) {
-			VATtotal=VATtotal.add(vam.getCalculated());
+			VATtotal = VATtotal.add(vam.getCalculated());
 		}
-    }
+	}
 	public BigDecimal getGrandTotal() {
-		if (grandTotal==null) {
+		if (grandTotal == null) {
 			calculate();
 		}
 		return grandTotal;
@@ -69,11 +69,11 @@ public class CalculatedInvoice extends Invoice implements Serializable {
 	 * @return fluent setter
 	 */
 	public CalculatedInvoice setGrandTotal(BigDecimal grand) {
-		grandTotal=grand;
+		grandTotal = grand;
 		return this;
 	}
 	public BigDecimal getTaxBasis() {
-		if (taxBasis==null) {
+		if (taxBasis == null) {
 			calculate();
 		}
 		return taxBasis;
@@ -86,12 +86,12 @@ public class CalculatedInvoice extends Invoice implements Serializable {
 	 * @return fluent setter
 	 */
 	public CalculatedInvoice setTaxBasis(BigDecimal basis) {
-		taxBasis=basis;
+		taxBasis = basis;
 		return this;
 	}
 
 	public BigDecimal getDuePayable() {
-		if (duePayable==null) {
+		if (duePayable == null) {
 			calculate();
 		}
 		return duePayable;
@@ -104,12 +104,12 @@ public class CalculatedInvoice extends Invoice implements Serializable {
 	 * @return fluent setter
 	 */
 	public CalculatedInvoice setDuePayable(BigDecimal due) {
-		duePayable=due;
+		duePayable = due;
 		return this;
 	}
 
 	public BigDecimal getLineTotalAmount() {
-		if (lineTotalAmount==null) {
+		if (lineTotalAmount == null) {
 			calculate();
 		}
 		return lineTotalAmount;
@@ -122,7 +122,7 @@ public class CalculatedInvoice extends Invoice implements Serializable {
 	 * @return fluent setter
 	 */
 	public CalculatedInvoice setVATtotal(BigDecimal parsedValue) {
-		VATtotal=parsedValue;
+		VATtotal = parsedValue;
 		return this;
 	}
 
@@ -131,7 +131,7 @@ public class CalculatedInvoice extends Invoice implements Serializable {
 	 * @return expect a value close to getGrandTotal-LineTotalAmount
 	 */
 	public BigDecimal getVATtotal() {
-		if (VATtotal==null) {
+		if (VATtotal == null) {
 			calculate();
 		}
 		return VATtotal;
@@ -143,7 +143,7 @@ public class CalculatedInvoice extends Invoice implements Serializable {
 	 * @return fluent setter
 	 */
 	public CalculatedInvoice setLineTotalAmount(BigDecimal total) {
-		lineTotalAmount=total;
+		lineTotalAmount = total;
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/CashDiscount.java
+++ b/library/src/main/java/org/mustangproject/CashDiscount.java
@@ -42,7 +42,7 @@ public class CashDiscount implements IZUGFeRDCashDiscount {
 	}
 
 	/***
-	 * bean contructor
+	 * bean constructor
 	 */
 	public CashDiscount() {
 
@@ -95,8 +95,8 @@ public class CashDiscount implements IZUGFeRDCashDiscount {
 		if (basisAmount != null) {
 			s += "    <ram:BasisAmount>" + XMLTools.nDigitFormat(basisAmount, 2) + "</ram:BasisAmount>";
 		}
-		s += "    <ram:CalculationPercent>"+XMLTools.nDigitFormat(percent,3)+"</ram:CalculationPercent>"+
-				"  </ram:ApplicableTradePaymentDiscountTerms>"+
+		s += "    <ram:CalculationPercent>" + XMLTools.nDigitFormat(percent, 3) + "</ram:CalculationPercent>" +
+				"  </ram:ApplicableTradePaymentDiscountTerms>" +
 				"</ram:SpecifiedTradePaymentTerms>";
 		return s;
 	}
@@ -108,6 +108,6 @@ public class CashDiscount implements IZUGFeRDCashDiscount {
 	 */
 	@JsonIgnore
 	public String getAsXRechnung() {
-		return "#SKONTO#TAGE="+days+"#PROZENT="+XMLTools.nDigitFormat(percent,2)+"#\n";
+		return "#SKONTO#TAGE=" + days + "#PROZENT=" + XMLTools.nDigitFormat(percent, 2) + "#\n";
 	}
 }

--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -146,11 +146,11 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 
 	@Override
 	public BigDecimal getTotalAmount(IAbsoluteValueProvider currentItem) {
-		if(totalAmount != null) {
+		if (totalAmount != null) {
 			return totalAmount;
-		} else if (percent!=null) {
-			BigDecimal singlePrice=currentItem.getValue().multiply(BigDecimal.ONE.subtract(getPercent().divide(new BigDecimal(100),  18, RoundingMode.HALF_UP)));
-			BigDecimal singlePriceDiff=currentItem.getValue().subtract(singlePrice);
+		} else if (percent != null) {
+			BigDecimal singlePrice = currentItem.getValue().multiply(BigDecimal.ONE.subtract(getPercent().divide(new BigDecimal(100), 18, RoundingMode.HALF_UP)));
+			BigDecimal singlePriceDiff = currentItem.getValue().subtract(singlePrice);
 			return singlePriceDiff.multiply(currentItem.getQuantity());
 
 		} else {
@@ -159,10 +159,10 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	}
 
 	public BigDecimal getTotalAmount() {
-		if (totalAmount!=null) {
+		if (totalAmount != null) {
 			return totalAmount;
 		} else {
-			if (percent==null) {
+			if (percent == null) {
 				throw new RuntimeException("totalAmount must be set");
 			}
 			return null;
@@ -229,8 +229,7 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	 * @return
 	 */
 	@Deprecated
-	public Charge setTaxPercent(BigDecimal percent)
-	{
+	public Charge setTaxPercent(BigDecimal percent) {
 		this.setTaxRateApplicablePercent(percent);
 		return this;
 	}
@@ -251,8 +250,7 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	 * @return
 	 */
 	@Deprecated
-	public Charge setCategoryCode(String taxCategoryCode)
-	{
+	public Charge setCategoryCode(String taxCategoryCode) {
 		this.setTaxCategoryCode(taxCategoryCode);
 		return this;
 	}

--- a/library/src/main/java/org/mustangproject/Contact.java
+++ b/library/src/main/java/org/mustangproject/Contact.java
@@ -49,7 +49,7 @@ public class Contact implements IZUGFeRDExportableContact {
 	/**
 	 * the fax number of the contact person
 	 */
-	protected String fax = null;
+	protected String fax;
 
 	/***
 	 * default constructor.
@@ -119,7 +119,7 @@ public class Contact implements IZUGFeRDExportableContact {
 
 					List<String> nameElements = Arrays.asList("PersonName"/*CII*/, "Name"/*UBL*/);
 					if (localName != null && nameElements.contains(localName)
-						&& currentItemNode.getFirstChild()!=null) {
+						&& currentItemNode.getFirstChild() != null) {
 							setName(currentItemNode.getFirstChild().getNodeValue());
 						}
 

--- a/library/src/main/java/org/mustangproject/DesignatedProductClassification.java
+++ b/library/src/main/java/org/mustangproject/DesignatedProductClassification.java
@@ -58,7 +58,7 @@ public class DesignatedProductClassification implements IDesignatedProductClassi
 	 * Bean constructor for schemed product descriptor
 	 */
 	public DesignatedProductClassification() {
-		classCode = null;// we need this constructor for jackson, i.e. to be able to JSON
+		classCode = null; // we need this constructor for jackson, i.e. to be able to JSON
 	}
 
 	@Override

--- a/library/src/main/java/org/mustangproject/EStandard.java
+++ b/library/src/main/java/org/mustangproject/EStandard.java
@@ -2,34 +2,34 @@ package org.mustangproject;
 
 public enum EStandard {
 	/**factur-x/zugferd 2*/
-	facturx,
+	FACTUR_X,
 	/***
 	 * order-x
 	 */
-	orderx,
+	ORDER_X,
 	/***
 	 * deliver-x
 	 */
-	despatchadvice,
+	DELIVER_X,
 	/***
 	 * 1lieferschein
 	 */
-	ubldespatchadvice,
+	UBL_DESPATCHADVICE,
 	/***
 	 * ZUGFeRD 1
 	 */
-	zugferd,
+	ZUGFERD,
 	/***
 	 * imported from cross industry invoice
 	 */
-	cii,
+	CII,
 	/***
 	 * imported from an UBL invoice
 	 */
-	ubl,
+	UBL,
 	/***
 	 * imported from an UBL credit note
 	 */
-	ubl_creditnote
+	UBL_CREDITNOTE
 
 }

--- a/library/src/main/java/org/mustangproject/Exceptions/ArithmeticException.java
+++ b/library/src/main/java/org/mustangproject/Exceptions/ArithmeticException.java
@@ -1,6 +1,5 @@
 package org.mustangproject.Exceptions;
 
-import java.text.ParseException;
 
 /***
  * ArithmetricException for backwards compatibility, was a spelling error

--- a/library/src/main/java/org/mustangproject/IncludedNote.java
+++ b/library/src/main/java/org/mustangproject/IncludedNote.java
@@ -9,10 +9,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class IncludedNote {
-	private String content;
-
-	private SubjectCode subjectCode;
-
 	private static final String INCLUDE_START = "<ram:IncludedNote>";
 	private static final String INCLUDE_END = "</ram:IncludedNote>";
 	private static final String CONTENT_START = "<ram:Content>";
@@ -20,16 +16,19 @@ public class IncludedNote {
 	private static final String SUBJECT_CODE_START = "<ram:SubjectCode>";
 	private static final String SUBJECT_CODE_END = "</ram:SubjectCode>";
 
-	public IncludedNote(String content, SubjectCode subjectCode) {
-		this.content = content;
-		this.subjectCode = subjectCode;
-	}
+	private String content;
+
+	private SubjectCode subjectCode;
 
 	/**
 	 * bean constructor
 	 */
 	public IncludedNote() {
+	}
 
+	public IncludedNote(String content, SubjectCode subjectCode) {
+		this.content = content;
+		this.subjectCode = subjectCode;
 	}
 
 	public static IncludedNote generalNote(String content) {
@@ -63,23 +62,23 @@ public class IncludedNote {
 	public static IncludedNote discountBonusNote(String content) {
 		return new IncludedNote(content, SubjectCode.AAK);
 	}
-	
+
 	public static IncludedNote paymentTermNote(String content) {
 		return new IncludedNote(content, SubjectCode.AAB);
 	}
-	
+
 	public static IncludedNote paymentDetailRemittanceInformationNote(String content) {
 		return new IncludedNote(content, SubjectCode.PMD);
 	}
-	
+
 	public static IncludedNote additionalInformationNote(String content) {
 		return new IncludedNote(content, SubjectCode.ACB);
 	}
-	
+
 	public static IncludedNote invoiceInstructionNote(String content) {
 		return new IncludedNote(content, SubjectCode.INV);
 	}
-	
+
 	public static IncludedNote unspecifiedNote(String content) {
 		return new IncludedNote(content, null);
 	}

--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -21,14 +21,24 @@
 package org.mustangproject;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.mustangproject.ZUGFeRD.*;
+import org.mustangproject.ZUGFeRD.IExportableTransaction;
+import org.mustangproject.ZUGFeRD.IReferencedDocument;
+import org.mustangproject.ZUGFeRD.IZUGFeRDAllowanceCharge;
+import org.mustangproject.ZUGFeRD.IZUGFeRDExportableItem;
+import org.mustangproject.ZUGFeRD.IZUGFeRDLogisticsServiceCharge;
+import org.mustangproject.ZUGFeRD.IZUGFeRDPaymentTerms;
+import org.mustangproject.ZUGFeRD.IZUGFeRDTradeSettlement;
 import org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /***
@@ -40,22 +50,21 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public class Invoice implements IExportableTransaction {
 
 	protected boolean testIndicator;
-	protected String documentName = null, documentCode = null, number = null, ownOrganisationFullPlaintextInfo = null, referenceNumber = null, shipToOrganisationID = null, shipToOrganisationName = null, shipToStreet = null, shipToZIP = null, shipToLocation = null, shipToCountry = null, buyerOrderReferencedDocumentID = null, ownForeignOrganisationID = null, ownOrganisationName = null, currency = null, paymentTermDescription = null;
+	protected String documentName, documentCode, number, ownOrganisationFullPlaintextInfo, referenceNumber, shipToOrganisationID, shipToOrganisationName, shipToStreet, shipToZIP, shipToLocation, shipToCountry, buyerOrderReferencedDocumentID, ownForeignOrganisationID, ownOrganisationName, currency, paymentTermDescription;
 	protected String deliveryTypeCode;
-	protected Date issueDate = null, dueDate = null, deliveryDate = null, buyerOrderReferencedDocumentIssueDateTime = null;
-	protected TradeParty sender = null, recipient = null, deliveryAddress = null, endCustomerDeliveryAddress = null, payee = null, invoicer = null, invoicee = null;
-	protected ArrayList<CashDiscount> cashDiscounts = null;
+	protected Date issueDate, dueDate, deliveryDate, buyerOrderReferencedDocumentIssueDateTime;
+	protected TradeParty sender, recipient, deliveryAddress, endCustomerDeliveryAddress, payee, invoicer, invoicee;
+	protected ArrayList<CashDiscount> cashDiscounts;
 	@JsonDeserialize(contentAs = Item.class)
-	protected List<IZUGFeRDExportableItem> zfItems = null;
-	protected ArrayList<String> notes = null;
-	private List<IncludedNote> includedNotes = null;
+	protected List<IZUGFeRDExportableItem> zfItems;
+	protected ArrayList<String> notes;
 	protected String sellerOrderReferencedDocumentID;
-	protected String contractReferencedDocument = null;
-	protected ArrayList<FileAttachment> xmlEmbeddedFiles = null;
+	protected String contractReferencedDocument;
+	protected ArrayList<FileAttachment> xmlEmbeddedFiles;
 
-	protected BigDecimal totalPrepaidAmount = null;
-	protected Date detailedDeliveryDateStart = null;
-	protected Date detailedDeliveryPeriodEnd = null;
+	protected BigDecimal totalPrepaidAmount;
+	protected Date detailedDeliveryDateStart;
+	protected Date detailedDeliveryPeriodEnd;
 	protected IReferencedDocument tenderReference; // TypeCode 50
 	protected IReferencedDocument objectIdentifierReferencedDocument; // TypeCode 130
 	protected IReferencedDocument relatedReferenceDocument; // TypeCode 916
@@ -64,21 +73,24 @@ public class Invoice implements IExportableTransaction {
 	protected ArrayList<IZUGFeRDLogisticsServiceCharge> logisticsServiceCharges = new ArrayList<>();
 	protected ArrayList<IZUGFeRDPaymentTerms> paymentTerms = new ArrayList<>();
 
-	protected String invoiceReferencedDocumentID = null;
+	protected String invoiceReferencedDocumentID;
 	protected Date invoiceReferencedIssueDate;
 	// New field for storing Invoiced Object Identifier (BG-3)
-	protected List<ReferencedDocument> invoiceReferencedDocuments = null;
+	protected List<ReferencedDocument> invoiceReferencedDocuments;
 
-	protected String specifiedProcuringProjectID = null;
-	protected String specifiedProcuringProjectName = null;
-	protected String despatchAdviceReferencedDocumentID = null;
-	protected String deliveryNoteReferencedDocumentID = null;
-	protected Date deliveryNoteReferencedDocumentDate = null;
-	protected String vatDueDateTypeCode = null;
+	protected String specifiedProcuringProjectID;
+	protected String specifiedProcuringProjectName;
+	protected String despatchAdviceReferencedDocumentID;
+	protected String deliveryNoteReferencedDocumentID;
+	protected Date deliveryNoteReferencedDocumentDate;
+	protected String vatDueDateTypeCode;
 	protected String creditorReferenceID; // required when direct debit is used.
-	private BigDecimal roundingAmount=null;
+
+	private List<IncludedNote> includedNotes;
+	private BigDecimal roundingAmount;
 	private String paymentReference; // Remittance information / Verwendungszweck, BT-83
 	private String businessProcessId;
+
 	public Invoice() {
 		zfItems = new ArrayList<>();
 		cashDiscounts = new ArrayList<>();
@@ -143,7 +155,7 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setAdditionalReferencedDocuments(FileAttachment[] fileArr) {
-		if (fileArr!=null) {
+		if (fileArr != null) {
 			xmlEmbeddedFiles = new ArrayList<>(Arrays.asList(fileArr));
 		} else {
 			xmlEmbeddedFiles = new ArrayList<>();
@@ -223,17 +235,17 @@ public class Invoice implements IExportableTransaction {
 
 	@JsonIgnore
 	public Invoice setObjectIdentifierReferencedDocument(String id, String referenceTypeCode) {
-	    ReferencedDocument dr = new ReferencedDocument(id);
-	    dr.setReferenceTypeCode(referenceTypeCode);
-	    return setObjectIdentifierReferencedDocument(dr);
+		ReferencedDocument dr = new ReferencedDocument(id);
+		dr.setReferenceTypeCode(referenceTypeCode);
+		return setObjectIdentifierReferencedDocument(dr);
 	}
 
 	@JsonIgnore
 	public Invoice setObjectIdentifierReferencedDocument(String id, String referenceTypeCode, Date issueDate) {
-	    ReferencedDocument dr = new ReferencedDocument(id);
-	    dr.setReferenceTypeCode(referenceTypeCode);
-	    dr.setFormattedIssueDateTime(issueDate);
-	    return setObjectIdentifierReferencedDocument(dr);
+		ReferencedDocument dr = new ReferencedDocument(id);
+		dr.setReferenceTypeCode(referenceTypeCode);
+		dr.setFormattedIssueDateTime(issueDate);
+		return setObjectIdentifierReferencedDocument(dr);
 	}
 
 	@Override
@@ -257,17 +269,17 @@ public class Invoice implements IExportableTransaction {
 
 	@JsonIgnore
 	public Invoice setRelatedReferencedDocument(String id, String referenceTypeCode) {
-	    ReferencedDocument dr = new ReferencedDocument(id);
-	    dr.setReferenceTypeCode(referenceTypeCode);
-	    return setRelatedReferencedDocument(dr);
+		ReferencedDocument dr = new ReferencedDocument(id);
+		dr.setReferenceTypeCode(referenceTypeCode);
+		return setRelatedReferencedDocument(dr);
 	}
 
 	@JsonIgnore
 	public Invoice setRelatedReferencedDocument(String id, String referenceTypeCode, Date issueDate) {
-	    ReferencedDocument dr = new ReferencedDocument(id);
-	    dr.setReferenceTypeCode(referenceTypeCode);
-	    dr.setFormattedIssueDateTime(issueDate);
-	    return setRelatedReferencedDocument(dr);
+		ReferencedDocument dr = new ReferencedDocument(id);
+		dr.setReferenceTypeCode(referenceTypeCode);
+		dr.setFormattedIssueDateTime(issueDate);
+		return setRelatedReferencedDocument(dr);
 	}
 
 
@@ -428,11 +440,13 @@ public class Invoice implements IExportableTransaction {
 		return this;
 	}
 
+	@Deprecated
 	@Override
 	public String getInvoiceReferencedDocumentID() {
 		return invoiceReferencedDocumentID;
 	}
 
+	@Deprecated
 	@Override
 	public Date getInvoiceReferencedIssueDate() {
 		return invoiceReferencedIssueDate;
@@ -579,7 +593,7 @@ public class Invoice implements IExportableTransaction {
 	}
 
 	public Invoice setNotesWithSubjectCode(List<IncludedNote> theList) {
-		includedNotes=theList;
+		includedNotes = theList;
 		return this;
 	}
 
@@ -654,7 +668,7 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setRoundingAmount(BigDecimal amount) {
-		 roundingAmount=amount;
+		 roundingAmount = amount;
 		 return this;
 	}
 
@@ -745,7 +759,7 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setZFCharges(Charge[] iza) {
-		charges=new ArrayList<>();
+		charges = new ArrayList<>();
 		charges.addAll(Arrays.asList(iza));
 		return this;
 	}
@@ -793,8 +807,7 @@ public class Invoice implements IExportableTransaction {
 	public Invoice setPaymentTerms(IZUGFeRDPaymentTerms paymentTerm) {
 		if (paymentTerms.isEmpty()) {
 			paymentTerms.add(paymentTerm);
-		}
-		else {
+		} else {
 			paymentTerms.set(0, paymentTerm);
 		}
 		return this;
@@ -1017,7 +1030,7 @@ public class Invoice implements IExportableTransaction {
 	}
 
 	public Invoice setDetailedDeliveryPeriodFrom(Date dt) {
-		detailedDeliveryDateStart=dt;
+		detailedDeliveryDateStart = dt;
 		return this;
 	}
 
@@ -1027,7 +1040,7 @@ public class Invoice implements IExportableTransaction {
 	}
 
 	public Invoice setDetailedDeliveryPeriodTo(Date dt) {
-		detailedDeliveryPeriodEnd=dt;
+		detailedDeliveryPeriodEnd = dt;
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -1,18 +1,21 @@
 package org.mustangproject;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.mustangproject.ZUGFeRD.*;
-import org.mustangproject.util.BigDecimalUtils;
-import org.mustangproject.util.NodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+
+import org.mustangproject.ZUGFeRD.IReferencedDocument;
+import org.mustangproject.ZUGFeRD.IZUGFeRDAllowanceCharge;
+import org.mustangproject.ZUGFeRD.IZUGFeRDExportableItem;
+import org.mustangproject.util.BigDecimalUtils;
+import org.mustangproject.util.NodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 /***
  * describes any invoice line
@@ -27,25 +30,25 @@ public class Item implements IZUGFeRDExportableItem {
 	protected BigDecimal grossPrice;
 	protected BigDecimal lineTotalAmount;
 	protected BigDecimal basisQuantity = BigDecimal.ONE;
-	protected Date detailedDeliveryPeriodFrom = null;
-	protected Date detailedDeliveryPeriodTo = null;
+	protected Date detailedDeliveryPeriodFrom;
+	protected Date detailedDeliveryPeriodTo;
 	protected String id;
-	protected String buyerOrderReferencedDocumentLineID = null;
-	protected String buyerOrderReferencedDocumentID = null;
+	protected String buyerOrderReferencedDocumentLineID;
+	protected String buyerOrderReferencedDocumentID;
 	protected Product product;
-	protected ArrayList<String> notes = null;
-	protected ArrayList<ReferencedDocument> referencedDocuments = null;
-	protected ArrayList<ReferencedDocument> additionalReference = null;
+	protected ArrayList<String> notes;
+	protected ArrayList<ReferencedDocument> referencedDocuments;
+	protected ArrayList<ReferencedDocument> additionalReference;
 	protected ArrayList<IZUGFeRDAllowanceCharge> allowances = new ArrayList<>();
 	protected ArrayList<IZUGFeRDAllowanceCharge> charges = new ArrayList<>();
-	protected List<IncludedNote> includedNotes = null;
+	protected List<IncludedNote> includedNotes;
 	protected String accountingReference;
-	protected String parentLineID = null;
-	protected String lineStatusReasonCode = null;
+	protected String parentLineID;
+	protected String lineStatusReasonCode;
  	protected TradeParty lineSeller;
-	protected String deliveryNoteReferencedDocumentID = null;
-	protected Date deliveryNoteReferencedDocumentDate = null;
-	protected String deliveryNoteReferencedDocumentLineID = null;
+	protected String deliveryNoteReferencedDocumentID;
+	protected Date deliveryNoteReferencedDocumentDate;
+	protected String deliveryNoteReferencedDocumentLineID;
 	//protected HashMap<String, String> attributes = new HashMap<>();
 
 	/***
@@ -208,7 +211,7 @@ public class Item implements IZUGFeRDExportableItem {
 
 						/** mustang attributes differences between net and gross price to the product */
 						String chargeIndicator = gpptpAtacNodes.getAsStringOrNull("ChargeIndicator");
-						if ((chargeIndicator != null)&&(gpptpAtacNodes.getAsBigDecimal("ActualAmount").isPresent())) {
+						if (chargeIndicator != null && gpptpAtacNodes.getAsBigDecimal("ActualAmount").isPresent()) {
 							BigDecimal actual = gpptpAtacNodes.getAsBigDecimal("ActualAmount").get();
 							if (chargeIndicator.equals("true")) {
 								product.addCharge(new Charge(actual));
@@ -548,8 +551,9 @@ public class Item implements IZUGFeRDExportableItem {
 	public IZUGFeRDAllowanceCharge[] getItemAllowances() {
 		if (allowances.isEmpty()) {
 			return null;
-		} else
+		} else {
 			return allowances.toArray(new IZUGFeRDAllowanceCharge[0]);
+		}
 	}
 
 	/***
@@ -576,8 +580,9 @@ public class Item implements IZUGFeRDExportableItem {
 	public IZUGFeRDAllowanceCharge[] getItemCharges() {
 		if (charges.isEmpty()) {
 			return null;
-		} else
+		} else {
 			return charges.toArray(new IZUGFeRDAllowanceCharge[0]);
+		}
 	}
 
 

--- a/library/src/main/java/org/mustangproject/LegalOrganisation.java
+++ b/library/src/main/java/org/mustangproject/LegalOrganisation.java
@@ -1,20 +1,21 @@
 package org.mustangproject;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import org.mustangproject.ZUGFeRD.*;
+import org.mustangproject.ZUGFeRD.IZUGFeRDLegalOrganisation;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /***
- * A organisation, i.e. usually a company
+ * A organization, i.e. usually a company
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class LegalOrganisation implements IZUGFeRDLegalOrganisation {
 
-	protected SchemedID schemedID = null;
-	protected String tradingBusinessName = null;
+	protected SchemedID schemedID;
+	protected String tradingBusinessName;
 
 	public LegalOrganisation() {
 	}
@@ -40,7 +41,7 @@ public class LegalOrganisation implements IZUGFeRDLegalOrganisation {
 		if (nodes.getLength() > 0) {
 		/*
 			will parse sth like
-			<ram:SpecifiedLegalOrganization>  
+			<ram:SpecifiedLegalOrganization>
 				<ram:ID schemeID="0002">4711</ram:ID>
 				<ram:TradingBusinessName>Test GmbH &amp; Co.KG</ram:TradingBusinessName>
 			</ram:SpecifiedLegalOrganization>

--- a/library/src/main/java/org/mustangproject/Product.java
+++ b/library/src/main/java/org/mustangproject/Product.java
@@ -1,17 +1,21 @@
 package org.mustangproject;
 
-import com.fasterxml.jackson.annotation.*;
-import org.mustangproject.ZUGFeRD.IDesignatedProductClassification;
-import org.mustangproject.ZUGFeRD.IZUGFeRDExportableProduct;
-import org.mustangproject.util.NodeMap;
-import org.w3c.dom.Node;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.mustangproject.ZUGFeRD.IDesignatedProductClassification;
+import org.mustangproject.ZUGFeRD.IZUGFeRDExportableProduct;
+import org.mustangproject.util.NodeMap;
+import org.w3c.dom.Node;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 /***
  * describes a product, good or service used in an invoice item line
@@ -20,20 +24,21 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 
 public class Product implements IZUGFeRDExportableProduct {
+	private static final HashMap<String, HashMap<String, String>> unitAbbrevs = new HashMap<>();
+
 	protected String unit, name, sellerAssignedID, buyerAssignedID;
 	protected String description = "";
-	protected String taxExemptionReason = null;
-	protected String taxExemptionReasonCode = null;
-	protected String taxCategoryCode = null;
-	protected BigDecimal VATPercent;
-	protected boolean isReverseCharge = false;
-	protected boolean isIntraCommunitySupply = false;
-	protected SchemedID globalId = null;
-	protected String countryOfOrigin = null;
-	protected ArrayList<Charge> charges=new ArrayList<>();
-	protected ArrayList<Allowance> allowances=new ArrayList<>();
+	protected String taxExemptionReason;
+	protected String taxExemptionReasonCode;
+	protected String taxCategoryCode;
+	protected BigDecimal vatPercent;
+	protected boolean isReverseCharge;
+	protected boolean isIntraCommunitySupply;
+	protected SchemedID globalId;
+	protected String countryOfOrigin;
+	protected ArrayList<Charge> charges = new ArrayList<>();
+	protected ArrayList<Allowance> allowances = new ArrayList<>();
 	protected HashMap<String, String> attributes = new HashMap<>();
-
 	protected List<IDesignatedProductClassification> classifications = new ArrayList<>();
 
 	/***
@@ -47,7 +52,7 @@ public class Product implements IZUGFeRDExportableProduct {
 		this.unit = unit;
 		this.name = name;
 		this.description = description;
-		this.VATPercent = VATPercent;
+		this.vatPercent = VATPercent;
 	}
 
 	public Product(Node node) {
@@ -82,13 +87,13 @@ public class Product implements IZUGFeRDExportableProduct {
 
 		//UBL
 		nodeMap.getAsNodeMap("AdditionalItemProperty").ifPresent(aipNodes -> {
-			String name = aipNodes.getAsStringOrNull("Name");
-			String val = aipNodes.getAsStringOrNull("Value");
-			if (name != null && val != null) {
+			String propertyName = aipNodes.getAsStringOrNull("Name");
+			String propertyValue = aipNodes.getAsStringOrNull("Value");
+			if (propertyName != null && propertyValue != null) {
 				if (attributes == null) {
 					attributes = new HashMap<>();
 				}
-				attributes.put(name, val);
+				attributes.put(propertyName, propertyValue);
 			}
 		});
 
@@ -249,7 +254,7 @@ public class Product implements IZUGFeRDExportableProduct {
 	 */
 	public Product setReverseCharge() {
 		isReverseCharge = true;
-		if ((getTaxExemptionReason()==null)||(getTaxExemptionReason().isEmpty())) {
+		if (getTaxExemptionReason() == null || getTaxExemptionReason().isEmpty()) {
 			setTaxExemptionReason("Reverse charge");
 		}
 		setVATPercent(BigDecimal.ZERO);
@@ -319,7 +324,7 @@ public class Product implements IZUGFeRDExportableProduct {
 
 	@Override
 	public BigDecimal getVATPercent() {
-		return VATPercent;
+		return vatPercent;
 	}
 
 	/****
@@ -329,9 +334,9 @@ public class Product implements IZUGFeRDExportableProduct {
 	 */
 	public Product setVATPercent(BigDecimal VATPercent) {
 		if (VATPercent == null) {
-			this.VATPercent = BigDecimal.ZERO;
+			this.vatPercent = BigDecimal.ZERO;
 		} else {
-			this.VATPercent = VATPercent;
+			this.vatPercent = VATPercent;
 		}
 		return this;
 	}
@@ -434,8 +439,9 @@ public class Product implements IZUGFeRDExportableProduct {
 	 * Jackson courtesy function, please use addCharge if you have the choice
 	 * @return array of or null, if none
 	 */
-	public Product setCharges(ArrayList<Charge> charges) {
-		this.charges=charges;
+	public Product setCharges(List<Charge> charges) {
+		this.charges.clear();
+		this.charges.addAll(charges);
 		return this;
 	}
 
@@ -445,7 +451,7 @@ public class Product implements IZUGFeRDExportableProduct {
 	 */
 	@Override
 	public Charge[] getCharges() {
-		if (charges.size()==0) {
+		if (charges.isEmpty()) {
 			return null;
 		}
 		Charge[] chargeArr = new Charge[charges.size()];
@@ -458,7 +464,7 @@ public class Product implements IZUGFeRDExportableProduct {
 	 * @return array of or null, if none
 	 */
 	public Allowance[] getAllowances() {
-		if (allowances.size()==0) {
+		if (allowances.isEmpty()) {
 			return null;
 		}
 		Allowance[] allowanceArr = new Allowance[allowances.size()];
@@ -469,13 +475,11 @@ public class Product implements IZUGFeRDExportableProduct {
 	 * Jackson courtesy function, please use addAllowance if you have the choice
 	 * @return array of or null, if none
 	 */
-	public Product setAllowances(ArrayList<Allowance> allowances) {
-		this.allowances=allowances;
+	public Product setAllowances(List<Allowance> allowances) {
+		this.allowances.clear();
+		this.allowances.addAll(allowances);
 		return this;
 	}
-
-
-	private static final HashMap<String, HashMap<String, String>> unitAbbrevs = new HashMap<>();
 
 	static {
 		HashMap<String, String> inner1 = new HashMap<>();
@@ -538,7 +542,7 @@ public class Product implements IZUGFeRDExportableProduct {
 		}
 		if (unitAbbrevs.get(language).containsKey(unitcode)) {
 			return unitAbbrevs.get(language).get(unitcode);
-		} else{
+		} else {
 			return unitcode;
 		}
 	}

--- a/library/src/main/java/org/mustangproject/SchemedID.java
+++ b/library/src/main/java/org/mustangproject/SchemedID.java
@@ -10,6 +10,14 @@ public class SchemedID {
 	protected String scheme;
 	protected String id;
 
+	public SchemedID() {
+	}
+
+	public SchemedID(String scheme, String id) {
+		setScheme(scheme);
+		setId(id);
+	}
+
 	public String getScheme() {
 		return scheme;
 	}
@@ -26,15 +34,6 @@ public class SchemedID {
 	public SchemedID setId(String id) {
 		this.id = id;
 		return this;
-	}
-
-	public SchemedID() {
-
-	}
-
-	public SchemedID(String scheme, String id) {
-		setScheme(scheme);
-		setId(id);
 	}
 
 	@Override

--- a/library/src/main/java/org/mustangproject/TradeParty.java
+++ b/library/src/main/java/org/mustangproject/TradeParty.java
@@ -26,24 +26,23 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class TradeParty implements IZUGFeRDExportableTradeParty {
 
 	protected String name, zip, street, location, country, taxScheme;
-	protected String taxID = null, vatID = null;
-	protected String ID = null;
-	protected String description = null;
-	protected String additionalAddress = null;
-	protected String additionalAddressExtension = null;
+	protected String taxID, vatID;
+	protected String ID;
+	protected String description;
+	protected String additionalAddress;
+	protected String additionalAddressExtension;
 	protected List<BankDetails> bankDetails = new ArrayList<>();
 	protected List<DirectDebit> debitDetails = new ArrayList<>();
-	protected Contact contact = null;
-	protected LegalOrganisation legalOrg = null;
-	protected SchemedID globalId = null;
-	protected SchemedID uriUniversalCommunicationId = null; //e.g. the email address of the organization
+	protected Contact contact;
+	protected LegalOrganisation legalOrg;
+	protected SchemedID globalId;
+	protected SchemedID uriUniversalCommunicationId; //e.g. the email address of the organization
 
 	/**
 	 * Default constructor.
 	 * Probably a bad idea but might be needed by jackson or similar
 	 */
 	public TradeParty() {
-
 	}
 
 
@@ -61,242 +60,6 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 		this.zip = zip;
 		this.location = location;
 		this.country = country;
-
-	}
-
-
-	protected void parseFromUBL(NodeList nodes) {
-		if (nodes.getLength() > 0) {
-
-			for (int nodeIndex = 0; nodeIndex < nodes.getLength(); nodeIndex++) {
-				//nodes.item(i).getTextContent())) {
-				Node currentItemNode = nodes.item(nodeIndex);
-
-				if (currentItemNode.getLocalName() != null) {
-					String currentUBLChild = currentItemNode.getLocalName();
-//					if (currentUBLChild.equals("Delivery")) {
-//						NodeList delivery = currentItemNode.getChildNodes();
-//						for (int deliveryIndex = 0; deliveryIndex < delivery.getLength(); deliveryIndex++) {
-//							if (delivery.item(deliveryIndex).getLocalName() != null) {
-//								Node currentNode = delivery.item(deliveryIndex);
-//								if (currentNode.getLocalName().equals("DeliveryLocation")) {
-//									NodeList deliveryLocation = currentNode.getChildNodes();
-//									for (int deliveryLocationIndex = 0; deliveryLocationIndex < deliveryLocation.getLength(); deliveryLocationIndex++) {
-//										if (deliveryLocation.item(deliveryLocationIndex).getLocalName() != null) {
-//											if (deliveryLocation.item(deliveryLocationIndex).getLocalName().equals("ID")) {
-//												//Node currentNode = partyID.item(partyIDIndex);
-//												setID(deliveryLocation.item(deliveryLocationIndex).getTextContent());
-//												if ((deliveryLocation.item(deliveryLocationIndex).getAttributes() != null &&
-//													(deliveryLocation.item(deliveryLocationIndex).getAttributes().getNamedItem("schemeID") != null))
-//												) {
-//													SchemedID sID = new SchemedID().setScheme(deliveryLocation.item(deliveryLocationIndex).getAttributes().getNamedItem("schemeID").getTextContent());
-//													addGlobalID(sID);
-//												}
-//											}
-//										}
-//									}
-//								}
-//
-//							}
-//						}
-//					}
-
-					if (currentUBLChild.equals("Party")) {
-						NodeList party = currentItemNode.getChildNodes();
-						for (int partyIndex = 0; partyIndex < party.getLength(); partyIndex++) {
-							if (party.item(partyIndex).getLocalName() != null) {
-								String currentTopElementName = party.item(partyIndex).getLocalName();
-								if (currentTopElementName.equals("PartyName")) {
-
-									NodeList partyName = party.item(partyIndex).getChildNodes();
-									for (int partyNameIndex = 0; partyNameIndex < partyName.getLength(); partyNameIndex++) {
-										if (partyName.item(partyNameIndex).getLocalName() != null) {
-
-											if (partyName.item(partyNameIndex).getLocalName().equals("Name")) {
-												setName(partyName.item(partyNameIndex).getTextContent());
-											}
-
-										}
-									}
-								}
-								if (party.item(partyIndex).getLocalName().equals("EndpointID")) {
-									Node currentNode = party.item(partyIndex);
-									List<String> supportedSchemeIDs = Arrays.asList("EM", "0225");
-									if ((currentNode.getAttributes() != null
-											&& (currentNode.getAttributes().getNamedItem("schemeID") != null))
-											&& (supportedSchemeIDs.contains(currentNode.getAttributes().getNamedItem("schemeID").getNodeValue()))) {
-										setEmail(currentNode.getAttributes().getNamedItem("schemeID").getNodeValue(), currentNode.getTextContent());
-									}
-
-								}
-								if (currentTopElementName.equals("PartyIdentification")) {
-									NodeList partyID = party.item(partyIndex).getChildNodes();
-									for (int partyIDIndex = 0; partyIDIndex < partyID.getLength(); partyIDIndex++) {
-										if (partyID.item(partyIDIndex).getLocalName() != null) {
-											if (partyID.item(partyIDIndex).getLocalName().equals("ID")) {
-												Node currentNode = partyID.item(partyIDIndex);
-												if ((currentNode.getAttributes() != null &&
-													(currentNode.getAttributes().getNamedItem("schemeID") != null))
-												) {
-													SchemedID sID = new SchemedID().setScheme(currentNode.getAttributes().getNamedItem("schemeID").getTextContent()).setId(currentNode.getTextContent());
-													addGlobalID(sID);
-
-												}
-												else {
-													setID(currentNode.getTextContent());
-												}
-
-											}
-										}
-									}
-								}
-
-								if (currentTopElementName.equals("PartyTaxScheme")) {
-									NodeList partyTaxScheme = party.item(partyIndex).getChildNodes();
-									String CompanyId = null;
-									for (int partyTaxSchemeIndex = 0; partyTaxSchemeIndex < partyTaxScheme.getLength(); partyTaxSchemeIndex++) {
-										if (partyTaxScheme.item(partyTaxSchemeIndex).getLocalName() != null) {
-											if (partyTaxScheme.item(partyTaxSchemeIndex).getLocalName().equals("CompanyID")) {
-												CompanyId = (partyTaxScheme.item(partyTaxSchemeIndex).getTextContent());
-											}
-											if (partyTaxScheme.item(partyTaxSchemeIndex).getLocalName().equals("TaxScheme")) {
-												NodeList taxSchemechilds = partyTaxScheme.item(partyTaxSchemeIndex).getChildNodes();
-												for (int taxSchemechildsIndex = 0; taxSchemechildsIndex < taxSchemechilds.getLength(); taxSchemechildsIndex++) {
-													if (taxSchemechilds.item(taxSchemechildsIndex).getLocalName() != null) {
-														List<String> taxSchemeTypes = Arrays.asList("FC", "NOVAT");
-														String textContent = taxSchemechilds.item(taxSchemechildsIndex).getTextContent();
-														if (textContent != null && taxSchemeTypes.contains(textContent)) {
-															setTaxID(CompanyId);
-														} else {
-															setVATID(CompanyId);
-														}
-													}
-												}
-											}
-										}
-
-									}
-								}
-
-
-								 /*
-								 UBL only: formally it can have a name as well but BT27 party name *should* be stored in
-								 so overwrite if one exists
-								*/
-
-								if (currentTopElementName.equals("PartyLegalEntity")) {
-									NodeList legal = party.item(partyIndex).getChildNodes();
-									LegalOrganisation lo = null;
-									for (int legalChildIndex = 0; legalChildIndex < legal.getLength(); legalChildIndex++) {
-										if (legal.item(legalChildIndex).getLocalName() != null) {
-
-											if (legal.item(legalChildIndex).getLocalName().equals("RegistrationName")) {
-												if (lo == null) {
-													lo = new LegalOrganisation();
-												}
-												lo.setTradingBusinessName(legal.item(legalChildIndex).getTextContent());
-											}
-											if (legal.item(legalChildIndex).getLocalName().equals("CompanyLegalForm")) {
-												setDescription(legal.item(legalChildIndex).getTextContent());
-											}
-											if (legal.item(legalChildIndex).getLocalName().equals("CompanyID")) {
-												if (lo == null) {
-													lo = new LegalOrganisation();
-												}
-												if (legal.item(legalChildIndex).getAttributes().getNamedItem("schemeID")!=null) {
-													SchemedID sid = new SchemedID(legal.item(legalChildIndex).getAttributes().getNamedItem("schemeID").getNodeValue(), legal.item(legalChildIndex).getTextContent());
-													lo.setSchemedID(sid);
-												}
-											}
-											// we dont have that attribute yet in the legalorganisation: CompanyLegalForm
-											if (lo != null) {
-												setLegalOrganisation(lo);
-											}
-
-										}
-									}
-								}
-
-								if (currentTopElementName.equals("PostalAddress")) {
-
-									NodeList postal = party.item(partyIndex).getChildNodes();
-									for (int postalChildIndex = 0; postalChildIndex < postal.getLength(); postalChildIndex++) {
-										if (postal.item(postalChildIndex).getLocalName() != null) {
-
-											if (postal.item(postalChildIndex).getLocalName().equals("StreetName")) {
-												setStreet(postal.item(postalChildIndex).getTextContent());
-											}
-											if (postal.item(postalChildIndex).getLocalName().equals("AdditionalStreetName")) {
-												setAdditionalAddress(postal.item(postalChildIndex).getTextContent());
-											}
-											//unknow correspondence if (postal.item(postalChildIndex).getLocalName().equals("LineThree")) {
-
-
-											if (postal.item(postalChildIndex).getLocalName().equals("CityName")) {
-												setLocation(postal.item(postalChildIndex).getTextContent());
-											}
-											if (postal.item(postalChildIndex).getLocalName().equals("PostalZone")) {
-												setZIP(postal.item(postalChildIndex).getTextContent());
-											}
-											if (postal.item(postalChildIndex).getLocalName().equals("Country")) {
-												NodeList country = postal.item(postalChildIndex).getChildNodes();
-												for (int countryIndex = 0; countryIndex < country.getLength(); countryIndex++) {
-													if (country.item(countryIndex).getLocalName() != null) {
-
-														if (country.item(countryIndex).getLocalName().equals("IdentificationCode")) {
-															setCountry(country.item(countryIndex).getTextContent());
-														}
-
-													}
-												}
-
-
-											}
-
-											if (postal.item(postalChildIndex).getLocalName().equals("AddressLine")) {
-												NodeList AddressLine = postal.item(postalChildIndex).getChildNodes();
-												for (int lineIndex = 0; lineIndex < AddressLine.getLength(); lineIndex++) {
-													if (AddressLine.item(lineIndex).getLocalName() != null) {
-
-														if (AddressLine.item(lineIndex).getLocalName().equals("Line")) {
-															setAdditionalAddressExtension(AddressLine.item(lineIndex).getTextContent());
-														}
-
-													}
-												}
-											}
-											if (postal.item(postalChildIndex).getLocalName().equals("Name")) {
-												setName(postal.item(postalChildIndex).getTextContent());
-											}
-
-										}
-									}
-								}
-
-								if (currentTopElementName.equals("Contact")) {
-									NodeList contact = party.item(partyIndex).getChildNodes();
-									setContact(new Contact(contact));
-
-								}
-							}
-						}
-
-					}
-
-					if (currentUBLChild.equals("GlobalID")) {
-						if (nodes.item(nodeIndex).getAttributes().getNamedItem("schemeID") != null) {
-							SchemedID gid = new SchemedID().setScheme(nodes.item(nodeIndex).getAttributes().getNamedItem("schemeID").getNodeValue()).setId(nodes.item(nodeIndex).getTextContent());
-							addGlobalID(gid);
-						}
-
-					}
-					if (currentUBLChild.equals("DefinedTradeContact")) {
-						NodeList contact = nodes.item(nodeIndex).getChildNodes();
-						setContact(new Contact(contact));
-					}
-				}
-			}
-		}
 
 	}
 
@@ -395,8 +158,8 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 							setLegalOrganisation(new LegalOrganisation(organization));
 						}
 						if (itemChilds.item(itemChildIndex).getLocalName().equals("DefinedTradeContact")) {
-							NodeList contact = itemChilds.item(itemChildIndex).getChildNodes();
-							setContact(new Contact(contact));
+							NodeList ml = itemChilds.item(itemChildIndex).getChildNodes();
+							setContact(new Contact(ml));
 						}
 						if (itemChilds.item(itemChildIndex).getLocalName().equals("PostalTradeAddress")) {
 							NodeList postal = itemChilds.item(itemChildIndex).getChildNodes();
@@ -465,6 +228,239 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 	@Override
 	public String getID() {
 		return ID;
+	}
+
+	protected void parseFromUBL(NodeList nodes) {
+		if (nodes.getLength() > 0) {
+
+			for (int nodeIndex = 0; nodeIndex < nodes.getLength(); nodeIndex++) {
+				//nodes.item(i).getTextContent())) {
+				Node currentItemNode = nodes.item(nodeIndex);
+
+				if (currentItemNode.getLocalName() != null) {
+					String currentUBLChild = currentItemNode.getLocalName();
+//					if (currentUBLChild.equals("Delivery")) {
+//						NodeList delivery = currentItemNode.getChildNodes();
+//						for (int deliveryIndex = 0; deliveryIndex < delivery.getLength(); deliveryIndex++) {
+//							if (delivery.item(deliveryIndex).getLocalName() != null) {
+//								Node currentNode = delivery.item(deliveryIndex);
+//								if (currentNode.getLocalName().equals("DeliveryLocation")) {
+//									NodeList deliveryLocation = currentNode.getChildNodes();
+//									for (int deliveryLocationIndex = 0; deliveryLocationIndex < deliveryLocation.getLength(); deliveryLocationIndex++) {
+//										if (deliveryLocation.item(deliveryLocationIndex).getLocalName() != null) {
+//											if (deliveryLocation.item(deliveryLocationIndex).getLocalName().equals("ID")) {
+//												//Node currentNode = partyID.item(partyIDIndex);
+//												setID(deliveryLocation.item(deliveryLocationIndex).getTextContent());
+//												if ((deliveryLocation.item(deliveryLocationIndex).getAttributes() != null &&
+//													(deliveryLocation.item(deliveryLocationIndex).getAttributes().getNamedItem("schemeID") != null))
+//												) {
+//													SchemedID sID = new SchemedID().setScheme(deliveryLocation.item(deliveryLocationIndex).getAttributes().getNamedItem("schemeID").getTextContent());
+//													addGlobalID(sID);
+//												}
+//											}
+//										}
+//									}
+//								}
+//
+//							}
+//						}
+//					}
+
+					if (currentUBLChild.equals("Party")) {
+						NodeList party = currentItemNode.getChildNodes();
+						for (int partyIndex = 0; partyIndex < party.getLength(); partyIndex++) {
+							if (party.item(partyIndex).getLocalName() != null) {
+								String currentTopElementName = party.item(partyIndex).getLocalName();
+								if (currentTopElementName.equals("PartyName")) {
+
+									NodeList partyName = party.item(partyIndex).getChildNodes();
+									for (int partyNameIndex = 0; partyNameIndex < partyName.getLength(); partyNameIndex++) {
+										if (partyName.item(partyNameIndex).getLocalName() != null) {
+
+											if (partyName.item(partyNameIndex).getLocalName().equals("Name")) {
+												setName(partyName.item(partyNameIndex).getTextContent());
+											}
+
+										}
+									}
+								}
+								if (party.item(partyIndex).getLocalName().equals("EndpointID")) {
+									Node currentNode = party.item(partyIndex);
+									List<String> supportedSchemeIDs = Arrays.asList("EM", "0225");
+									if ((currentNode.getAttributes() != null
+											&& (currentNode.getAttributes().getNamedItem("schemeID") != null))
+											&& (supportedSchemeIDs.contains(currentNode.getAttributes().getNamedItem("schemeID").getNodeValue()))) {
+										setEmail(currentNode.getAttributes().getNamedItem("schemeID").getNodeValue(), currentNode.getTextContent());
+									}
+
+								}
+								if (currentTopElementName.equals("PartyIdentification")) {
+									NodeList partyID = party.item(partyIndex).getChildNodes();
+									for (int partyIDIndex = 0; partyIDIndex < partyID.getLength(); partyIDIndex++) {
+										if (partyID.item(partyIDIndex).getLocalName() != null) {
+											if (partyID.item(partyIDIndex).getLocalName().equals("ID")) {
+												Node currentNode = partyID.item(partyIDIndex);
+												if ((currentNode.getAttributes() != null &&
+													(currentNode.getAttributes().getNamedItem("schemeID") != null))
+												) {
+													SchemedID sID = new SchemedID().setScheme(currentNode.getAttributes().getNamedItem("schemeID").getTextContent()).setId(currentNode.getTextContent());
+													addGlobalID(sID);
+												} else {
+													setID(currentNode.getTextContent());
+												}
+
+											}
+										}
+									}
+								}
+
+								if (currentTopElementName.equals("PartyTaxScheme")) {
+									NodeList partyTaxScheme = party.item(partyIndex).getChildNodes();
+									String CompanyId = null;
+									for (int partyTaxSchemeIndex = 0; partyTaxSchemeIndex < partyTaxScheme.getLength(); partyTaxSchemeIndex++) {
+										if (partyTaxScheme.item(partyTaxSchemeIndex).getLocalName() != null) {
+											if (partyTaxScheme.item(partyTaxSchemeIndex).getLocalName().equals("CompanyID")) {
+												CompanyId = (partyTaxScheme.item(partyTaxSchemeIndex).getTextContent());
+											}
+											if (partyTaxScheme.item(partyTaxSchemeIndex).getLocalName().equals("TaxScheme")) {
+												NodeList taxSchemechilds = partyTaxScheme.item(partyTaxSchemeIndex).getChildNodes();
+												for (int taxSchemechildsIndex = 0; taxSchemechildsIndex < taxSchemechilds.getLength(); taxSchemechildsIndex++) {
+													if (taxSchemechilds.item(taxSchemechildsIndex).getLocalName() != null) {
+														List<String> taxSchemeTypes = Arrays.asList("FC", "NOVAT");
+														String textContent = taxSchemechilds.item(taxSchemechildsIndex).getTextContent();
+														if (textContent != null && taxSchemeTypes.contains(textContent)) {
+															setTaxID(CompanyId);
+														} else {
+															setVATID(CompanyId);
+														}
+													}
+												}
+											}
+										}
+
+									}
+								}
+
+
+								 /*
+								 UBL only: formally it can have a name as well but BT27 party name *should* be stored in
+								 so overwrite if one exists
+								*/
+
+								if (currentTopElementName.equals("PartyLegalEntity")) {
+									NodeList legal = party.item(partyIndex).getChildNodes();
+									LegalOrganisation lo = null;
+									for (int legalChildIndex = 0; legalChildIndex < legal.getLength(); legalChildIndex++) {
+										if (legal.item(legalChildIndex).getLocalName() != null) {
+
+											if (legal.item(legalChildIndex).getLocalName().equals("RegistrationName")) {
+												if (lo == null) {
+													lo = new LegalOrganisation();
+												}
+												lo.setTradingBusinessName(legal.item(legalChildIndex).getTextContent());
+											}
+											if (legal.item(legalChildIndex).getLocalName().equals("CompanyLegalForm")) {
+												setDescription(legal.item(legalChildIndex).getTextContent());
+											}
+											if (legal.item(legalChildIndex).getLocalName().equals("CompanyID")) {
+												if (lo == null) {
+													lo = new LegalOrganisation();
+												}
+												if (legal.item(legalChildIndex).getAttributes().getNamedItem("schemeID") != null) {
+													SchemedID sid = new SchemedID(legal.item(legalChildIndex).getAttributes().getNamedItem("schemeID").getNodeValue(), legal.item(legalChildIndex).getTextContent());
+													lo.setSchemedID(sid);
+												}
+											}
+											// we dont have that attribute yet in the legalorganisation: CompanyLegalForm
+											if (lo != null) {
+												setLegalOrganisation(lo);
+											}
+
+										}
+									}
+								}
+
+								if (currentTopElementName.equals("PostalAddress")) {
+
+									NodeList postal = party.item(partyIndex).getChildNodes();
+									for (int postalChildIndex = 0; postalChildIndex < postal.getLength(); postalChildIndex++) {
+										if (postal.item(postalChildIndex).getLocalName() != null) {
+
+											if (postal.item(postalChildIndex).getLocalName().equals("StreetName")) {
+												setStreet(postal.item(postalChildIndex).getTextContent());
+											}
+											if (postal.item(postalChildIndex).getLocalName().equals("AdditionalStreetName")) {
+												setAdditionalAddress(postal.item(postalChildIndex).getTextContent());
+											}
+											//unknow correspondence if (postal.item(postalChildIndex).getLocalName().equals("LineThree")) {
+
+
+											if (postal.item(postalChildIndex).getLocalName().equals("CityName")) {
+												setLocation(postal.item(postalChildIndex).getTextContent());
+											}
+											if (postal.item(postalChildIndex).getLocalName().equals("PostalZone")) {
+												setZIP(postal.item(postalChildIndex).getTextContent());
+											}
+											if (postal.item(postalChildIndex).getLocalName().equals("Country")) {
+												NodeList nl = postal.item(postalChildIndex).getChildNodes();
+												for (int countryIndex = 0; countryIndex < nl.getLength(); countryIndex++) {
+													if (nl.item(countryIndex).getLocalName() != null) {
+
+														if (nl.item(countryIndex).getLocalName().equals("IdentificationCode")) {
+															setCountry(nl.item(countryIndex).getTextContent());
+														}
+
+													}
+												}
+
+
+											}
+
+											if (postal.item(postalChildIndex).getLocalName().equals("AddressLine")) {
+												NodeList AddressLine = postal.item(postalChildIndex).getChildNodes();
+												for (int lineIndex = 0; lineIndex < AddressLine.getLength(); lineIndex++) {
+													if (AddressLine.item(lineIndex).getLocalName() != null) {
+
+														if (AddressLine.item(lineIndex).getLocalName().equals("Line")) {
+															setAdditionalAddressExtension(AddressLine.item(lineIndex).getTextContent());
+														}
+
+													}
+												}
+											}
+											if (postal.item(postalChildIndex).getLocalName().equals("Name")) {
+												setName(postal.item(postalChildIndex).getTextContent());
+											}
+
+										}
+									}
+								}
+
+								if (currentTopElementName.equals("Contact")) {
+									NodeList nl = party.item(partyIndex).getChildNodes();
+									setContact(new Contact(nl));
+
+								}
+							}
+						}
+
+					}
+
+					if (currentUBLChild.equals("GlobalID")) {
+						if (nodes.item(nodeIndex).getAttributes().getNamedItem("schemeID") != null) {
+							SchemedID gid = new SchemedID().setScheme(nodes.item(nodeIndex).getAttributes().getNamedItem("schemeID").getNodeValue()).setId(nodes.item(nodeIndex).getTextContent());
+							addGlobalID(gid);
+						}
+
+					}
+					if (currentUBLChild.equals("DefinedTradeContact")) {
+						NodeList nl = nodes.item(nodeIndex).getChildNodes();
+						setContact(new Contact(nl));
+					}
+				}
+			}
+		}
+
 	}
 
 	@Override
@@ -554,8 +550,8 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 	 * @return fluent setter
 	 */
 	public TradeParty setGlobalID(String ID) {
-		if (globalId==null) {
-			globalId=new SchemedID();
+		if (globalId == null) {
+			globalId = new SchemedID();
 		}
 		globalId.setId(ID);
 		return this;
@@ -567,8 +563,8 @@ public class TradeParty implements IZUGFeRDExportableTradeParty {
 	 * @return fluent setter
 	 */
 	public TradeParty setGlobalIDScheme(String scheme) {
-		if (globalId==null) {
-			globalId=new SchemedID();
+		if (globalId == null) {
+			globalId = new SchemedID();
 		}
 		globalId.setScheme(scheme);
 		return this;

--- a/library/src/main/java/org/mustangproject/TradeTax.java
+++ b/library/src/main/java/org/mustangproject/TradeTax.java
@@ -1,4 +1,4 @@
-package org.mustangproject;
+	package org.mustangproject;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -161,8 +161,8 @@ public class TradeTax implements IZUGFeRDTradeTax {
 	 */
 	@Override
 	public String getTaxCategoryCode() {
-		if(taxCategoryCode != null){
-		    return taxCategoryCode;
+		if (taxCategoryCode != null) {
+			return taxCategoryCode;
 		}
 		return IZUGFeRDTradeTax.super.getTaxCategoryCode();
 	}

--- a/library/src/main/java/org/mustangproject/XMLTools.java
+++ b/library/src/main/java/org/mustangproject/XMLTools.java
@@ -87,8 +87,7 @@ public class XMLTools extends XMLWriter {
 		return dbf.newDocumentBuilder();
 	}
 
-	public static Validator getValidator(URL schemaFile) throws SAXException
-	{
+	public static Validator getValidator(URL schemaFile) throws SAXException {
 		SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 		try {
 			schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -106,8 +105,7 @@ public class XMLTools extends XMLWriter {
 		return validator;
 	}
 
-	public static TransformerFactory getTransformerFactory()
-	{
+	public static TransformerFactory getTransformerFactory() {
 		TransformerFactory factory = new net.sf.saxon.TransformerFactoryImpl();
 		try {
 			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
@@ -192,11 +190,11 @@ public class XMLTools extends XMLWriter {
 	 * @return value as String with decimals in the specified range
 	 */
 	public static String nDigitFormatDecimalRange(BigDecimal value, int maxDecimals, int minDecimals) {
-		if ((maxDecimals<minDecimals)||(maxDecimals<0)||(minDecimals<0)) {
+		if (maxDecimals < minDecimals || maxDecimals < 0 || minDecimals < 0) {
 			throw new IllegalArgumentException("Invalid scale range provided");
 		}
-		int curDecimals=maxDecimals;
-		while  ( (curDecimals>minDecimals) && (value.setScale(curDecimals, RoundingMode.HALF_UP).compareTo(value.setScale(curDecimals-1, RoundingMode.HALF_UP))==0)) {
+		int curDecimals = maxDecimals;
+		while (curDecimals > minDecimals && value.setScale(curDecimals, RoundingMode.HALF_UP).compareTo(value.setScale(curDecimals - 1, RoundingMode.HALF_UP)) == 0) {
 			 curDecimals--;
 		}
 		return value.setScale(curDecimals, RoundingMode.HALF_UP).toPlainString();
@@ -224,7 +222,7 @@ public class XMLTools extends XMLWriter {
 	 */
 	public static Date tryDate(String toParse) {
 		SimpleDateFormat formatter = null;
-		if (toParse==null) {
+		if (toParse == null) {
 			return null;
 		}
 		if (toParse.contains("-")) {
@@ -302,7 +300,7 @@ public class XMLTools extends XMLWriter {
 	 */
 	public static byte[] removeBOM(byte[] zugferdRaw) {
 		final byte[] zugferdData;
-		// This handles the UTF-8 BOM 
+		// This handles the UTF-8 BOM
 		if ((zugferdRaw[0] == (byte) 0xEF) && (zugferdRaw[1] == (byte) 0xBB) && (zugferdRaw[2] == (byte) 0xBF)) {
 			// I don't like BOMs, lets remove it
 			zugferdData = new byte[zugferdRaw.length - 3];

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/CustomXMLProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/CustomXMLProvider.java
@@ -26,7 +26,7 @@ public class CustomXMLProvider implements IXMLProvider {
 	/***
 	 * the scope=profile this XML data is provided in
 	 */
-	protected Profile profile=Profiles.getByName("EN16931");
+	protected Profile profile = Profiles.getByName("EN16931");
 
 	@Override
 	public byte[] getXML() {
@@ -58,6 +58,6 @@ public class CustomXMLProvider implements IXMLProvider {
 	}
 
 	public void setProfile(Profile level) {
-		profile=level;
+		profile = level;
 	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
@@ -37,9 +37,9 @@ import org.mustangproject.XMLTools;
  */
 public class DAPullProvider extends ZUGFeRD2PullProvider {
 
-	protected IExportableTransaction trans;
-	protected Profile profile = Profiles.getByName(EStandard.despatchadvice,"pilot", 1);
-
+	public DAPullProvider() {
+		profile = Profiles.getByName(EStandard.DELIVER_X, "pilot", 1);
+	}
 
 	@Override
 	public void generateXML(IExportableTransaction trans) {
@@ -50,7 +50,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 			typecode = trans.getDocumentCode();
 		}*/
 
-		String testBooleanStr="true";
+		String testBooleanStr = "true";
 		StringBuilder xml = new StringBuilder("<SCRDMCCBDACIDAMessageStructure\n" +
 				"        xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:25\"\n" +
 				"        xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:101\"\n" +
@@ -60,7 +60,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 				// ../Schema/ZUGFeRD1p0.xsd\""
 				+ "<px:ExchangedDocumentContext>"
 				// + "
-				+" <ram:TestIndicator><udt:Indicator>"+testBooleanStr+"</udt:Indicator></ram:TestIndicator>\n"
+				+ "<ram:TestIndicator><udt:Indicator>" + testBooleanStr + "</udt:Indicator></ram:TestIndicator>\n"
 				//
 				+ "<ram:BusinessProcessSpecifiedDocumentContextParameter>"
 				+ "<ram:ID>" + getProfile().getID() + "</ram:ID>"
@@ -87,7 +87,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 			xml.append("<ram:IncludedSupplyChainTradeLineItem>" +
 					"<ram:AssociatedDocumentLineDocument>"
 					+ "<ram:LineID>" + lineID + "</ram:LineID>"
-          + buildItemNotes(currentItem)
+					+ buildItemNotes(currentItem)
 					+ "</ram:AssociatedDocumentLineDocument>"
 
 					+ "<ram:SpecifiedTradeProduct>");
@@ -129,7 +129,6 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 					+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
 					+ "</ram:Description>"
 					+ "</ram:SpecifiedTradeProduct>"
-
 					+ "<ram:SpecifiedLineTradeDelivery>"
 					+ "<ram:DespatchedQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
 					+ quantityFormat(currentItem.getQuantity()) + "</ram:DespatchedQuantity>"
@@ -227,7 +226,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 		xml.append(" <ram:ActualDespatchSupplyChainEvent>\n" +
 				"                <ram:OccurrenceDateTime>\n" +
 				"                    <udt:DateTimeString\n" +
-				"                            format=\"102\">"+ DATE.udtFormat(trans.getDeliveryDate() )+"</udt:DateTimeString>\n" +
+				"                            format=\"102\">" + DATE.udtFormat(trans.getDeliveryDate() ) + "</udt:DateTimeString>\n" +
 				"                </ram:OccurrenceDateTime>\n" +
 				"            </ram:ActualDespatchSupplyChainEvent>");
 
@@ -285,7 +284,7 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
     Invoice copyWithoutRebateInfo = new Invoice()
         .setOwnOrganisationFullPlaintextInfo(exportableTransaction.getOwnOrganisationFullPlaintextInfo())
         .addNotes(exportableTransaction.getNotesWithSubjectCode());
-    if(exportableTransaction.getNotes() != null) {
+    if (exportableTransaction.getNotes() != null) {
       for (String note : exportableTransaction.getNotes()) {
         copyWithoutRebateInfo.addNote(note);
       }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA1.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA1.java
@@ -30,10 +30,14 @@ import org.apache.pdfbox.preflight.parser.PreflightParser;
 import jakarta.activation.DataSource;
 
 public class DXExporterFromA1 extends DXExporterFromA3 {
-	protected boolean ignorePDFAErrors = false;
+
+	public DXExporterFromA1() {
+		setZUGFeRDVersion(ZUGFeRDExporterFromA3.defaultZUGFeRDVersion);
+
+	}
 
 	@Override
-  public DXExporterFromA1 ignorePDFAErrors() {
+	public DXExporterFromA1 ignorePDFAErrors() {
 		this.ignorePDFAErrors = true;
 		return this;
 	}
@@ -49,7 +53,7 @@ public class DXExporterFromA1 extends DXExporterFromA3 {
 		 * PDF/A requirements. (Stream length consistency, EOL after some Keyword...)
 		 */
 		// might add a Format.PDF_A1A as parameter and iterate through A1 and A3
-		
+
 		try (PreflightDocument document = (PreflightDocument) parser.parse()) {
 			/*
 			 * Once the syntax validation is done, the parser can provide a
@@ -73,63 +77,58 @@ public class DXExporterFromA1 extends DXExporterFromA3 {
 
 
 	@Override
-  public DXExporterFromA1 setProfile(Profile p) {
-		return (DXExporterFromA1)super.setProfile(p);
+	public DXExporterFromA1 setProfile(Profile p) {
+		return (DXExporterFromA1) super.setProfile(p);
 	}
 	@Override
-  public DXExporterFromA1 setProfile(String profileName) {
-		return (DXExporterFromA1)super.setProfile(profileName);
+	public DXExporterFromA1 setProfile(String profileName) {
+		return (DXExporterFromA1) super.setProfile(profileName);
 	}
 
 	@Override
-  public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
+	public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
 		if (!ignorePDFAErrors && !isValidA1(dataSource)) {
 			throw new IOException("File is not a valid PDF/A input file");
 		}
 		return true;
 	}
 
-	public DXExporterFromA1() {
-		setZUGFeRDVersion(ZUGFeRDExporterFromA3.DefaultZUGFeRDVersion);
-
-	}
-
 	@Override
-  public DXExporterFromA1 load(String pdfFilename) throws IOException {
+	public DXExporterFromA1 load(String pdfFilename) throws IOException {
 		return (DXExporterFromA1) super.load(pdfFilename);
 	}
 	@Override
-  public DXExporterFromA1 load(byte[] pdfBinary) throws IOException {
+	public DXExporterFromA1 load(byte[] pdfBinary) throws IOException {
 		return (DXExporterFromA1) super.load(pdfBinary);
 	}
 	@Override
-  public DXExporterFromA1 load(InputStream pdfSource) throws IOException{
+	public DXExporterFromA1 load(InputStream pdfSource) throws IOException {
 		return (DXExporterFromA1) super.load(pdfSource);
 	}
 	@Override
-  public DXExporterFromA1 setCreator(String creator) {
+	public DXExporterFromA1 setCreator(String creator) {
 		return (DXExporterFromA1) super.setCreator(creator);
 	}
 	@Override
-  public DXExporterFromA1 setConformanceLevel(PDFAConformanceLevel newLevel) {
+	public DXExporterFromA1 setConformanceLevel(PDFAConformanceLevel newLevel) {
 		return (DXExporterFromA1) super.setConformanceLevel(newLevel);
 	}
 
 	@Override
-  public DXExporterFromA1 setProducer(String producer){
+	public DXExporterFromA1 setProducer(String producer) {
 		return (DXExporterFromA1) super.setProducer(producer);
 	}
 	@Override
-  public DXExporterFromA1 setZUGFeRDVersion(int version){
+	public DXExporterFromA1 setZUGFeRDVersion(int version) {
 		return (DXExporterFromA1) super.setZUGFeRDVersion(version);
 	}
 	@Override
-  public DXExporterFromA1 setXML(byte[] zugferdData) throws IOException{
+	public DXExporterFromA1 setXML(byte[] zugferdData) throws IOException {
 		return (DXExporterFromA1) super.setXML(zugferdData);
 	}
 
 	@Override
-  public DXExporterFromA1 disableAutoClose(boolean disableAutoClose){
+	public DXExporterFromA1 disableAutoClose(boolean disableAutoClose) {
 		return (DXExporterFromA1) super.disableAutoClose(disableAutoClose);
 	}
 	public DXExporterFromA1 convertOnly() {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA3.java
@@ -26,7 +26,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -72,56 +71,7 @@ import jakarta.activation.FileDataSource;
 
 public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 
-	protected PDFAConformanceLevel conformanceLevel = PDFAConformanceLevel.UNICODE;
-	protected boolean compressionEnabled = false;
-	protected ArrayList<FileAttachment> fileAttachments = new ArrayList<>();
-
-	/**
-	 * This flag controls whether or not the metadata is overwritten, or kind of merged.
-	 * The merging probably needs to be overhauled, but for my purpose it was good enough.
-	 */
-	protected boolean overwrite = true;
-
-	private boolean disableAutoClose;
-	private boolean fileAttached = false;
-	private Profile profile = null;
-	private boolean documentPrepared = false;
-
-	/**
-	 * Data (XML invoice) to be added to the ZUGFeRD PDF. It may be externally set,
-	 * in which case passing a IZUGFeRDExportableTransaction is not necessary. By
-	 * default it is null meaning the caller needs to pass a
-	 * IZUGFeRDExportableTransaction for the XML to be populated.
-	 */
-	protected PDMetadata metadata = null;
-	/**
-	 * Producer attribute for PDF
-	 */
-	protected String producer = "mustangproject";
-	/**
-	 * Author/Creator attribute for PDF
-	 */
-	protected String creator = "mustangproject";
-	/**
-	 * CreatorTool
-	 */
-	protected String creatorTool = "mustangproject";
-
-	/**
-	 * @deprecated author is never set yet
-	 */
-	@Deprecated
-	protected String author;
-	/**
-	 * @deprecated title is never set yet
-	 */
-	@Deprecated
-	protected String title;
-	/**
-	 * @deprecated subject is never set yet
-	 */
-	@Deprecated
-	protected String subject;
+	protected boolean compressionEnabled;
 
 	/**
 	 * OrderX document type. As of version 1.0 it may be
@@ -129,8 +79,15 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 */
 	protected String despatchAdviceDocumentType = "DESPATCHADVICE";
 
+	private boolean disableAutoClose;
+	private boolean fileAttached;
+	private Profile profile;
 
 	private boolean attachZUGFeRDHeaders = true;
+
+	public DXExporterFromA3() {
+		super();
+	}
 
 	/***
 	 * internal helper function: get namespace for order-x
@@ -162,7 +119,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param pdfFilename filename of an PDF/A1 compliant document
 	 */
 	@Override
-  public DXExporterFromA3 load(String pdfFilename) throws IOException {
+	public DXExporterFromA3 load(String pdfFilename) throws IOException {
 
 		ensurePDFIsValid(new FileDataSource(pdfFilename));
 		try (FileInputStream pdf = new FileInputStream(pdfFilename)) {
@@ -171,12 +128,12 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  public IXMLProvider getProvider() {
+	public IXMLProvider getProvider() {
 		return xmlProvider;
 	}
 
 	@Override
-  public DXExporterFromA3 setProfile(Profile p) {
+	public DXExporterFromA3 setProfile(Profile p) {
 		this.profile = p;
 		if (xmlProvider != null) {
 			xmlProvider.setProfile(p);
@@ -185,7 +142,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  public DXExporterFromA3 setProfile(String profilename) {
+	public DXExporterFromA3 setProfile(String profilename) {
 		this.profile = Profiles.getByName(profilename);
 
 		if (xmlProvider != null) {
@@ -195,7 +152,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  public DXExporterFromA3 addAdditionalFile(String name, byte[] content) {
+	public DXExporterFromA3 addAdditionalFile(String name, byte[] content) {
 		fileAttachments.add(new FileAttachment(name, "text/xml", "Supplement", content).setDescription("ZUGFeRD extension/additional data"));
 		return this;
 	}
@@ -209,23 +166,19 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param pdfBinary binary of a PDF/A1 compliant document
 	 */
 	@Override
-  public DXExporterFromA3 load(byte[] pdfBinary) throws IOException {
+	public DXExporterFromA3 load(byte[] pdfBinary) throws IOException {
 		ensurePDFIsValid(new ByteArrayDataSource(new ByteArrayInputStream(pdfBinary)));
 		doc = Loader.loadPDF(pdfBinary);
 		return this;
 	}
 
-	public DXExporterFromA3() {
-		super();
-	}
-
 	@Override
-  public void attachFile(FileAttachment file) {
+	public void attachFile(FileAttachment file) {
 		fileAttachments.add(file);
 	}
 
 	@Override
-  public void attachFile(String filename, byte[] data, String mimetype, String relation) {
+	public void attachFile(String filename, byte[] data, String mimetype, String relation) {
 		FileAttachment fa = new FileAttachment(filename, mimetype, relation, data);
 		fileAttachments.add(fa);
 	}
@@ -236,7 +189,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong in the target location
 	 */
 	@Override
-  public void export(String ZUGFeRDfilename) throws IOException {
+	public void export(String ZUGFeRDfilename) throws IOException {
 		if (!documentPrepared) {
 			prepareDocument();
 		}
@@ -264,7 +217,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong in the OutputStream
 	 */
 	@Override
-  public void export(OutputStream output) throws IOException {
+	public void export(OutputStream output) throws IOException {
 		if (!documentPrepared) {
 			prepareDocument();
 		}
@@ -291,7 +244,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong with filename
 	 */
 	@Override
-  public void PDFAttachGenericFile(String filename, String relationship, String description,
+	public void PDFAttachGenericFile(String filename, String relationship, String description,
 									 String subType, byte[] data) throws IOException {
 		PDFAttachGenericFile(this.doc, filename, relationship, description, subType, data);
 	}
@@ -309,7 +262,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong with filename
 	 */
 	@Override
-  public void PDFAttachGenericFile(PDDocument doc, String filename, String relationship, String description,
+	public void PDFAttachGenericFile(PDDocument doc, String filename, String relationship, String description,
 									 String subType, byte[] data) throws IOException {
 		fileAttached = true;
 
@@ -349,9 +302,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 
 		Map<String, PDComplexFileSpecification> oldNamesMap = efTree.getNames();
 		if (oldNamesMap != null) {
-			for (String key : oldNamesMap.keySet()) {
-				namesMap.put(key, oldNamesMap.get(key));
-			}
+			namesMap.putAll(oldNamesMap);
 		}
 		namesMap.put(filename, fs);
 		efTree.setNames(namesMap);
@@ -387,13 +338,13 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException (should not happen)
 	 */
 	@Override
-  public DXExporterFromA3 setXML(byte[] zugferdData) throws IOException {
+	public DXExporterFromA3 setXML(byte[] zugferdData) throws IOException {
 		CustomXMLProvider cus = new CustomXMLProvider();
 		// As of late 2022 the Delivery-X standard is not yet published. See specification:
 		// Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022
 		// Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
 		// http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html
-		cus.setProfile(Profiles.getByName(EStandard.despatchadvice, "PILOT", 1));
+		cus.setProfile(Profiles.getByName(EStandard.DELIVER_X, "PILOT", 1));
 
 		cus.setXML(zugferdData);
 		this.setXMLProvider(cus);
@@ -409,12 +360,12 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param pdfSource source to read a PDF/A1 compliant document from
 	 */
 	@Override
-  public DXExporterFromA3 load(InputStream pdfSource) throws IOException {
+	public DXExporterFromA3 load(InputStream pdfSource) throws IOException {
 		return load(readAllBytes(pdfSource));
 	}
 
 	@Override
-  public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
+	public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
 		return true;
 	}
 
@@ -438,25 +389,25 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Feel free to pass "A" as new level if you know what you are doing :-)
 	 */
 	@Override
-  public DXExporterFromA3 setConformanceLevel(PDFAConformanceLevel newLevel) {
+	public DXExporterFromA3 setConformanceLevel(PDFAConformanceLevel newLevel) {
 		conformanceLevel = newLevel;
 		return this;
 	}
 
 	@Override
-  public DXExporterFromA3 setCreator(String creator) {
+	public DXExporterFromA3 setCreator(String creator) {
 		this.creator = creator;
 		return this;
 	}
 
 	@Override
-  public DXExporterFromA3 setCreatorTool(String creatorTool) {
+	public DXExporterFromA3 setCreatorTool(String creatorTool) {
 		this.creatorTool = creatorTool;
 		return this;
 	}
 
 	@Override
-  public DXExporterFromA3 setProducer(String producer) {
+	public DXExporterFromA3 setProducer(String producer) {
 		this.producer = producer;
 		return this;
 	}
@@ -468,15 +419,13 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 *
 	 * @return this exporter
 	 */
-	public DXExporterFromA3 setDocumentType(String DocumentType)
-	{
+	public DXExporterFromA3 setDocumentType(String DocumentType) {
 		this.despatchAdviceDocumentType = DocumentType;
-
 		return this;
 	}
 
 	@Override
-  protected DXExporterFromA3 setAttachZUGFeRDHeaders(boolean attachHeaders) {
+	protected DXExporterFromA3 setAttachZUGFeRDHeaders(boolean attachHeaders) {
 		this.attachZUGFeRDHeaders = attachHeaders;
 		return this;
 	}
@@ -490,7 +439,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param metadata the PDFbox XMPMetadata object
 	 */
 	@Override
-  protected void addXMP(XMPMetadata metadata) {
+	protected void addXMP(XMPMetadata metadata) {
 
 		if (attachZUGFeRDHeaders) {
 			// As of late 2022 the Delivery-X standard is not yet published. See specification:
@@ -504,7 +453,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 
 			metadata.addSchema(zf);
 			// also add the schema extensions...
-			XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, 1, attachZUGFeRDHeaders, EStandard.despatchadvice);
+			XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, 1, attachZUGFeRDHeaders, EStandard.DELIVER_X);
 			pdfaex.setZUGFeRDVersion(1);
 			metadata.addSchema(pdfaex);
 		}
@@ -522,13 +471,13 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong with already loaded PDF
 	 */
 	@Override
-  public IExporter setTransaction(IExportableTransaction trans) throws IOException {
+	public IExporter setTransaction(IExportableTransaction trans) throws IOException {
 		this.trans = trans;
 		return prepare();
 	}
 
 	@Override
-  public IExporter prepare() throws IOException {
+	public IExporter prepare() throws IOException {
 		prepareDocument();
 		xmlProvider.generateXML(trans);
 		String filename = "cida.xml";
@@ -548,7 +497,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Otherwise creates XMPMetadata.
 	 */
 	@Override
-  protected XMPMetadata getXmpMetadata() throws IOException {
+	protected XMPMetadata getXmpMetadata() throws IOException {
 		PDMetadata meta = doc.getDocumentCatalog().getMetadata();
 		if ((meta != null) && (meta.getLength() > 0)) {
 			try {
@@ -562,7 +511,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  protected byte[] serializeXmpMetadata(XMPMetadata xmpMetadata) throws TransformerException {
+	protected byte[] serializeXmpMetadata(XMPMetadata xmpMetadata) throws TransformerException {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		new XmpSerializer().serialize(xmpMetadata, buffer, true); // see https://github.com/ZUGFeRD/mustangproject/issues/44
 		return buffer.toByteArray();
@@ -573,10 +522,11 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Sets the PDFVersion to 1.4 if the field is empty.
 	 */
 	@Override
-  protected void writeAdobePDFSchema(XMPMetadata xmp) {
+	protected void writeAdobePDFSchema(XMPMetadata xmp) {
 		AdobePDFSchema pdf = getAdobePDFSchema(xmp);
-		if (overwrite || isBlank(pdf.getProducer()))
+		if (overwrite || isBlank(pdf.getProducer())) {
 			pdf.setProducer(producer);
+		}
 	}
 
 	/**
@@ -584,18 +534,20 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * If the overwrite flag is set or no AdobePDFSchema exists in the XMPMetadata, it is created, added and returned.
 	 */
 	@Override
-  protected AdobePDFSchema getAdobePDFSchema(XMPMetadata xmp) {
+	protected AdobePDFSchema getAdobePDFSchema(XMPMetadata xmp) {
 		AdobePDFSchema pdf = xmp.getAdobePDFSchema();
-		if (pdf != null)
-			if (overwrite)
+		if (pdf != null) {
+			if (overwrite) {
 				xmp.removeSchema(pdf);
-			else
+			} else {
 				return pdf;
+			}
+		}
 		return xmp.createAndAddAdobePDFSchema();
 	}
 
 	@Override
-  protected void writePDFAIdentificationSchema(XMPMetadata xmp) {
+	protected void writePDFAIdentificationSchema(XMPMetadata xmp) {
 		PDFAIdentificationSchema pdfaid = getPDFAIdentificationSchema(xmp);
 		if (overwrite || isBlank(pdfaid.getConformance())) {
 			try {
@@ -611,25 +563,30 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  protected PDFAIdentificationSchema getPDFAIdentificationSchema(XMPMetadata xmp) {
+	protected PDFAIdentificationSchema getPDFAIdentificationSchema(XMPMetadata xmp) {
 		PDFAIdentificationSchema pdfaid = xmp.getPDFAIdentificationSchema();
-		if (pdfaid != null)
-			if (overwrite)
+		if (pdfaid != null) {
+			if (overwrite) {
 				xmp.removeSchema(pdfaid);
-			else
+			} else {
 				return pdfaid;
+			}
+		}
 		return xmp.createAndAddPDFAIdentificationSchema();
 	}
 
 	@Override
-  protected void writeDublinCoreSchema(XMPMetadata xmp) {
+	protected void writeDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = getDublinCoreSchema(xmp);
-		if (dc.getFormat() == null)
+		if (dc.getFormat() == null) {
 			dc.setFormat("application/pdf");
-		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null)
+		}
+		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null) {
 			dc.addCreator(creator);
-		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null)
+		}
+		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null) {
 			dc.addDate(Calendar.getInstance());
+		}
 
 		ArrayProperty titleProperty = dc.getTitleProperty();
 		if (titleProperty != null) {
@@ -646,68 +603,80 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
+	protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = xmp.getDublinCoreSchema();
-		if (dc != null)
-			if (overwrite)
+		if (dc != null) {
+			if (overwrite) {
 				xmp.removeSchema(dc);
-			else
+			} else {
 				return dc;
+			}
+		}
 		return xmp.createAndAddDublinCoreSchema();
 	}
 
 	@Override
-  protected void writeXMLBasicSchema(XMPMetadata xmp) {
+	protected void writeXMLBasicSchema(XMPMetadata xmp) {
 		XMPBasicSchema xsb = getXmpBasicSchema(xmp);
-		if (overwrite || isBlank(xsb.getCreatorTool()) || "UnknownApplication".equals(xsb.getCreatorTool()))
+		if (overwrite || isBlank(xsb.getCreatorTool()) || "UnknownApplication".equals(xsb.getCreatorTool())) {
 			xsb.setCreatorTool(creatorTool);
-		if (overwrite || xsb.getCreateDate() == null)
+		}
+		if (overwrite || xsb.getCreateDate() == null) {
 			xsb.setCreateDate(Calendar.getInstance());
+		}
 	}
 
 	@Override
-  protected XMPBasicSchema getXmpBasicSchema(XMPMetadata xmp) {
+	protected XMPBasicSchema getXmpBasicSchema(XMPMetadata xmp) {
 		XMPBasicSchema xsb = xmp.getXMPBasicSchema();
-		if (xsb != null)
-			if (overwrite)
+		if (xsb != null) {
+			if (overwrite) {
 				xmp.removeSchema(xsb);
-			else
+			} else {
 				return xsb;
+			}
+		}
 		return xmp.createAndAddXMPBasicSchema();
 	}
 
 	// TODO this method does the same as the inherited one - deletion possible
 	@Override
-  protected void writeDocumentInformation() {
+	protected void writeDocumentInformation() {
 		String fullProducer = producer + " (via mustangproject.org " + Version.VERSION + ")";
 		PDDocumentInformation info = doc.getDocumentInformation();
-		if (overwrite || info.getCreationDate() == null)
+		if (overwrite || info.getCreationDate() == null) {
 			info.setCreationDate(Calendar.getInstance());
-		if (overwrite || info.getModificationDate() == null)
+		}
+		if (overwrite || info.getModificationDate() == null) {
 			info.setModificationDate(Calendar.getInstance());
-		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author)))
+		}
+		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author))) {
 			info.setAuthor(author);
-		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer)))
+		}
+		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer))) {
 			info.setProducer(fullProducer);
-		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator)))
+		}
+		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator))) {
 			info.setCreator(creator);
-		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title)))
+		}
+		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title))) {
 			info.setTitle(title);
-		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject)))
+		}
+		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject))) {
 			info.setSubject(subject);
+		}
 	}
 
 	/**
 	 * Adds an OutputIntent and the sRGB color profile if no OutputIntent exist
 	 */
 	@Override
-  protected void addSRGBOutputIntend() throws IOException {
+	protected void addSRGBOutputIntend() throws IOException {
 		if (!doc.getDocumentCatalog().getOutputIntents().isEmpty()) {
 			return;
 		}
 
-		try {
-			InputStream colorProfile = Thread.currentThread().getContextClassLoader().getResourceAsStream("sRGB.icc");
+		try (InputStream colorProfile = Thread.currentThread().getContextClassLoader().getResourceAsStream("sRGB.icc")) {
 			if (colorProfile != null) {
 				PDOutputIntent intent = new PDOutputIntent(doc, colorProfile);
 				intent.setInfo("sRGB IEC61966-2.1");
@@ -725,7 +694,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Adds a MarkInfo element to the PDF if it doesn't already exist and sets it as marked.
 	 */
 	@Override
-  protected void setMarked() {
+	protected void setMarked() {
 		PDDocumentCatalog catalog = doc.getDocumentCatalog();
 		if (catalog.getMarkInfo() == null) {
 			catalog.setMarkInfo(new PDMarkInfo(doc.getPages().getCOSObject()));
@@ -737,7 +706,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Adds a StructureTreeRoot element to the PDF if it doesn't already exist.
 	 */
 	@Override
-  protected void addStructureTreeRoot() {
+	protected void addStructureTreeRoot() {
 		if (doc.getDocumentCatalog().getStructureTreeRoot() == null) {
 			doc.getDocumentCatalog().setStructureTreeRoot(new PDStructureTreeRoot());
 		}
@@ -748,7 +717,7 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @return if pdf file will be automatically closed after adding ZF
 	 */
 	@Override
-  public boolean isAutoCloseDisabled() {
+	public boolean isAutoCloseDisabled() {
 		return disableAutoClose;
 	}
 
@@ -756,13 +725,13 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param disableAutoClose prevent PDF file from being closed after adding ZF
 	 */
 	@Override
-  public DXExporterFromA3 disableAutoClose(boolean disableAutoClose) {
+	public DXExporterFromA3 disableAutoClose(boolean disableAutoClose) {
 		this.disableAutoClose = disableAutoClose;
 		return this;
 	}
 
 	@Override
-  protected void setXMLProvider(IXMLProvider p) {
+	protected void setXMLProvider(IXMLProvider p) {
 		this.xmlProvider = p;
 		if (profile != null) {
 			xmlProvider.setProfile(profile);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/EinLieferscheinExporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/EinLieferscheinExporter.java
@@ -25,18 +25,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class EinLieferscheinExporter implements IExporter  {
+public class EinLieferscheinExporter implements IExporter {
 	IXMLProvider xmlProvider;
 	IExportableTransaction trans;
 
 	public EinLieferscheinExporter() {
-		xmlProvider=new UBLDAPullProvider();
+		xmlProvider = new UBLDAPullProvider();
 	}
 
 
 	@Override
 	public IExporter setTransaction(IExportableTransaction trans) throws IOException {
-		this.trans=trans;
+		this.trans = trans;
 		return this;
 	}
 
@@ -49,7 +49,7 @@ public class EinLieferscheinExporter implements IExporter  {
 	@Override
 	public void export(OutputStream output) throws IOException {
 		xmlProvider.generateXML(trans);
-		byte[] bytes=xmlProvider.getXML();
+		byte[] bytes = xmlProvider.getXML();
 		output.write(bytes, 0, bytes.length);
 	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IAbsoluteValueProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IAbsoluteValueProvider.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 
 public interface IAbsoluteValueProvider {
 
-	public BigDecimal getValue();
+	BigDecimal getValue();
 
 	default BigDecimal getQuantity() {
 		return BigDecimal.ONE;

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IDesignatedProductClassification.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IDesignatedProductClassification.java
@@ -38,5 +38,7 @@ public interface IDesignatedProductClassification {
 	 *
 	 * @return the name or {@code null} if not set
 	 */
-	default String getClassName() { return null; }
+	default String getClassName() {
+		return null;
+	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -30,7 +30,6 @@ package org.mustangproject.ZUGFeRD;
  * */
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -148,7 +147,9 @@ public interface IExportableTransaction {
 		return null;
 	}
 
-	default IZUGFeRDCashDiscount[] getCashDiscounts() {	return null; }
+	default IZUGFeRDCashDiscount[] getCashDiscounts() {
+		return null;
+	}
 
 	/***
 	 * @return the invoice line items with the positions
@@ -472,8 +473,7 @@ public interface IExportableTransaction {
 	}
 
 	/**
-	 * get the ID of the preceding invoice, which is e.g. to be corrected if this is
-	 * a correction
+	 * get the ID of the preceding invoice, which is e.g. to be corrected if this is a correction
 	 *
 	 * @return the ID of the document
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExporter.java
@@ -23,8 +23,8 @@ import java.io.OutputStream;
 
 public interface IExporter {
 
-	public IExporter setTransaction(IExportableTransaction trans) throws IOException;
-	public void export(String ZUGFeRDfilename) throws IOException;
-	public void export(OutputStream output) throws IOException;
+	IExporter setTransaction(IExportableTransaction trans) throws IOException;
+	void export(String ZUGFeRDfilename) throws IOException;
+	void export(OutputStream output) throws IOException;
 
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IReferencedDocument.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IReferencedDocument.java
@@ -20,7 +20,9 @@ public interface IReferencedDocument {
 	 * sets the Name assigned by the sender
 	 * @return String of the Name
 	 */
-	default String getName() { return null; }
+	default String getName() {
+		return null;
+	}
 
 	/***
 	 * type of the reference of this line, a UNTDID 1153 code
@@ -29,7 +31,7 @@ public interface IReferencedDocument {
 	String getReferenceTypeCode();
 
 	/***
-	 * 
+	 *
 	 * issue date of this line
 	 *
 	 * @return date of the issue

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IXMLProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IXMLProvider.java
@@ -20,11 +20,11 @@ package org.mustangproject.ZUGFeRD;
 
 public interface IXMLProvider {
 
-	public byte[] getXML();
+	byte[] getXML();
 
-	public void generateXML(IExportableTransaction trans);
+	void generateXML(IExportableTransaction trans);
 
-	public void setProfile(Profile p);
+	void setProfile(Profile p);
 
-	public Profile getProfile();
+	Profile getProfile();
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -20,7 +20,7 @@ import java.math.BigDecimal;
 /**
  * The interface for allowances or charges, to be used by the pullprovider
  * @author AlexanderSchmidt
- * 
+ *
  * <xs:complexType name="TradeAllowanceChargeType">
  *   <xs:sequence>
  *     <xs:element name="ChargeIndicator" type="udt:IndicatorType"/>
@@ -41,31 +41,39 @@ public interface IZUGFeRDAllowanceCharge extends IZUGFeRDTradeTax {
 	 * is this in reality a charge and now allowance
 	 * @return true if amount to be treated negative
 	 */
-	public boolean isCharge();
+	boolean isCharge();
 
 	/***
 	 * returns the sequence number
 	 * @return	sequence number
 	 */
-	default Integer getSequenceNumeric() {return null;}
+	default Integer getSequenceNumeric() {
+		return null;
+	}
 
 	/***
 	 * returns a percentage, if relative amount, or null for absolute amounts
 	 * @return null or Percentage as BigDecimal
 	 */
-	default BigDecimal getPercent() {return null;}
+	default BigDecimal getPercent() {
+		return null;
+	}
 
 	/***
 	 * returns a basis the percentage is calculated from
 	 * @return null or the basis
 	 */
-	default BigDecimal getBasisAmount() {return null;}
+	default BigDecimal getBasisAmount() {
+		return null;
+	}
 
 	/***
 	 * returns a basis the percentage is calculated from
 	 * @return null or the basis
 	 */
-	default BigDecimal getBasisQuantity() {return null;}
+	default BigDecimal getBasisQuantity() {
+		return null;
+	}
 
 	/***
 	 * returns the absolute amount, even if it was relative in the first place

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDCashDiscount.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDCashDiscount.java
@@ -6,13 +6,13 @@ public interface IZUGFeRDCashDiscount {
 	/***
 	 * @return this particular cash discount as cross industry invoice XML
 	 */
-	public String getAsCII();
+	String getAsCII();
 
 	/***
 	 * since EN16931 voted not to have (or even allow) cash discounts in their core invoice the german
 	 * XRechnung CIUS defined it's own proprietary format for a freetext field
 	 * @return this particular cash discount in proprietary xrechnung format
 	 */
-	public String getAsXRechnung();
+	String getAsXRechnung();
 
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableContact.java
@@ -112,7 +112,7 @@ public interface IZUGFeRDExportableContact {
 
 	/**
 	 * returns additional address information which is display in xml tag "LineTwo"
-	 * 
+	 *
 	 * @return additional address information
 	 */
 	default String getAdditionalAddress() {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
@@ -24,7 +24,7 @@ package org.mustangproject.ZUGFeRD;
  * @date 2014-05-10
  * @version 1.2.0
  * @author jstaerk
- * */
+ **/
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -37,7 +37,7 @@ import org.mustangproject.TradeParty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = Item.class)
-public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
+public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	IZUGFeRDExportableProduct getProduct();
 
 	/**
@@ -45,7 +45,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	 * @return array of the discounts on a single item
 	 */
 	default IZUGFeRDAllowanceCharge[] getItemAllowances() {
-		if (getProduct()!=null) {
+		if (getProduct() != null) {
 			return getProduct().getAllowances();
 		}
 		return null;
@@ -56,7 +56,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	 * @return array of the additional charges on the item
 	 */
 	default IZUGFeRDAllowanceCharge[] getItemCharges() {
-		if (getProduct()!=null) {
+		if (getProduct() != null) {
 			return getProduct().getCharges();
 		}
 		return null;
@@ -159,7 +159,7 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 	 *
 	 * @return the line ID
 	 */
-	default String getId()  {
+	default String getId() {
 		return null;
 	}
 
@@ -211,13 +211,15 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider{
 		return null;
 	}
 
-	default LineCalculator getCalculation() { return new LineCalculator(this); }
+	default LineCalculator getCalculation() {
+		return new LineCalculator(this);
+	}
 
     /***
-	 * For line seller 
+	 * For line seller
 	 * @return the seller
 	 */
-	default  TradeParty getLineSeller() { 
+	default TradeParty getLineSeller() {
 		return null;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportablePostalTradeAddress.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportablePostalTradeAddress.java
@@ -1,11 +1,31 @@
 package org.mustangproject.ZUGFeRD;
 
 public interface IZUGFeRDExportablePostalTradeAddress {
-	default String getPostcodeCode(){return null;}
-	default String getLineOne() {return null;}
-	default String getLineTwo() {return null;}
-	default String getLineThree() {return null;}
-	default String getCityName() {return null;}
-	default String getCountryID() {return null;}
-	default String getCountrySubDivisionName() {return null;}
+	default String getPostcodeCode() {
+		return null;
+	}
+
+	default String getLineOne() {
+		return null;
+	}
+
+	default String getLineTwo() {
+		return null;
+	}
+
+	default String getLineThree() {
+		return null;
+	}
+
+	default String getCityName() {
+		return null;
+	}
+
+	default String getCountryID() {
+		return null;
+	}
+
+	default String getCountrySubDivisionName() {
+		return null;
+	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableProduct.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableProduct.java
@@ -117,14 +117,14 @@ public interface IZUGFeRDExportableProduct {
 
 	default String getTaxCategoryCode() {
 		if (isIntraCommunitySupply()) {
-		    return TaxCategoryCodeTypeConstants.INTRACOMMUNITY;// "K"; // within europe
+		    return TaxCategoryCodeTypeConstants.INTRACOMMUNITY; // "K"; // within europe
 		} else if (isReverseCharge()) {
-		    return TaxCategoryCodeTypeConstants.REVERSECHARGE;// "AE"; // to out of europe...
-		} else if ((getVATPercent()==null)||(getVATPercent().compareTo(BigDecimal.ZERO) == 0)) {
+		    return TaxCategoryCodeTypeConstants.REVERSECHARGE; // "AE"; // to out of europe...
+		} else if (getVATPercent() == null || getVATPercent().compareTo(BigDecimal.ZERO) == 0) {
 		    return TaxCategoryCodeTypeConstants.ZEROTAXPRODUCTS; // "Z"; // zero rated goods
 		} else {
-		    return TaxCategoryCodeTypeConstants.STANDARDRATE;// "S"; // one of the "standard" rates (not
-								     // neccessarily a default rate, even a deducted VAT
+		    return TaxCategoryCodeTypeConstants.STANDARDRATE; // "S"; // one of the "standard" rates (not
+								     // Necessarily a default rate, even a deducted VAT
 								     // is standard calculation)
 		}
 	}
@@ -194,5 +194,7 @@ public interface IZUGFeRDExportableProduct {
 	 *
 	 * @return an array containing the product classifications or {@code null} if not set
 	 */
-	default IDesignatedProductClassification[] getClassifications() { return null; }
+	default IDesignatedProductClassification[] getClassifications() {
+		return null;
+	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTradeParty.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableTradeParty.java
@@ -97,7 +97,7 @@ public interface IZUGFeRDExportableTradeParty {
 	 * @return String the email, or null
 	 */
 	default String getEmail() {
-		if ((getUriUniversalCommunicationIDScheme()!=null)&&(getUriUniversalCommunicationIDScheme().equals("EM"))) {
+		if (getUriUniversalCommunicationIDScheme() != null && getUriUniversalCommunicationIDScheme().equals("EM")) {
 			return getUriUniversalCommunicationID();
 		}
 		return null;
@@ -121,7 +121,9 @@ public interface IZUGFeRDExportableTradeParty {
 	/**
 	 * @return description, e.g. if it's a small company
 	 */
-	default String getDescription() { return null; }
+	default String getDescription() {
+		return null;
+	}
 
 	/**
 	 * Postal code of the recipient

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExporter.java
@@ -25,15 +25,15 @@ import java.io.InputStream;
 import jakarta.activation.DataSource;
 import org.mustangproject.FileAttachment;
 
-public interface IZUGFeRDExporter extends Closeable, IExporter  {
+public interface IZUGFeRDExporter extends Closeable, IExporter {
 	/**
-	 * factory: loads a PDF file and returns an appropriate exporter 
+	 * factory: loads a PDF file and returns an appropriate exporter
 	 *
 	 * @param pdfFilename binary of a PDF/A1 compliant document
 	 * @return the generated exporter
 	 * @throws IOException if anything is wrong with filename
 	 */
-	public IZUGFeRDExporter load(String pdfFilename) throws IOException;
+	IZUGFeRDExporter load(String pdfFilename) throws IOException;
 
 	/**
 	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on the
@@ -43,7 +43,7 @@ public interface IZUGFeRDExporter extends Closeable, IExporter  {
 	 * @return the generated exporter
 	 * @throws IOException (should not happen at all)
 	 */
-	public IZUGFeRDExporter load(byte[] pdfBinary) throws IOException;
+	IZUGFeRDExporter load(byte[] pdfBinary) throws IOException;
 
 	/**
 	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on the
@@ -53,19 +53,19 @@ public interface IZUGFeRDExporter extends Closeable, IExporter  {
 	 * @throws IOException if anything is wrong with inputstream
 	 * @return the generated ZUGFeRDExporter
 	 */
-	public IZUGFeRDExporter load(InputStream pdfSource) throws IOException;
-	public IZUGFeRDExporter setCreator(String creator);
-	public IZUGFeRDExporter setConformanceLevel(PDFAConformanceLevel newLevel);
-	public IZUGFeRDExporter setEnablePDFAttachmentCompression(boolean enablePDFAttachmentCompression);
-	public IZUGFeRDExporter setProducer(String producer);
-	public IZUGFeRDExporter setZUGFeRDVersion(int version);
-	public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException;
-	public IZUGFeRDExporter setXML(byte[] zugferdData) throws IOException;
-	public IZUGFeRDExporter disableFacturX();
-	public IZUGFeRDExporter setProfile(Profile zugferdConformanceLevel);
-	public String getNamespaceForVersion(int ver);
-	public String getPrefixForVersion(int ver) ;
-	public IZUGFeRDExporter disableAutoClose(boolean disableAutoClose);
+	IZUGFeRDExporter load(InputStream pdfSource) throws IOException;
+	IZUGFeRDExporter setCreator(String creator);
+	IZUGFeRDExporter setConformanceLevel(PDFAConformanceLevel newLevel);
+	IZUGFeRDExporter setEnablePDFAttachmentCompression(boolean enablePDFAttachmentCompression);
+	IZUGFeRDExporter setProducer(String producer);
+	IZUGFeRDExporter setZUGFeRDVersion(int version);
+	boolean ensurePDFIsValid(DataSource dataSource) throws IOException;
+	IZUGFeRDExporter setXML(byte[] zugferdData) throws IOException;
+	IZUGFeRDExporter disableFacturX();
+	IZUGFeRDExporter setProfile(Profile zugferdConformanceLevel);
+	String getNamespaceForVersion(int ver);
+	String getPrefixForVersion(int ver) ;
+	IZUGFeRDExporter disableAutoClose(boolean disableAutoClose);
 
 	/***
 	 * attach an additional PDF file attachment for Factur-X attachments
@@ -73,7 +73,8 @@ public interface IZUGFeRDExporter extends Closeable, IExporter  {
 	 * please refer to @see Invoice.embedFileInXML)
 	 * @param file mime type and data
 	 */
-	public void attachFile(FileAttachment file);
+	void attachFile(FileAttachment file);
+
 	/***
 	 * attach an additional PDF file attachment for Factur-X attachments
 	 * (for attached files embedded into XML, within Germany domestically preferred,
@@ -84,7 +85,8 @@ public interface IZUGFeRDExporter extends Closeable, IExporter  {
 	 * @param mimetype the mime type, from the list of allowed mime types
 	 * @param relation the PDF relation
 	 */
-	public void attachFile(String filename, byte[] data, String mimetype, String relation);
-	public IXMLProvider getProvider();
+	void attachFile(String filename, byte[] data, String mimetype, String relation);
+
+	IXMLProvider getProvider();
 
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDLegalOrganisation.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDLegalOrganisation.java
@@ -20,17 +20,17 @@ package org.mustangproject.ZUGFeRD;
 
 import org.mustangproject.SchemedID;
 
-public interface IZUGFeRDLegalOrganisation   {
+public interface IZUGFeRDLegalOrganisation {
 
 	/**
 	 *
 	 * @return the scheme attribute of the legal organization=the type of the identification, e.g. 0002=Siren, and its value
 	 */
-	public SchemedID getSchemedID();
+	SchemedID getSchemedID();
 
 	/***
 	 *
 	 * @return the TradingBusinessName of the legal organisation
 	 */
-	public String getTradingBusinessName();
+	String getTradingBusinessName();
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementDebit.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementDebit.java
@@ -30,7 +30,6 @@ public interface IZUGFeRDTradeSettlementDebit extends IZUGFeRDTradeSettlement {
 				+ "<ram:PayerPartyDebtorFinancialAccount>"
 				+ "<ram:IBANID>" + XMLTools.encodeXML(getIBAN()) + "</ram:IBANID>"
 				+ "</ram:PayerPartyDebtorFinancialAccount>";
-		
 		xml += "</ram:SpecifiedTradeSettlementPaymentMeans>";
 		return xml;
 	}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeSettlementPayment.java
@@ -46,7 +46,6 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 		return null;
 	}
 
-
 	/**
 	 * IBAN of the sender
 	 *
@@ -61,26 +60,32 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 	 *
 	 * @return the name of the account holder (if not identical to sender)
 	 */
-	default String getAccountName() { return null; }
+	default String getAccountName() {
+		return null;
+	}
 
 	/***
 	 * @return payment means code (BT-81 / UNTDID 4461)
 	 */
-	default String getPaymentMeansCode() { return null; }
+	default String getPaymentMeansCode() {
+		return null;
+	}
 
 	/***
 	 * @return payment means description (BT-82) (optional)
 	 */
-	default String getPaymentMeansInformation() { return null; }
+	default String getPaymentMeansInformation() {
+		return null;
+	}
 
 
 	@Override
 	@JsonIgnore
 	default String getSettlementXML(Profile profile) {
 		List<Profile> basicProfiles = Arrays.asList(Profiles.getByName("Basic", 1), Profiles.getByName("BasicWL", 2), Profiles.getByName("Basic", 2));
-		String accountNameStr="";
+		String accountNameStr = "";
 		if (getAccountName() != null) {
-			accountNameStr="<ram:AccountName>" + XMLTools.encodeXML(getAccountName()) + "</ram:AccountName>";
+			accountNameStr = "<ram:AccountName>" + XMLTools.encodeXML(getAccountName()) + "</ram:AccountName>";
 		}
 
 		String xml = "<ram:SpecifiedTradeSettlementPaymentMeans>"
@@ -104,8 +109,8 @@ public interface IZUGFeRDTradeSettlementPayment extends IZUGFeRDTradeSettlement 
 		xml += "</ram:SpecifiedTradeSettlementPaymentMeans>";
 		return xml;
 	}
-	
-	
+
+
 	/* I'd love to implement getPaymentXML() and put <ram:DueDateDateTime> there because this is where it belongs
 	 * unfortunately, the due date is part of the transaction which is not accessible here :-(
 	 */

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeTax.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDTradeTax.java
@@ -45,31 +45,39 @@ public interface IZUGFeRDTradeTax {
 	 * returns the calculated amount
 	 * @return null or the basis
 	 */
-	default BigDecimal getTaxCalculatedAmount() {return null;}
+	default BigDecimal getTaxCalculatedAmount() {
+		return null;
+	}
 
 	/***
 	 * the the reason (text) why this allowance/charge is tax free
 	 * @return the reason text
 	 */
-	public String getTaxExemptionReason();
+	String getTaxExemptionReason();
 
 	/***
 	 * returns a basis the percentage is calculated from
 	 * @return null or the basis
 	 */
-	default BigDecimal getTaxBasisAmount() {return null;}
+	default BigDecimal getTaxBasisAmount() {
+		return null;
+	}
 
 	/***
 	 * returns the line total basis amount
 	 * @return null or the basis
 	 */
-	default BigDecimal getTaxLineTotalBasisAmount() {return null;}
+	default BigDecimal getTaxLineTotalBasisAmount() {
+		return null;
+	}
 
 	/***
 	 * returns the allowance & charge basis amount
 	 * @return null or the basis
 	 */
-	default BigDecimal getTaxAllowanceChargeBasisAmount() {return null;}
+	default BigDecimal getTaxAllowanceChargeBasisAmount() {
+		return null;
+	}
 
 	/***
 	 * the category ID why this has been applied
@@ -83,23 +91,31 @@ public interface IZUGFeRDTradeTax {
 	 * the the reason code why this allowance/charge is tax free
 	 * @return the reason code
 	 */
-	default String getTaxExemptionReasonCode() {return null;}
+	default String getTaxExemptionReasonCode() {
+		return null;
+	}
 
 	/***
-	 * 
+	 *
 	 * @return
 	 */
-	default Date getTaxPointDate() {return null;}
+	default Date getTaxPointDate() {
+		return null;
+	}
 
 	/***
-	 * 
+	 *
 	 * @return
 	 */
-	default String getTaxDueDateTypeCode() {return null;}
+	default String getTaxDueDateTypeCode() {
+		return null;
+	}
 
 	/***
 	 * get the applicable tax percentage for the allowance/charge
 	 * @return the percentage
 	 */
-	default BigDecimal getTaxRateApplicablePercent() {return null;}
+	default BigDecimal getTaxRateApplicablePercent() {
+		return null;
+	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXExporterFromA1.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXExporterFromA1.java
@@ -30,11 +30,66 @@ import org.apache.pdfbox.preflight.parser.PreflightParser;
 import jakarta.activation.DataSource;
 
 public class OXExporterFromA1 extends OXExporterFromA3 {
-	protected boolean ignorePDFAErrors = false;
+
+	public OXExporterFromA1() {
+		setZUGFeRDVersion(ZUGFeRDExporterFromA3.defaultZUGFeRDVersion);
+	}
 
 	@Override
-  public OXExporterFromA1 ignorePDFAErrors() {
+	public OXExporterFromA1 ignorePDFAErrors() {
 		this.ignorePDFAErrors = true;
+		return this;
+	}
+
+	@Override
+	public OXExporterFromA1 setProfile(Profile p) {
+		return (OXExporterFromA1) super.setProfile(p);
+	}
+
+	@Override
+	public OXExporterFromA1 setProfile(String profileName) {
+		return (OXExporterFromA1) super.setProfile(profileName);
+	}
+
+	@Override
+	public OXExporterFromA1 load(String pdfFilename) throws IOException {
+		return (OXExporterFromA1) super.load(pdfFilename);
+	}
+	@Override
+	public OXExporterFromA1 load(byte[] pdfBinary) throws IOException {
+		return (OXExporterFromA1) super.load(pdfBinary);
+	}
+	@Override
+	public OXExporterFromA1 load(InputStream pdfSource) throws IOException {
+		return (OXExporterFromA1) super.load(pdfSource);
+	}
+	@Override
+	public OXExporterFromA1 setCreator(String creator) {
+		return (OXExporterFromA1) super.setCreator(creator);
+	}
+	@Override
+	public OXExporterFromA1 setConformanceLevel(PDFAConformanceLevel newLevel) {
+		return (OXExporterFromA1) super.setConformanceLevel(newLevel);
+	}
+	@Override
+	public OXExporterFromA1 setProducer(String producer) {
+		return (OXExporterFromA1) super.setProducer(producer);
+	}
+	@Override
+	public OXExporterFromA1 setZUGFeRDVersion(int version) {
+		return (OXExporterFromA1) super.setZUGFeRDVersion(version);
+	}
+	@Override
+	public OXExporterFromA1 setXML(byte[] zugferdData) throws IOException {
+		return (OXExporterFromA1) super.setXML(zugferdData);
+	}
+
+	@Override
+	public OXExporterFromA1 disableAutoClose(boolean disableAutoClose) {
+		return (OXExporterFromA1) super.disableAutoClose(disableAutoClose);
+	}
+	public OXExporterFromA1 convertOnly() {
+		setAttachZUGFeRDHeaders(false);
 		return this;
 	}
 
@@ -73,67 +128,10 @@ public class OXExporterFromA1 extends OXExporterFromA3 {
 
 
 	@Override
-  public OXExporterFromA1 setProfile(Profile p) {
-		return (OXExporterFromA1)super.setProfile(p);
-	}
-	@Override
-  public OXExporterFromA1 setProfile(String profileName) {
-		return (OXExporterFromA1)super.setProfile(profileName);
-	}
-
-	@Override
-  public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
+	public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
 		if (!ignorePDFAErrors && !isValidA1(dataSource)) {
 			throw new IOException("File is not a valid PDF/A input file");
 		}
 		return true;
 	}
-
-	public OXExporterFromA1() {
-		setZUGFeRDVersion(ZUGFeRDExporterFromA3.DefaultZUGFeRDVersion);
-
-	}
-
-	@Override
-  public OXExporterFromA1 load(String pdfFilename) throws IOException {
-		return (OXExporterFromA1) super.load(pdfFilename);
-	}
-	@Override
-  public OXExporterFromA1 load(byte[] pdfBinary) throws IOException {
-		return (OXExporterFromA1) super.load(pdfBinary);
-	}
-	@Override
-  public OXExporterFromA1 load(InputStream pdfSource) throws IOException{
-		return (OXExporterFromA1) super.load(pdfSource);
-	}
-	@Override
-  public OXExporterFromA1 setCreator(String creator) {
-		return (OXExporterFromA1) super.setCreator(creator);
-	}
-	@Override
-  public OXExporterFromA1 setConformanceLevel(PDFAConformanceLevel newLevel) {
-		return (OXExporterFromA1) super.setConformanceLevel(newLevel);
-	}
-	@Override
-  public OXExporterFromA1 setProducer(String producer){
-		return (OXExporterFromA1) super.setProducer(producer);
-	}
-	@Override
-  public OXExporterFromA1 setZUGFeRDVersion(int version){
-		return (OXExporterFromA1) super.setZUGFeRDVersion(version);
-	}
-	@Override
-  public OXExporterFromA1 setXML(byte[] zugferdData) throws IOException{
-		return (OXExporterFromA1) super.setXML(zugferdData);
-	}
-
-	@Override
-  public OXExporterFromA1 disableAutoClose(boolean disableAutoClose){
-		return (OXExporterFromA1) super.disableAutoClose(disableAutoClose);
-	}
-	public OXExporterFromA1 convertOnly() {
-		setAttachZUGFeRDHeaders(false);
-		return this;
-	}
-
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXExporterFromA3.java
@@ -26,7 +26,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -72,63 +71,24 @@ import jakarta.activation.FileDataSource;
 
 public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 
-	protected PDFAConformanceLevel conformanceLevel = PDFAConformanceLevel.UNICODE;
-	protected ArrayList<FileAttachment> fileAttachments = new ArrayList<>();
-
-	/**
-	 * This flag controls whether or not the metadata is overwritten, or kind of merged.
-	 * The merging probably needs to be overhauled, but for my purpose it was good enough.
-	 */
-	protected boolean overwrite = true;
+	protected String orderXDocumentType = "ORDER";
 
 	private boolean disableAutoClose;
-	private boolean fileAttached = false;
-	private Profile profile = null;
-	private boolean documentPrepared = false;
+	private boolean fileAttached;
+	private Profile profile;
 
-	/**
-	 * Data (XML invoice) to be added to the ZUGFeRD PDF. It may be externally set,
-	 * in which case passing a IZUGFeRDExportableTransaction is not necessary. By
-	 * default it is null meaning the caller needs to pass a
-	 * IZUGFeRDExportableTransaction for the XML to be populated.
-	 */
-	protected PDMetadata metadata = null;
-	/**
-	 * Producer attribute for PDF
-	 */
-	protected String producer = "mustangproject";
-	/**
-	 * Author/Creator attribute for PDF
-	 */
-	protected String creator = "mustangproject";
-	/**
-	 * CreatorTool
-	 */
-	protected String creatorTool = "mustangproject";
-
-	/**
-	 * @deprecated author is never set yet
-	 */
-	@Deprecated
-	protected String author;
-	/**
-	 * @deprecated title is never set yet
-	 */
-	@Deprecated
-	protected String title;
-	/**
-	 * @deprecated subject is never set yet
-	 */
-	@Deprecated
-	protected String subject;
+	/** Defines whether attachments to the PDF should be using FLATE compression */
+	private boolean compressionEnabled;
 
 	/**
 	 * OrderX document type. As of version 1.0 it may be
 	 * ORDER, ORDER_RESPONSE, or ORDER_CHANGE
 	 */
-	protected String orderXDocumentType = "ORDER";
-
 	private boolean attachZUGFeRDHeaders = true;
+
+	public OXExporterFromA3() {
+		super();
+	}
 
 	/***
 	 * internal helper function: get namespace for order-x
@@ -149,9 +109,6 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 		return "fx";
 	}
 
-	/** Defines whether attachments to the PDF should be using FLATE compression */
-	private boolean compressionEnabled = false;
-
 	/**
 	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on the
 	 * metadata level, this will not e.g. convert graphics to JPG-2000)
@@ -159,7 +116,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param pdfFilename filename of an PDF/A1 compliant document
 	 */
 	@Override
-  public OXExporterFromA3 load(String pdfFilename) throws IOException {
+	public OXExporterFromA3 load(String pdfFilename) throws IOException {
 
 		ensurePDFIsValid(new FileDataSource(pdfFilename));
 		try (FileInputStream pdf = new FileInputStream(pdfFilename)) {
@@ -168,12 +125,12 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  public IXMLProvider getProvider() {
+	public IXMLProvider getProvider() {
 		return xmlProvider;
 	}
 
 	@Override
-  public OXExporterFromA3 setProfile(Profile p) {
+	public OXExporterFromA3 setProfile(Profile p) {
 		this.profile = p;
 		if (xmlProvider != null) {
 			xmlProvider.setProfile(p);
@@ -182,7 +139,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  public OXExporterFromA3 setProfile(String profilename) {
+	public OXExporterFromA3 setProfile(String profilename) {
 		this.profile = Profiles.getByName(profilename);
 
 		if (xmlProvider != null) {
@@ -192,12 +149,10 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  public OXExporterFromA3 addAdditionalFile(String name, byte[] content) {
+	public OXExporterFromA3 addAdditionalFile(String name, byte[] content) {
 		fileAttachments.add(new FileAttachment(name, "text/xml", "Supplement", content).setDescription("ZUGFeRD extension/additional data"));
 		return this;
 	}
-
-
 
 	/**
 	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on the
@@ -206,23 +161,19 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param pdfBinary binary of a PDF/A1 compliant document
 	 */
 	@Override
-  public OXExporterFromA3 load(byte[] pdfBinary) throws IOException {
+	public OXExporterFromA3 load(byte[] pdfBinary) throws IOException {
 		ensurePDFIsValid(new ByteArrayDataSource(new ByteArrayInputStream(pdfBinary)));
 		doc = Loader.loadPDF(pdfBinary);
 		return this;
 	}
 
-	public OXExporterFromA3() {
-		super();
-	}
-
 	@Override
-  public void attachFile(FileAttachment file) {
+	public void attachFile(FileAttachment file) {
 		fileAttachments.add(file);
 	}
 
 	@Override
-  public void attachFile(String filename, byte[] data, String mimetype, String relation) {
+	public void attachFile(String filename, byte[] data, String mimetype, String relation) {
 		FileAttachment fa = new FileAttachment(filename, mimetype, relation, data);
 		fileAttachments.add(fa);
 	}
@@ -233,7 +184,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong in the target location
 	 */
 	@Override
-  public void export(String ZUGFeRDfilename) throws IOException {
+	public void export(String ZUGFeRDfilename) throws IOException {
 		if (!documentPrepared) {
 			prepareDocument();
 		}
@@ -261,7 +212,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong in the OutputStream
 	 */
 	@Override
-  public void export(OutputStream output) throws IOException {
+	public void export(OutputStream output) throws IOException {
 		if (!documentPrepared) {
 			prepareDocument();
 		}
@@ -288,7 +239,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws java.io.IOException if anything is wrong with filename
 	 */
 	@Override
-  public void PDFAttachGenericFile(String filename, String relationship, String description,
+	public void PDFAttachGenericFile(String filename, String relationship, String description,
 									 String subType, byte[] data) throws IOException {
 		PDFAttachGenericFile(this.doc, filename, relationship, description, subType, data);
 	}
@@ -306,7 +257,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong with filename
 	 */
 	@Override
-  public void PDFAttachGenericFile(PDDocument doc, String filename, String relationship, String description,
+	public void PDFAttachGenericFile(PDDocument doc, String filename, String relationship, String description,
 									 String subType, byte[] data) throws IOException {
 		fileAttached = true;
 
@@ -346,9 +297,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 
 		Map<String, PDComplexFileSpecification> oldNamesMap = efTree.getNames();
 		if (oldNamesMap != null) {
-			for (String key : oldNamesMap.keySet()) {
-				namesMap.put(key, oldNamesMap.get(key));
-			}
+			namesMap.putAll(oldNamesMap);
 		}
 		namesMap.put(filename, fs);
 		efTree.setNames(namesMap);
@@ -384,7 +333,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException (should not happen)
 	 */
 	@Override
-  public OXExporterFromA3 setXML(byte[] zugferdData) throws IOException {
+	public OXExporterFromA3 setXML(byte[] zugferdData) throws IOException {
 		CustomXMLProvider cus = new CustomXMLProvider();
 		cus.setXML(zugferdData);
 		this.setXMLProvider(cus);
@@ -400,12 +349,12 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param pdfSource source to read a PDF/A1 compliant document from
 	 */
 	@Override
-  public OXExporterFromA3 load(InputStream pdfSource) throws IOException {
+	public OXExporterFromA3 load(InputStream pdfSource) throws IOException {
 		return load(readAllBytes(pdfSource));
 	}
 
 	@Override
-  public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
+	public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
 		return true;
 	}
 
@@ -429,26 +378,26 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Feel free to pass "A" as new level if you know what you are doing :-)
 	 */
 	@Override
-  public OXExporterFromA3 setConformanceLevel(PDFAConformanceLevel newLevel) {
+	public OXExporterFromA3 setConformanceLevel(PDFAConformanceLevel newLevel) {
 		conformanceLevel = newLevel;
 		return this;
 	}
 
 
 	@Override
-  public OXExporterFromA3 setCreator(String creator) {
+	public OXExporterFromA3 setCreator(String creator) {
 		this.creator = creator;
 		return this;
 	}
 
 	@Override
-  public OXExporterFromA3 setCreatorTool(String creatorTool) {
+	public OXExporterFromA3 setCreatorTool(String creatorTool) {
 		this.creatorTool = creatorTool;
 		return this;
 	}
 
 	@Override
-  public OXExporterFromA3 setProducer(String producer) {
+	public OXExporterFromA3 setProducer(String producer) {
 		this.producer = producer;
 		return this;
 	}
@@ -460,15 +409,14 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 *
 	 * @return this exporter
 	 */
-	public OXExporterFromA3 setOrderXDocumentType(String orderXDocumentType)
-	{
+	public OXExporterFromA3 setOrderXDocumentType(String orderXDocumentType) {
 		this.orderXDocumentType = orderXDocumentType;
 
 		return this;
 	}
 
 	@Override
-  protected OXExporterFromA3 setAttachZUGFeRDHeaders(boolean attachHeaders) {
+	protected OXExporterFromA3 setAttachZUGFeRDHeaders(boolean attachHeaders) {
 		this.attachZUGFeRDHeaders = attachHeaders;
 		return this;
 	}
@@ -482,7 +430,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param metadata the PDFbox XMPMetadata object
 	 */
 	@Override
-  protected void addXMP(XMPMetadata metadata) {
+	protected void addXMP(XMPMetadata metadata) {
 
 		if (attachZUGFeRDHeaders) {
 			XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, 1, true, xmlProvider.getProfile(),
@@ -492,7 +440,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 
 			metadata.addSchema(zf);
 			// also add the schema extensions...
-			XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, 1, attachZUGFeRDHeaders, EStandard.orderx);
+			XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, 1, attachZUGFeRDHeaders, EStandard.ORDER_X);
 			pdfaex.setZUGFeRDVersion(1);
 			metadata.addSchema(pdfaex);
 		}
@@ -510,13 +458,13 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @throws IOException if anything is wrong with already loaded PDF
 	 */
 	@Override
-  public IExporter setTransaction(IExportableTransaction trans) throws IOException {
+	public IExporter setTransaction(IExportableTransaction trans) throws IOException {
 		this.trans = trans;
 		return prepare();
 	}
 
 	@Override
-  public IExporter prepare() throws IOException {
+	public IExporter prepare() throws IOException {
 		prepareDocument();
 		xmlProvider.generateXML(trans);
 		String filename = "order-x.xml";
@@ -536,7 +484,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Otherwise creates XMPMetadata.
 	 */
 	@Override
-  protected XMPMetadata getXmpMetadata() throws IOException {
+	protected XMPMetadata getXmpMetadata() throws IOException {
 		PDMetadata meta = doc.getDocumentCatalog().getMetadata();
 		if ((meta != null) && (meta.getLength() > 0)) {
 			try {
@@ -550,7 +498,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  protected byte[] serializeXmpMetadata(XMPMetadata xmpMetadata) throws TransformerException {
+	protected byte[] serializeXmpMetadata(XMPMetadata xmpMetadata) throws TransformerException {
 		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 		new XmpSerializer().serialize(xmpMetadata, buffer, true); // see https://github.com/ZUGFeRD/mustangproject/issues/44
 		return buffer.toByteArray();
@@ -561,10 +509,11 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Sets the PDFVersion to 1.4 if the field is empty.
 	 */
 	@Override
-  protected void writeAdobePDFSchema(XMPMetadata xmp) {
+	protected void writeAdobePDFSchema(XMPMetadata xmp) {
 		AdobePDFSchema pdf = getAdobePDFSchema(xmp);
-		if (overwrite || isBlank(pdf.getProducer()))
+		if (overwrite || isBlank(pdf.getProducer())) {
 			pdf.setProducer(producer);
+		}
 	}
 
 	/**
@@ -572,18 +521,20 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * If the overwrite flag is set or no AdobePDFSchema exists in the XMPMetadata, it is created, added and returned.
 	 */
 	@Override
-  protected AdobePDFSchema getAdobePDFSchema(XMPMetadata xmp) {
+	protected AdobePDFSchema getAdobePDFSchema(XMPMetadata xmp) {
 		AdobePDFSchema pdf = xmp.getAdobePDFSchema();
-		if (pdf != null)
-			if (overwrite)
+		if (pdf != null) {
+			if (overwrite) {
 				xmp.removeSchema(pdf);
-			else
+			} else {
 				return pdf;
+			}
+		}
 		return xmp.createAndAddAdobePDFSchema();
 	}
 
 	@Override
-  protected void writePDFAIdentificationSchema(XMPMetadata xmp) {
+	protected void writePDFAIdentificationSchema(XMPMetadata xmp) {
 		PDFAIdentificationSchema pdfaid = getPDFAIdentificationSchema(xmp);
 		if (overwrite || isBlank(pdfaid.getConformance())) {
 			try {
@@ -599,25 +550,30 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  protected PDFAIdentificationSchema getPDFAIdentificationSchema(XMPMetadata xmp) {
+	protected PDFAIdentificationSchema getPDFAIdentificationSchema(XMPMetadata xmp) {
 		PDFAIdentificationSchema pdfaid = xmp.getPDFAIdentificationSchema();
-		if (pdfaid != null)
-			if (overwrite)
+		if (pdfaid != null) {
+			if (overwrite) {
 				xmp.removeSchema(pdfaid);
-			else
+			} else {
 				return pdfaid;
+			}
+		}
 		return xmp.createAndAddPDFAIdentificationSchema();
 	}
 
 	@Override
-  protected void writeDublinCoreSchema(XMPMetadata xmp) {
+	protected void writeDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = getDublinCoreSchema(xmp);
-		if (dc.getFormat() == null)
+		if (dc.getFormat() == null) {
 			dc.setFormat("application/pdf");
-		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null)
+		}
+		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null) {
 			dc.addCreator(creator);
-		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null)
+		}
+		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null) {
 			dc.addDate(Calendar.getInstance());
+		}
 
 		ArrayProperty titleProperty = dc.getTitleProperty();
 		if (titleProperty != null) {
@@ -634,67 +590,79 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-  protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
+	protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = xmp.getDublinCoreSchema();
-		if (dc != null)
-			if (overwrite)
+		if (dc != null) {
+			if (overwrite) {
 				xmp.removeSchema(dc);
-			else
+			} else {
 				return dc;
+			}
+		}
 		return xmp.createAndAddDublinCoreSchema();
 	}
 
 	@Override
-  protected void writeXMLBasicSchema(XMPMetadata xmp) {
+	protected void writeXMLBasicSchema(XMPMetadata xmp) {
 		XMPBasicSchema xsb = getXmpBasicSchema(xmp);
-		if (overwrite || isBlank(xsb.getCreatorTool()) || "UnknownApplication".equals(xsb.getCreatorTool()))
+		if (overwrite || isBlank(xsb.getCreatorTool()) || "UnknownApplication".equals(xsb.getCreatorTool())) {
 			xsb.setCreatorTool(creatorTool);
-		if (overwrite || xsb.getCreateDate() == null)
+		}
+		if (overwrite || xsb.getCreateDate() == null) {
 			xsb.setCreateDate(Calendar.getInstance());
+		}
 	}
 
 	@Override
-  protected XMPBasicSchema getXmpBasicSchema(XMPMetadata xmp) {
+	protected XMPBasicSchema getXmpBasicSchema(XMPMetadata xmp) {
 		XMPBasicSchema xsb = xmp.getXMPBasicSchema();
-		if (xsb != null)
-			if (overwrite)
+		if (xsb != null) {
+			if (overwrite) {
 				xmp.removeSchema(xsb);
-			else
+			} else {
 				return xsb;
+			}
+		}
 		return xmp.createAndAddXMPBasicSchema();
 	}
 
 	@Override
-  protected void writeDocumentInformation() {
+	protected void writeDocumentInformation() {
 		String fullProducer = producer + " (via mustangproject.org " + Version.VERSION + ")";
 		PDDocumentInformation info = doc.getDocumentInformation();
-		if (overwrite || info.getCreationDate() == null)
+		if (overwrite || info.getCreationDate() == null) {
 			info.setCreationDate(Calendar.getInstance());
-		if (overwrite || info.getModificationDate() == null)
+		}
+		if (overwrite || info.getModificationDate() == null) {
 			info.setModificationDate(Calendar.getInstance());
-		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author)))
+		}
+		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author))) {
 			info.setAuthor(author);
-		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer)))
+		}
+		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer))) {
 			info.setProducer(fullProducer);
-		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator)))
+		}
+		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator))) {
 			info.setCreator(creator);
-		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title)))
+		}
+		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title))) {
 			info.setTitle(title);
-		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject)))
+		}
+		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject))) {
 			info.setSubject(subject);
+		}
 	}
 
 	/**
 	 * Adds an OutputIntent and the sRGB color profile if no OutputIntent exist
 	 */
 	@Override
-  protected void addSRGBOutputIntend() throws IOException {
+	protected void addSRGBOutputIntend() throws IOException {
 		if (!doc.getDocumentCatalog().getOutputIntents().isEmpty()) {
 			return;
 		}
 
-		try {
-			InputStream colorProfile = Thread.currentThread().getContextClassLoader().getResourceAsStream("sRGB.icc");
+		try (InputStream colorProfile = Thread.currentThread().getContextClassLoader().getResourceAsStream("sRGB.icc")) {
 			if (colorProfile != null) {
 				PDOutputIntent intent = new PDOutputIntent(doc, colorProfile);
 				intent.setInfo("sRGB IEC61966-2.1");
@@ -712,7 +680,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Adds a MarkInfo element to the PDF if it doesn't already exist and sets it as marked.
 	 */
 	@Override
-  protected void setMarked() {
+	protected void setMarked() {
 		PDDocumentCatalog catalog = doc.getDocumentCatalog();
 		if (catalog.getMarkInfo() == null) {
 			catalog.setMarkInfo(new PDMarkInfo(doc.getPages().getCOSObject()));
@@ -724,7 +692,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * Adds a StructureTreeRoot element to the PDF if it doesn't already exist.
 	 */
 	@Override
-  protected void addStructureTreeRoot() {
+	protected void addStructureTreeRoot() {
 		if (doc.getDocumentCatalog().getStructureTreeRoot() == null) {
 			doc.getDocumentCatalog().setStructureTreeRoot(new PDStructureTreeRoot());
 		}
@@ -735,7 +703,7 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @return if pdf file will be automatically closed after adding ZF
 	 */
 	@Override
-  public boolean isAutoCloseDisabled() {
+	public boolean isAutoCloseDisabled() {
 		return disableAutoClose;
 	}
 
@@ -743,13 +711,13 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	 * @param disableAutoClose prevent PDF file from being closed after adding ZF
 	 */
 	@Override
-  public OXExporterFromA3 disableAutoClose(boolean disableAutoClose) {
+	public OXExporterFromA3 disableAutoClose(boolean disableAutoClose) {
 		this.disableAutoClose = disableAutoClose;
 		return this;
 	}
 
 	@Override
-  protected void setXMLProvider(IXMLProvider p) {
+	protected void setXMLProvider(IXMLProvider p) {
 		this.xmlProvider = p;
 		if (profile != null) {
 			xmlProvider.setProfile(profile);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
@@ -24,7 +24,6 @@ import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
 import static org.mustangproject.ZUGFeRD.model.DocumentCodeTypeConstants.CORRECTEDINVOICE;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Base64;
@@ -38,11 +37,9 @@ import org.mustangproject.XMLTools;
 
 public class OXPullProvider extends ZUGFeRD2PullProvider {
 
-	protected IExportableTransaction trans;
-	protected TransactionCalculator calc;
-	private String paymentTermsDescription;
-	protected Profile profile = Profiles.getByName(EStandard.orderx,"basic", 1);
-
+	public OXPullProvider() {
+		profile = Profiles.getByName(EStandard.ORDER_X, "basic", 1);
+	}
 
 	@Override
 	public void generateXML(IExportableTransaction trans) {
@@ -55,19 +52,18 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		final String exemptionReason = "";
 
 		if (trans.getPaymentTermDescription() != null) {
-      paymentTermsDescription = XMLTools.encodeXML(trans.getPaymentTermDescription());
+			paymentTermsDescription = XMLTools.encodeXML(trans.getPaymentTermDescription());
 		}
 
 		if (paymentTermsDescription == null && !CORRECTEDINVOICE.equals(trans.getDocumentCode())/* && (trans.getDocumentCode() != DocumentCodeTypeConstants.CREDITNOTE)*/) {
 			paymentTermsDescription = "Zahlbar ohne Abzug bis " + germanDateFormat.format(trans.getDueDate());
-
 		}
 
 		final String typecode = "220";
 		/*if (trans.getDocumentCode() != null) {
 			typecode = trans.getDocumentCode();
 		}*/
-	
+
 		StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 
 				+ "<rsm:SCRDMCCBDACIOMessageStructure\n" +
@@ -107,7 +103,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			if (currentItem.getProduct().getTaxExemptionReason() != null) {
 			//	exemptionReason = "<ram:ExemptionReason>" + XMLTools.encodeXML(currentItem.getProduct().getTaxExemptionReason()) + "</ram:ExemptionReason>";
 			}
-    
+
 			final LineCalculator lc = currentItem.getCalculation();
 			xml.append("<ram:IncludedSupplyChainTradeLineItem>" +
 					"<ram:AssociatedDocumentLineDocument>"
@@ -291,7 +287,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		}
 		xml.append("</ram:ApplicableHeaderTradeAgreement>"
 				+ "<ram:ApplicableHeaderTradeDelivery>");
-		IZUGFeRDExportableTradeParty deliveryAddress=this.trans.getDeliveryAddress();
+		IZUGFeRDExportableTradeParty deliveryAddress = this.trans.getDeliveryAddress();
 		if (deliveryAddress == null) {
 			deliveryAddress = this.trans.getRecipient();
 		}
@@ -431,7 +427,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 
 			if (trans.getTradeSettlement() != null) {
 				for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement()) {
-					if ((payment != null) && (payment instanceof IZUGFeRDTradeSettlementDebit)) {
+					if (payment != null && payment instanceof IZUGFeRDTradeSettlementDebit) {
 		//not in order-x				xml.append(payment.getPaymentXML());
 					}
 				}
@@ -526,14 +522,12 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			return "";
 		}
 
-		for (IZUGFeRDPaymentTerms pt : paymentTerms)
-		{
+		for (IZUGFeRDPaymentTerms pt : paymentTerms) {
 			paymentTermsXml += "<ram:SpecifiedTradePaymentTerms>";
 
 			final IZUGFeRDPaymentDiscountTerms discountTerms = pt.getDiscountTerms();
 			paymentTermsXml += "<ram:Description>" + pt.getDescription() + "</ram:Description>";
-			if (discountTerms != null)
-			{
+			if (discountTerms != null) {
 				paymentTermsXml += "<ram:ApplicableTradePaymentDiscountTerms>";
 				final String currency = trans.getCurrency();
 				final String basisAmount = currencyFormat(calc.getGrandTotal());
@@ -541,8 +535,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 				paymentTermsXml += "<ram:CalculationPercent>" + discountTerms.getCalculationPercentage().toString()
 					+ "</ram:CalculationPercent>";
 
-				if (discountTerms.getBaseDate() != null)
-				{
+				if (discountTerms.getBaseDate() != null) {
 					final Date baseDate = discountTerms.getBaseDate();
 					paymentTermsXml += "<ram:BasisDateTime>";
 					paymentTermsXml += DATE.udtFormat(baseDate);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/PDFBoxUpdateMitigation.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/PDFBoxUpdateMitigation.java
@@ -14,87 +14,72 @@ import org.apache.pdfbox.preflight.parser.PreflightParser;
 import jakarta.activation.DataSource;
 
 // Copied from PDFBox preflight 2.0.x
-final class ByteArrayDataSource implements DataSource
-{
-  private ByteArrayOutputStream data;
-  private String type = null;
-  private String name = null;
+final class ByteArrayDataSource implements DataSource {
+	private ByteArrayOutputStream data;
+	private String type;
+	private String name;
 
-  public ByteArrayDataSource (final InputStream is) throws IOException
-  {
-    data = new ByteArrayOutputStream ();
-    IOUtils.copy (is, data);
-    IOUtils.closeQuietly (is);
-  }
+	ByteArrayDataSource (final InputStream is) throws IOException {
+		data = new ByteArrayOutputStream ();
+		IOUtils.copy (is, data);
+		IOUtils.closeQuietly (is);
+	}
 
-  public String getContentType ()
-  {
-    return this.type;
-  }
+	public String getContentType () {
+		return this.type;
+	}
 
-  /**
-   * @param type
-   *        the type to set
-   */
-  public void setType (final String type)
-  {
-    this.type = type;
-  }
+	/**
+	 * @param type
+	 *				the type to set
+	 */
+	public void setType (final String type) {
+		this.type = type;
+	}
 
-  /**
-   * @param name
-   *        the name to set
-   */
-  public void setName (final String name)
-  {
-    this.name = name;
-  }
+	/**
+	 * @param name
+	 *				the name to set
+	 */
+	public void setName (final String name) {
+		this.name = name;
+	}
 
-  public InputStream getInputStream () throws IOException
-  {
-    return new ByteArrayInputStream (data.toByteArray ());
-  }
+	public InputStream getInputStream () throws IOException {
+		return new ByteArrayInputStream (data.toByteArray ());
+	}
 
-  public String getName ()
-  {
-    return this.name;
-  }
+	public String getName () {
+		return this.name;
+	}
 
-  public OutputStream getOutputStream () throws IOException
-  {
-    this.data = new ByteArrayOutputStream ();
-    return data;
-  }
+	public OutputStream getOutputStream () throws IOException {
+		this.data = new ByteArrayOutputStream ();
+		return data;
+	}
 }
 
 // Try to create an API similar to the 2.x one
-final class PreflightParserHelper
-{
-  private static File createTmpFile (final InputStream input) throws IOException
-  {
-    FileOutputStream fos = null;
-    try
-    {
-      final File tmpFile = File.createTempFile ("mustang-pdf", ".pdf");
-      tmpFile.deleteOnExit ();
-      fos = new FileOutputStream (tmpFile);
-      IOUtils.copy (input, fos);
-      return tmpFile;
-    }
-    finally
-    {
-      IOUtils.closeQuietly (input);
-      IOUtils.closeQuietly (fos);
-    }
-  }
+final class PreflightParserHelper {
+	private static File createTmpFile (final InputStream input) throws IOException {
+		FileOutputStream fos = null;
+		try {
+			final File tmpFile = File.createTempFile ("mustang-pdf", ".pdf");
+			tmpFile.deleteOnExit ();
+			fos = new FileOutputStream (tmpFile);
+			IOUtils.copy (input, fos);
+			return tmpFile;
+		} finally {
+			IOUtils.closeQuietly (input);
+			IOUtils.closeQuietly (fos);
+		}
+	}
 
-  public static PreflightParser createPreflightParser (final DataSource dataSource) throws IOException
-  {
-    return new PreflightParser (createTmpFile (dataSource.getInputStream ()));
-  }
+	public static PreflightParser createPreflightParser (final DataSource dataSource) throws IOException {
+		return new PreflightParser (createTmpFile (dataSource.getInputStream ()));
+	}
 }
 
-final class PDFBoxUpdateMitigation
-{
-  // Dummy for the name only
+final class PDFBoxUpdateMitigation {
+	// Dummy for the name only
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/Profiles.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/Profiles.java
@@ -57,14 +57,14 @@ public class Profiles {
 
 
 	public static Profile getByName(EStandard standard, String name, int version) {
-		if (standard == EStandard.orderx) {
+		if (standard == EStandard.ORDER_X) {
 			Profile result = null;
 			result = ox1Map.get(name.toUpperCase());
 			if (result == null) {
 				throw new RuntimeException("Profile not found");
 			}
 			return result;
-		} else if (standard == EStandard.despatchadvice) {
+		} else if (standard == EStandard.DELIVER_X) {
 			Profile result = null;
 			result = dx1Map.get(name.toUpperCase());
 			if (result == null) {
@@ -73,7 +73,7 @@ public class Profiles {
 			return result;
 		} else {
 			int generation = version;
-			if ((standard==EStandard.facturx) && (version==1)) {
+			if (standard == EStandard.FACTUR_X && version == 1) {
 				generation = 2;
 			}
 			return getByName(name, generation);
@@ -95,7 +95,7 @@ public class Profiles {
 	}
 
 	public static Profile getByName(String name) {
-		return getByName(name, ZUGFeRDExporterFromA3.DefaultZUGFeRDVersion);
+		return getByName(name, ZUGFeRDExporterFromA3.defaultZUGFeRDVersion);
 	}
 
 
@@ -107,19 +107,16 @@ public class Profiles {
 	 *
 	 * @return a profile matching the requested name
 	 */
-	public static Profile getByNameDisregardingVersion(String name)
-	{
+	public static Profile getByNameDisregardingVersion(String name) {
 		Profile result = null;
 
 		result = zf1Map.get(name.toUpperCase());
 
-		if (result == null)
-		{
+		if (result == null) {
 			result = zf2Map.get(name.toUpperCase());
 		}
 
-		if (result==null)
-		{
+		if (result == null) {
 			throw new RuntimeException("Profile " + name + " not found");
 		}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/TransactionCalculator.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/TransactionCalculator.java
@@ -299,8 +299,7 @@ public class TransactionCalculator implements IAbsoluteValueProvider {
 	protected List<VATAmount> getVATAmountList() {
 		final List<VATAmount> vatAmounts = new ArrayList<>();
 		final String vatDueDateTypeCode = this.trans.getVATDueDateTypeCode();
-		for (final IZUGFeRDExportableItem currentItem : this.trans.getZFItems())
-		{
+		for (final IZUGFeRDExportableItem currentItem : this.trans.getZFItems()) {
 			// skip GROUP and INFORMATION lines for sub invoice lines
 			if (!currentItem.isCalculationRelevant()) {
 				continue;

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/UBLDAPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/UBLDAPullProvider.java
@@ -40,8 +40,8 @@ public class UBLDAPullProvider implements IXMLProvider {
 
 	protected IExportableTransaction trans;
 	protected TransactionCalculator calc;
+	protected Profile profile = Profiles.getByName(EStandard.UBL_DESPATCHADVICE, "basic", 1);
 	byte[] ublData;
-	protected Profile profile = Profiles.getByName(EStandard.ubldespatchadvice, "basic", 1);
 
 
 	@Override

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
@@ -60,8 +60,7 @@ public class VATAmount {
 		this.dueDateTypeCode = dueDateTypeCode;
 	}
 
-	public VATAmount(BigDecimal basis, BigDecimal calculated, String categoryCode, String dueDateTypeCode, BigDecimal applicablePercent)
-	{
+	public VATAmount(BigDecimal basis, BigDecimal calculated, String categoryCode, String dueDateTypeCode, BigDecimal applicablePercent) {
 		super();
 		this.basis = basis;
 		this.calculated = calculated;
@@ -157,7 +156,7 @@ public class VATAmount {
 
 	public VATAmount add(VATAmount v) {
 		return new VATAmount(basis.add(v.getBasis()), calculated.add(v.getCalculated()), this.categoryCode, this.dueDateTypeCode)
-			.setVatExemptionReasonCode(v.getVatExemptionReasonCode() != null ? v.getVatExemptionReasonCode(): this.vatExemptionReasonCode);
+			.setVatExemptionReasonCode(v.getVatExemptionReasonCode() != null ? v.getVatExemptionReasonCode() : this.vatExemptionReasonCode);
 
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
@@ -8,7 +8,26 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringReader;
-import org.apache.fop.apps.*;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+import org.apache.fop.apps.FOPException;
+import org.apache.fop.apps.FOUserAgent;
+import org.apache.fop.apps.Fop;
+import org.apache.fop.apps.FopFactory;
+import org.apache.fop.apps.FopFactoryBuilder;
 import org.apache.fop.apps.io.ResourceResolverFactory;
 import org.apache.fop.configuration.Configuration;
 import org.apache.fop.configuration.ConfigurationException;
@@ -18,14 +37,6 @@ import org.mustangproject.ClasspathResolverURIAdapter;
 import org.mustangproject.XMLTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.xml.XMLConstants;
-import javax.xml.transform.*;
-import javax.xml.transform.sax.SAXResult;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
-
-import java.nio.charset.StandardCharsets;
 
 public class ValidationLogVisualizer {
 	public enum Language {
@@ -38,8 +49,8 @@ public class ValidationLogVisualizer {
 	private static final String RESOURCE_PATH = "";
 	private static final Logger LOGGER = LoggerFactory.getLogger(ValidationLogVisualizer.class);
 
-	private TransformerFactory mFactory = null;
-	private Templates mXsltPDFTemplate = null;
+	private TransformerFactory mFactory;
+	private Templates mXsltPDFTemplate;
 
 
 	public ValidationLogVisualizer() {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMLUpgrader.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMLUpgrader.java
@@ -29,8 +29,8 @@ public class XMLUpgrader {
 
 	static final ClassLoader CLASS_LOADER = XMLUpgrader.class.getClassLoader();
 	private static final String RESOURCE_PATH = "";
-	private TransformerFactory mFactory = null;
-	private Templates mXsltTemplate = null;
+	private TransformerFactory mFactory;
+	private Templates mXsltTemplate;
 
 	public XMLUpgrader() {
 		mFactory = XMLTools.getTransformerFactory();

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaPDFAExtensions.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaPDFAExtensions.java
@@ -25,7 +25,7 @@ package org.mustangproject.ZUGFeRD;
  * @date 2014-05-10
  * @version 1.2.0
  * @author jstaerk
- * */
+ */
 
 import org.apache.xmpbox.XMPMetadata;
 import org.apache.xmpbox.XmpConstants;
@@ -59,11 +59,25 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 	public final String prefix_pdfaSchema = "pdfaSchema";
 	public final String xmlns_pdfaProperty = "http://www.aiim.org/pdfa/ns/property#";
 	public final String prefix_pdfaProperty = "pdfaProperty";
-	public String namespace = null;
-	public String prefix = null;
+	public String namespace;
+	public String prefix;
 
 	protected IZUGFeRDExporter exporter;
 
+	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion) {
+		this(ze, metadata, ZFVersion, true);
+	}
+
+	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion, boolean withZF) {
+		this(ze, metadata, ZFVersion, withZF, null);
+	}
+
+	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion, boolean withZF, EStandard eStandard) {
+		super(metadata);
+		exporter = ze;
+		setZUGFeRDVersion(ZFVersion);
+		attachExtensions(metadata, withZF, eStandard);
+	}
 
 	protected void setZUGFeRDVersion(int ver) {
 		namespace = exporter.getNamespaceForVersion(ver);
@@ -71,8 +85,7 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 	}
 
 
-	private DefinedStructuredType addProperty(ArrayProperty parent, String name, String type, String category,
-											  String description) {
+	private DefinedStructuredType addProperty(ArrayProperty parent, String name, String type, String category, String description) {
 		XMPMetadata metadata = getMetadata();
 
 		DefinedStructuredType li = new DefinedStructuredType(metadata, getNamespace(), getPrefix(),
@@ -98,72 +111,49 @@ public class XMPSchemaPDFAExtensions extends PDFAExtensionSchema {
 		return li;
 	}
 
-	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion) {
-		this(ze, metadata, ZFVersion, true);
-	}
-
-	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion, boolean withZF) {
-		this(ze, metadata, ZFVersion, withZF, null);
-	}
-
-	public XMPSchemaPDFAExtensions(IZUGFeRDExporter ze, XMPMetadata metadata, int ZFVersion, boolean withZF, EStandard eStandard) {
-		super(metadata);
-		exporter=ze;
-		setZUGFeRDVersion(ZFVersion);
-		attachExtensions(metadata, withZF, eStandard);
-	}
-
 	public void attachExtensions(XMPMetadata metadata, boolean withZF, EStandard eStandard) {
 
 		addNamespace(xmlns_pdfaSchema, prefix_pdfaSchema);
 		addNamespace(xmlns_pdfaProperty, prefix_pdfaProperty);
 
 		ArrayProperty newBag = createArrayProperty(SCHEMAS, Cardinality.Bag);
-		DefinedStructuredType li = new DefinedStructuredType(metadata, getNamespace(), getPrefix(),
-				XmpConstants.LIST_NAME);
+		DefinedStructuredType li = new DefinedStructuredType(metadata, getNamespace(), getPrefix(), XmpConstants.LIST_NAME);
 		li.setAttribute(new Attribute(getNamespace(), XmpConstants.PARSE_TYPE, XmpConstants.RESOURCE_NAME));
 		newBag.addProperty(li);
 		addProperty(newBag);
 		if (withZF) {
-			TextType pdfa1 = new TextType(metadata, xmlns_pdfaSchema, prefix_pdfaSchema, PDFASchemaType.SCHEMA,
-					"Factur-X PDFA Extension Schema");
+			TextType pdfa1 = new TextType(metadata, xmlns_pdfaSchema, prefix_pdfaSchema, PDFASchemaType.SCHEMA, "Factur-X PDFA Extension Schema");
 			li.addProperty(pdfa1);
 
-			pdfa1 = new TextType(metadata, xmlns_pdfaSchema, prefix_pdfaSchema, PDFASchemaType.NAMESPACE_URI,
-					namespace);
+			pdfa1 = new TextType(metadata, xmlns_pdfaSchema, prefix_pdfaSchema, PDFASchemaType.NAMESPACE_URI, namespace);
 			li.addProperty(pdfa1);
 
 			pdfa1 = new TextType(metadata, xmlns_pdfaSchema, prefix_pdfaSchema, PDFASchemaType.PREFIX, prefix);
 			li.addProperty(pdfa1);
 
-			ArrayProperty newSeq = new ArrayProperty(metadata, xmlns_pdfaSchema, prefix_pdfaSchema,
-					PDFASchemaType.PROPERTY, Cardinality.Seq);
+			ArrayProperty newSeq = new ArrayProperty(metadata, xmlns_pdfaSchema, prefix_pdfaSchema, PDFASchemaType.PROPERTY, Cardinality.Seq);
 			li.addProperty(newSeq);
 
-			if ((eStandard != null) && (eStandard == EStandard.orderx))
-			{
+			if ((eStandard != null) && (eStandard == EStandard.ORDER_X)) {
 				addProperty(newSeq, "DocumentFileName", "Text", "external", "Name of the embedded XML Order (or related) file");
 				addProperty(newSeq, "DocumentType", "Text", "external", "ORDER, ORDER_RESPONSE, or ORDER_CHANGE");
 				addProperty(newSeq, "Version", "Text", "external", "The actual version of the Order-X XML schema");
 				addProperty(newSeq, "ConformanceLevel", "Text", "external",
 								    "The selected Order-X profile completeness");
-			} else if ((eStandard != null) && (eStandard == EStandard.despatchadvice))
-			{
+			} else if ((eStandard != null) && (eStandard == EStandard.DELIVER_X)) {
 				// As of late 2022 the Delivery-X standard is not yet published. See specification:
 				// Die digitale Ablösung des Papier-Lieferscheins, Version 1.1, April 2022
 				// Chapter 7.1 XMP-Erweiterungsschema für PDF/A-3
 				// http://docplayer.org/230301085-Der-digitale-lieferschein-dls.html
 				addProperty(newSeq, "DocumentFileName", "Text", "external", "Name of the embedded XML despatch advice file");
-				addProperty(newSeq, "DocumentType",     "Text", "external", "DESPATCHADVICE");
-				addProperty(newSeq, "Version",          "Text", "external", "The actual version of the despatch advice dataset");
+				addProperty(newSeq, "DocumentType", "Text", "external", "DESPATCHADVICE");
+				addProperty(newSeq, "Version", "Text", "external", "The actual version of the despatch advice dataset");
 				addProperty(newSeq, "ConformanceLevel", "Text", "external", "The conformance level of the despatch advice dataset");
-			} else
-			{
+			} else {
 				addProperty(newSeq, "DocumentFileName", "Text", "external", "name of the embedded XML invoice file");
 				addProperty(newSeq, "DocumentType", "Text", "external", "INVOICE");
 				addProperty(newSeq, "Version", "Text", "external", "The actual version of the ZUGFeRD XML schema");
-				addProperty(newSeq, "ConformanceLevel", "Text", "external",
-								    "The selected ZUGFeRD profile completeness");
+				addProperty(newSeq, "ConformanceLevel", "Text", "external", "The selected ZUGFeRD profile completeness");
 			}
 		}
 	}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaZugferd.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XMPSchemaZugferd.java
@@ -73,8 +73,8 @@ public class XMPSchemaZugferd extends XMPSchema {
 
 		if (version == null) {
 		    version = "1.0";
-		    if ((zfVersion==2)&&(!isFacturX)) {
-				version="2p0";
+		    if (zfVersion == 2 && !isFacturX) {
+				version = "2p0";
 			}
 		}
 		setTextPropertyValue("Version", version);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/XRExporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/XRExporter.java
@@ -25,7 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class XRExporter implements IExporter  {
+public class XRExporter implements IExporter {
 	IXMLProvider xmlProvider;
 	IExportableTransaction trans;
 
@@ -35,7 +35,7 @@ public class XRExporter implements IExporter  {
 
 	@Override
 	public IExporter setTransaction(IExportableTransaction trans) throws IOException {
-		this.trans=trans;
+		this.trans = trans;
 		return this;
 	}
 
@@ -48,7 +48,7 @@ public class XRExporter implements IExporter  {
 	@Override
 	public void export(OutputStream output) throws IOException {
 		xmlProvider.generateXML(trans);
-		byte[] bytes=xmlProvider.getXML();
+		byte[] bytes = xmlProvider.getXML();
 		output.write(bytes, 0, bytes.length);
 	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
@@ -23,85 +23,29 @@ package org.mustangproject.ZUGFeRD;
 import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
 import static org.mustangproject.ZUGFeRD.model.TaxCategoryCodeTypeConstants.CATEGORY_CODES_WITH_EXEMPTION_REASON;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 
-import org.dom4j.Document;
-import org.dom4j.DocumentException;
-import org.dom4j.DocumentHelper;
-import org.dom4j.io.OutputFormat;
-import org.dom4j.io.XMLWriter;
 import org.mustangproject.XMLTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
-  private static final Logger LOGGER = LoggerFactory.getLogger (ZUGFeRD1PullProvider.class);
 
-	//// MAIN CLASS
-
-	protected byte[] zugferdData;
-	private String paymentTermsDescription;
-	protected Profile profile = Profiles.getByName("COMFORT", 1);
-
-	@Override
-  protected String vatFormat(BigDecimal value) {
-		return XMLTools.nDigitFormat(value, 2);
+	public ZUGFeRD1PullProvider() {
+		profile = Profiles.getByName("COMFORT", 1);
 	}
 
 	@Override
-  protected String currencyFormat(BigDecimal value) {
-		return XMLTools.nDigitFormat(value, 2);
-	}
-
-	@Override
-  protected String priceFormat(BigDecimal value) {
+	protected String priceFormat(BigDecimal value) {
 		return XMLTools.nDigitFormat(value, 4);
 	}
 
 	@Override
-  protected String quantityFormat(BigDecimal value) {
+	protected String quantityFormat(BigDecimal value) {
 		return XMLTools.nDigitFormat(value, 4);
 	}
-
-
-	@Override
-	public Profile getProfile() {
-		return profile;
-	}
-
-	@Override
-	public byte[] getXML() {
-
-		byte[] res = zugferdData;
-
-		final StringWriter sw = new StringWriter();
-		Document document = null;
-		try {
-			document = DocumentHelper.parseText(new String(zugferdData, StandardCharsets.UTF_8));
-		} catch (final DocumentException e1) {
-			LOGGER.error ("Failed to parse ZUGFeRD data", e1);
-		}
-		try {
-			final OutputFormat format = OutputFormat.createPrettyPrint();
-			format.setTrimText(false);
-			final XMLWriter writer = new XMLWriter(sw, format);
-			writer.write(document);
-			res = sw.toString().getBytes(StandardCharsets.UTF_8);
-
-		} catch (final IOException e) {
-      		LOGGER.error ("Failed to write ZUGFeRD data", e);
-		}
-
-		return res;
-
-	}
-
 
 	@Override
 	public void generateXML(IExportableTransaction trans) {
@@ -290,7 +234,7 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 			if (hasDueDate && (trans.getDueDate() != null)) {
 				xml.append("<ram:DueDateDateTime>" // $NON-NLS-2$
 						+ DATE.udtFormat(trans.getDueDate())
-						+ "</ram:DueDateDateTime>");// 20130704
+						+ "</ram:DueDateDateTime>"); // 20130704
 
 			}
 			xml.append("</ram:SpecifiedTradePaymentTerms>");
@@ -410,13 +354,8 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 				+ "</rsm:CrossIndustryDocument>");
 
 		final byte[] zugferdRaw;
-    zugferdRaw = xml.toString().getBytes(StandardCharsets.UTF_8);
-    zugferdData = XMLTools.removeBOM(zugferdRaw);
-  }
-
-	@Override
-	public void setProfile(Profile p) {
-		profile = p;
+		zugferdRaw = xml.toString().getBytes(StandardCharsets.UTF_8);
+		zugferdData = XMLTools.removeBOM(zugferdRaw);
 	}
 
 	private String buildPaymentTermsXml() {
@@ -427,27 +366,23 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 			return paymentTermsXml;
 		}
 
-		for (IZUGFeRDPaymentTerms pt : paymentTerms)
-		{
+		for (IZUGFeRDPaymentTerms pt : paymentTerms) {
 			paymentTermsXml += "<ram:SpecifiedTradePaymentTerms>";
 
 			final IZUGFeRDPaymentDiscountTerms discountTerms = pt.getDiscountTerms();
 			final Date dueDate = pt.getDueDate();
-			if (dueDate != null && discountTerms != null && discountTerms.getBaseDate() != null)
-			{
+			if (dueDate != null && discountTerms != null && discountTerms.getBaseDate() != null) {
 				throw new IllegalStateException(
 					"if paymentTerms.dueDate is specified, paymentTerms.discountTerms.baseDate has not to be specified");
 			}
 			paymentTermsXml += "<ram:Description>" + pt.getDescription() + "</ram:Description>";
-			if (dueDate != null)
-			{
+			if (dueDate != null) {
 				paymentTermsXml += "<ram:DueDateDateTime>";
 				paymentTermsXml += DATE.udtFormat(dueDate);
 				paymentTermsXml += "</ram:DueDateDateTime>";
 			}
 
-			if (discountTerms != null)
-			{
+			if (discountTerms != null) {
 				paymentTermsXml += "<ram:ApplicableTradePaymentDiscountTerms>";
 				final String currency = trans.getCurrency();
 				final String basisAmount = currencyFormat(calc.getGrandTotal());
@@ -455,8 +390,7 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 				paymentTermsXml += "<ram:CalculationPercent>" + discountTerms.getCalculationPercentage().toString()
 					+ "</ram:CalculationPercent>";
 
-				if (discountTerms.getBaseDate() != null)
-				{
+				if (discountTerms.getBaseDate() != null) {
 					final Date baseDate = discountTerms.getBaseDate();
 					paymentTermsXml += "<ram:BasisDateTime>";
 					paymentTermsXml += DATE.udtFormat(baseDate);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -60,7 +60,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 	protected byte[] zugferdData;
 	protected IExportableTransaction trans;
 	protected TransactionCalculator calc;
-	private String paymentTermsDescription;
+	protected String paymentTermsDescription;
 	protected Profile profile = Profiles.getByName("EN16931");
 
 	protected String vatFormat(BigDecimal value) {
@@ -96,10 +96,10 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		try {
 			final OutputFormat format = OutputFormat.createPrettyPrint();
 			format.setTrimText(false);
-			final XMLWriter writer = new XMLWriter(sw, format);
-			writer.write(document);
-			res = sw.toString().getBytes(StandardCharsets.UTF_8);
-
+			try (XMLWriter writer = new XMLWriter(sw, format)) {
+				writer.write(document);
+				res = sw.toString().getBytes(StandardCharsets.UTF_8);
+			}
 		} catch (final IOException e) {
 			LOGGER.error("Failed to write ZUGFeRD data", e);
 		}
@@ -108,6 +108,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 	}
 
+
+	@Override
+	public void setProfile(Profile p) {
+		profile = p;
+	}
 
 	@Override
 	public Profile getProfile() {
@@ -402,9 +407,9 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		String businessProcessId = trans.getBusinessProcessId();
 		if (isNotBlank(businessProcessId)) {
  			xml.append("<ram:BusinessProcessSpecifiedDocumentContextParameter>\n"
-				+ "<ram:ID>" +  XMLTools.encodeXML(businessProcessId)  + "</ram:ID>\n"
+				+ "<ram:ID>" + XMLTools.encodeXML(businessProcessId) + "</ram:ID>\n"
 				+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>\n");
-		}else if (getProfile() == Profiles.getByName("XRechnung")) {
+		} else if (getProfile() == Profiles.getByName("XRechnung")) {
 			xml.append("<ram:BusinessProcessSpecifiedDocumentContextParameter>\n"
 				+ "<ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>\n"
 				+ "</ram:BusinessProcessSpecifiedDocumentContextParameter>\n");
@@ -565,7 +570,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
 					+ "</ram:NetPriceProductTradePrice>");
 
-                if(currentItem.getLineSeller()!=null) {
+                if (currentItem.getLineSeller() != null) {
                     xml.append("<ram:ItemSellerTradeParty>" + getTradePartyAsXML(currentItem.getLineSeller(), true, false) + "</ram:ItemSellerTradeParty>");
 
                 }
@@ -582,7 +587,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 						}
 						if (currentItem.getDeliveryNoteReferencedDocumentDate() != null) {
 							final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-							xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">"+XMLTools.encodeXML(dateFormat102.format(currentItem.getDeliveryNoteReferencedDocumentDate()))+"</qdt:DateTimeString></ram:FormattedIssueDateTime>");
+							xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(currentItem.getDeliveryNoteReferencedDocumentDate())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
 						}
 						xml.append("</ram:DeliveryNoteReferencedDocument>");
 
@@ -600,11 +605,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				if (profile != Profiles.getByName("EN16931") && currentItem.getProduct().getTaxExemptionReasonCode() != null) {
 					xml.append("<ram:ExemptionReasonCode>" + XMLTools.encodeXML(currentItem.getProduct().getTaxExemptionReasonCode()) + "</ram:ExemptionReasonCode>");
 				}
-				BigDecimal vatValue=BigDecimal.ZERO;
+				BigDecimal vatValue;
 				if (currentItem.getProduct().getTaxCategoryCode().equals(TaxCategoryCodeTypeConstants.ZEROTAXPRODUCTS)) {
-					vatValue=BigDecimal.ZERO;
+					vatValue = BigDecimal.ZERO;
 				} else {
-					vatValue=currentItem.getProduct().getVATPercent();
+					vatValue = currentItem.getProduct().getVATPercent();
 				}
 
 				if ((!currentItem.getProduct().getTaxCategoryCode().equals(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE)) ) {
@@ -746,12 +751,12 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		    if (rtc != null && !rtc.isEmpty()) {
 		        xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
 		    }
-			if (trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime()!=null) {
+			if (trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime() != null) {
 				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
 			}
 			xml.append("</ram:AdditionalReferencedDocument>");
 		}
-		if (trans.getTenderReferencedDocument() != null){
+		if (trans.getTenderReferencedDocument() != null) {
 			xml.append("<ram:AdditionalReferencedDocument>"
 				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getTenderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
 				+ "<ram:TypeCode>50</ram:TypeCode>");
@@ -764,12 +769,12 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		    if (rtc != null && !rtc.isEmpty()) {
 		    	xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
 		    }
-			if (trans.getTenderReferencedDocument().getFormattedIssueDateTime()!=null) {
+			if (trans.getTenderReferencedDocument().getFormattedIssueDateTime() != null) {
 				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getTenderReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
 			}
 			xml.append("</ram:AdditionalReferencedDocument>");
 		}
-		if (trans.getRelatedReferencedDocument() != null){
+		if (trans.getRelatedReferencedDocument() != null) {
 			xml.append("<ram:AdditionalReferencedDocument>"
 				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getRelatedReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
 				+ "<ram:TypeCode>916</ram:TypeCode>");
@@ -782,7 +787,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		    if (rtc != null && !rtc.isEmpty()) {
 		    	xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
 		    }
-			if (trans.getRelatedReferencedDocument().getFormattedIssueDateTime()!=null) {
+			if (trans.getRelatedReferencedDocument().getFormattedIssueDateTime() != null) {
 				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getRelatedReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
 			}
 			xml.append("</ram:AdditionalReferencedDocument>");
@@ -827,7 +832,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			xml.append("<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getDeliveryNoteReferencedDocumentID()) + "</ram:IssuerAssignedID>");
 			if (trans.getDeliveryNoteReferencedDocumentDate() != null) {
 				final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-				xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">"+XMLTools.encodeXML(dateFormat102.format(trans.getDeliveryNoteReferencedDocumentDate()))+"</qdt:DateTimeString></ram:FormattedIssueDateTime>");
+				xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(trans.getDeliveryNoteReferencedDocumentDate())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
 			}
 			xml.append("</ram:DeliveryNoteReferencedDocument>");
 		}
@@ -970,8 +975,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				}
 			} else {
 				for (final VATAmount amount : vatAmounts) {
-					if (calc.getChargesForPercent(amount.getApplicablePercent()).compareTo(BigDecimal.ZERO) != 0)
-					{
+					if (calc.getChargesForPercent(amount.getApplicablePercent()).compareTo(BigDecimal.ZERO) != 0) {
 						xml.append("<ram:SpecifiedTradeAllowanceCharge>" +
 							"<ram:ChargeIndicator>" +
 							"<udt:Indicator>true</udt:Indicator>" +
@@ -1102,7 +1106,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					xml.append("</ram:SpecifiedLogisticsServiceCharge>");
 				}
 			} else {
-				((Invoice)trans).setZFLogisticsServiceCharges(new ArrayList<LogisticsServiceCharge>().toArray( new LogisticsServiceCharge[0]));
+				((Invoice) trans).setZFLogisticsServiceCharges(new ArrayList<LogisticsServiceCharge>().toArray( new LogisticsServiceCharge[0]));
 			}
 		}
 
@@ -1116,7 +1120,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			if (trans.getDueDate() != null) {
 				xml.append("<ram:DueDateDateTime>" // $NON-NLS-2$
 					+ DATE.udtFormat(trans.getDueDate())
-					+ "</ram:DueDateDateTime>");// 20130704
+					+ "</ram:DueDateDateTime>"); // 20130704
 			}
 
 			if (trans.getTradeSettlement() != null) {
@@ -1248,11 +1252,6 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		return includedNotes.stream().map(IncludedNote::toCiiXml).collect(Collectors.joining(""));
 	}
 
-	@Override
-	public void setProfile(Profile p) {
-		profile = p;
-	}
-
 	private String buildPaymentTermsXml() {
 
 		ArrayList<IZUGFeRDPaymentTerms> paymentTerms = new ArrayList<>();
@@ -1279,43 +1278,35 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			return "";
 		}
 
-		for (IZUGFeRDPaymentTerms pt : paymentTerms)
-		{
-
+		for (IZUGFeRDPaymentTerms pt : paymentTerms) {
 			paymentTermsXml += "<ram:SpecifiedTradePaymentTerms>";
 
 			final IZUGFeRDPaymentDiscountTerms discountTerms = pt.getDiscountTerms();
 			final Date dueDate = pt.getDueDate();
-			if (dueDate != null && discountTerms != null && discountTerms.getBaseDate() != null)
-			{
+			if (dueDate != null && discountTerms != null && discountTerms.getBaseDate() != null) {
 				throw new IllegalStateException(
 					"if paymentTerms.dueDate is specified, paymentTerms.discountTerms.baseDate has not to be specified");
 			}
 
-			if(pt.getDescription() != null) {
+			if (pt.getDescription() != null) {
 				paymentTermsXml += "<ram:Description>" + pt.getDescription() + "</ram:Description>";
 			}
 
-			if (dueDate != null)
-			{
+			if (dueDate != null) {
 				paymentTermsXml += "<ram:DueDateDateTime>";
 				paymentTermsXml += DATE.udtFormat(dueDate);
 				paymentTermsXml += "</ram:DueDateDateTime>";
 			}
 
-			if (trans.getTradeSettlement() != null)
-			{
-				for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement())
-				{
-					if ((payment != null) && (payment instanceof IZUGFeRDTradeSettlementDebit))
-					{
+			if (trans.getTradeSettlement() != null) {
+				for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement()) {
+					if ((payment != null) && (payment instanceof IZUGFeRDTradeSettlementDebit)) {
 						paymentTermsXml += payment.getPaymentXML();
 					}
 				}
 			}
 
-			if (discountTerms != null)
-			{
+			if (discountTerms != null) {
 				paymentTermsXml += "<ram:ApplicableTradePaymentDiscountTerms>";
 				final String currency = trans.getCurrency();
 				final String basisAmount = currencyFormat(calc.getGrandTotal());
@@ -1323,8 +1314,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				paymentTermsXml += "<ram:CalculationPercent>" + discountTerms.getCalculationPercentage().toString()
 					+ "</ram:CalculationPercent>";
 
-				if (discountTerms.getBaseDate() != null)
-				{
+				if (discountTerms.getBaseDate() != null) {
 					final Date baseDate = discountTerms.getBaseDate();
 					paymentTermsXml += "<ram:BasisDateTime>";
 					paymentTermsXml += DATE.udtFormat(baseDate);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDDateFormat.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDDateFormat.java
@@ -12,12 +12,13 @@ public enum ZUGFeRDDateFormat {
 	WEEK_OF_YEAR(DateTimeTypeConstants.WEEK, () -> new SimpleDateFormat("yyyyww")),
 	DATE(DateTimeTypeConstants.DATE, () -> new SimpleDateFormat("yyyyMMdd"));
 
-	private String dateTimeType;
-	private ThreadLocal<SimpleDateFormat> formatter;
 	private static final String QDT_FORMAT = "<qdt:DateTimeString format=\"%s\">%s</qdt:DateTimeString>";
 	private static final String UDT_FORMAT = "<udt:DateTimeString format=\"%s\">%s</udt:DateTimeString>";
 
-	private ZUGFeRDDateFormat(String dateTimeType, Supplier<SimpleDateFormat> formatter) {
+	private String dateTimeType;
+	private ThreadLocal<SimpleDateFormat> formatter;
+
+	ZUGFeRDDateFormat(String dateTimeType, Supplier<SimpleDateFormat> formatter) {
 		this.dateTimeType = dateTimeType;
 		this.formatter = ThreadLocal.withInitial(formatter);
 	}
@@ -29,14 +30,14 @@ public enum ZUGFeRDDateFormat {
 	public SimpleDateFormat getFormatter() {
 		return formatter.get();
 	}
-	
-	public String simpleFormat(Date date){
-    return getFormatter().format(date);
-  }
-	public String qdtFormat(Date date){
-    return String.format(QDT_FORMAT, getDateTimeType(), getFormatter().format(date));
-  }
-	public String udtFormat(Date date){
-    return String.format(UDT_FORMAT, getDateTimeType(), getFormatter().format(date));
-  }
+
+	public String simpleFormat(Date date) {
+		return getFormatter().format(date);
+	}
+	public String qdtFormat(Date date) {
+		return String.format(QDT_FORMAT, getDateTimeType(), getFormatter().format(date));
+	}
+	public String udtFormat(Date date) {
+		return String.format(UDT_FORMAT, getDateTimeType(), getFormatter().format(date));
+	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA1.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA1.java
@@ -67,16 +67,16 @@ public class ZUGFeRDExporterFromA1 extends ZUGFeRDExporterFromA3 {
 
 
 	@Override
-  public ZUGFeRDExporterFromA1 setProfile(Profile p) {
-		return (ZUGFeRDExporterFromA1)super.setProfile(p);
+	public ZUGFeRDExporterFromA1 setProfile(Profile p) {
+		return (ZUGFeRDExporterFromA1) super.setProfile(p);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setProfile(String profileName) {
-		return (ZUGFeRDExporterFromA1)super.setProfile(profileName);
+	public ZUGFeRDExporterFromA1 setProfile(String profileName) {
+		return (ZUGFeRDExporterFromA1) super.setProfile(profileName);
 	}
 
 	@Override
-  public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
+	public boolean ensurePDFIsValid(final DataSource dataSource) throws IOException {
 		if (!ignorePDFAErrors && !isValidA1(dataSource)) {
 			throw new IOException("File is not a valid PDF/A-1 input file");
 		}
@@ -85,44 +85,44 @@ public class ZUGFeRDExporterFromA1 extends ZUGFeRDExporterFromA3 {
 
 
 	@Override
-  public ZUGFeRDExporterFromA1 load(String pdfFilename) throws IOException {
+	public ZUGFeRDExporterFromA1 load(String pdfFilename) throws IOException {
 		return (ZUGFeRDExporterFromA1) super.load(pdfFilename);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 load(byte[] pdfBinary) throws IOException {
+	public ZUGFeRDExporterFromA1 load(byte[] pdfBinary) throws IOException {
 		return (ZUGFeRDExporterFromA1) super.load(pdfBinary);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 load(InputStream pdfSource) throws IOException{
+	public ZUGFeRDExporterFromA1 load(InputStream pdfSource) throws IOException {
 		return (ZUGFeRDExporterFromA1) super.load(pdfSource);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setCreator(String creator) {
+	public ZUGFeRDExporterFromA1 setCreator(String creator) {
 		return (ZUGFeRDExporterFromA1) super.setCreator(creator);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setConformanceLevel(PDFAConformanceLevel newLevel) {
+	public ZUGFeRDExporterFromA1 setConformanceLevel(PDFAConformanceLevel newLevel) {
 		return (ZUGFeRDExporterFromA1) super.setConformanceLevel(newLevel);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setProducer(String producer){
+	public ZUGFeRDExporterFromA1 setProducer(String producer) {
 		return (ZUGFeRDExporterFromA1) super.setProducer(producer);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setZUGFeRDVersion(EStandard est, int version){
+	public ZUGFeRDExporterFromA1 setZUGFeRDVersion(EStandard est, int version) {
 		return (ZUGFeRDExporterFromA1) super.setZUGFeRDVersion(est, version);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setZUGFeRDVersion(int version){
+	public ZUGFeRDExporterFromA1 setZUGFeRDVersion(int version) {
 		return (ZUGFeRDExporterFromA1) super.setZUGFeRDVersion(version);
 	}
 	@Override
-  public ZUGFeRDExporterFromA1 setXML(byte[] zugferdData) throws IOException{
+	public ZUGFeRDExporterFromA1 setXML(byte[] zugferdData) throws IOException {
 		return (ZUGFeRDExporterFromA1) super.setXML(zugferdData);
 	}
 
 	@Override
-  public ZUGFeRDExporterFromA1 disableAutoClose(boolean disableAutoClose){
+	public ZUGFeRDExporterFromA1 disableAutoClose(boolean disableAutoClose) {
 		return (ZUGFeRDExporterFromA1) super.disableAutoClose(disableAutoClose);
 	}
 	public ZUGFeRDExporterFromA1 convertOnly() {

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
@@ -79,49 +79,20 @@ import jakarta.activation.DataSource;
 import jakarta.activation.FileDataSource;
 
 public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporter {
-
+	public static final int defaultZUGFeRDVersion = 2;
 	private static final String XML_DESCRIPTION = "Invoice metadata conforming to ZUGFeRD standard (https://www.ferd-net.de/en/standards/zugferd/factur-x)";
 
-	private boolean isFacturX = true;
-	
-	public static final int DefaultZUGFeRDVersion = 2;
-	protected boolean ignorePDFAErrors = false;
+	protected boolean ignorePDFAErrors;
 
-	public ZUGFeRDExporterFromA3 ignorePDFAErrors() {
-		this.ignorePDFAErrors = true;
-		return this;
-	}
-
-	protected PDFAConformanceLevel conformanceLevel = PDFAConformanceLevel.UNICODE;
-	protected ArrayList<FileAttachment> fileAttachments = new ArrayList<>();
-
-	/**
-	 * This flag controls whether or not the metadata is overwritten, or kind of merged.
-	 * The merging probably needs to be overhauled, but for my purpose it was good enough.
-	 */
-	protected boolean overwrite = true;
-
-	public ZUGFeRDExporterFromA3 setOverwrite(boolean overwrite) {
-		this.overwrite = overwrite;
-		return this;
-	}
-
-	private boolean disableAutoClose;
-	private boolean fileAttached = false;
-	private Profile profile = null;
-	protected boolean documentPrepared = false;
-
-	/** Defines whether attachments to the PDF should be using FLATE compression */
-	private boolean compressionEnabled = false;
-
+	protected boolean documentPrepared;
 	/**
 	 * Data (XML invoice) to be added to the ZUGFeRD PDF. It may be externally set,
 	 * in which case passing a IZUGFeRDExportableTransaction is not necessary. By
 	 * default it is null meaning the caller needs to pass a
 	 * IZUGFeRDExportableTransaction for the XML to be populated.
 	 */
-	protected PDMetadata metadata = null;
-	protected XMPMetadata xmp = null;
+	protected PDMetadata metadata;
+	protected XMPMetadata xmp;
 	/**
 	 * Producer attribute for PDF
 	 */
@@ -153,13 +124,47 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	protected PDDocument doc;
 
-	protected int ZFVersion = DefaultZUGFeRDVersion;
-	private boolean attachZUGFeRDHeaders = true;
-
+	protected int zfVersion = defaultZUGFeRDVersion;
 
 	// Specific metaData version in case of XRechnung. We need it to be settable
 	// by the caller if necessary.
-	protected String XRechnungVersion = null; // Default XRechnung as of late 2021 is 2p0
+	protected String xRechnungVersion; // Default XRechnung as of late 2021 is 2p0
+
+	protected PDFAConformanceLevel conformanceLevel = PDFAConformanceLevel.UNICODE;
+
+	protected ArrayList<FileAttachment> fileAttachments = new ArrayList<>();
+
+	/**
+	 * This flag controls whether or not the metadata is overwritten, or kind of merged.
+	 * The merging probably needs to be overhauled, but for my purpose it was good enough.
+	 */
+	protected boolean overwrite = true;
+
+	private boolean isFacturX = true;
+	private boolean disableAutoClose;
+	private boolean fileAttached;
+	private Profile profile;
+
+	/** Defines whether attachments to the PDF should be using FLATE compression */
+	private boolean compressionEnabled;
+
+	private boolean attachZUGFeRDHeaders = true;
+
+	public ZUGFeRDExporterFromA3() {
+		super();
+		setZUGFeRDVersion(ZUGFeRDExporterFromA3.defaultZUGFeRDVersion);
+
+	}
+
+	public ZUGFeRDExporterFromA3 ignorePDFAErrors() {
+		this.ignorePDFAErrors = true;
+		return this;
+	}
+
+	public ZUGFeRDExporterFromA3 setOverwrite(boolean overwrite) {
+		this.overwrite = overwrite;
+		return this;
+	}
 
 	/**
 	 * Makes A PDF/A3a-compliant document from a PDF-A1 compliant document (on the
@@ -275,7 +280,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 * @param XRechnungVersion the XRechnung version
 	 */
 	public void setXRechnungSpecificVersion(String XRechnungVersion) {
-		this.XRechnungVersion = XRechnungVersion;
+		this.xRechnungVersion = XRechnungVersion;
 	}
 
 
@@ -298,12 +303,6 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		ensurePDFIsValid(new ByteArrayDataSource(new ByteArrayInputStream(pdfBinary)));
 		doc = Loader.loadPDF(pdfBinary);
 		return this;
-	}
-
-	public ZUGFeRDExporterFromA3() {
-		super();
-		setZUGFeRDVersion(ZUGFeRDExporterFromA3.DefaultZUGFeRDVersion);
-
 	}
 
 	public void attachFile(FileAttachment file) {
@@ -433,9 +432,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 		Map<String, PDComplexFileSpecification> oldNamesMap = efTree.getNames();
 		if (oldNamesMap != null) {
-			for (String key : oldNamesMap.keySet()) {
-				namesMap.put(key, oldNamesMap.get(key));
-			}
+			namesMap.putAll(oldNamesMap);
 		}
 		namesMap.put(filename, fs);
 		efTree.setNames(namesMap);
@@ -557,21 +554,21 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		String metaDataVersion = null; // default will be used
 
 		// The XRechnung version may be settable from outside.
-		if ((this.XRechnungVersion != null) && (this.profile != null) &&
+		if ((this.xRechnungVersion != null) && (this.profile != null) &&
 			this.profile.getName().equalsIgnoreCase(Profiles.getByName("XRECHNUNG").getName())) {
-			metaDataVersion = this.XRechnungVersion;
+			metaDataVersion = this.xRechnungVersion;
 		}
 
 		if (attachZUGFeRDHeaders) {
-			XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, ZFVersion, isFacturX, xmlProvider.getProfile(),
-				getNamespaceForVersion(ZFVersion), getPrefixForVersion(ZFVersion),
-				getFilenameForVersion(ZFVersion, xmlProvider.getProfile()), metaDataVersion);
+			XMPSchemaZugferd zf = new XMPSchemaZugferd(metadata, zfVersion, isFacturX, xmlProvider.getProfile(),
+				getNamespaceForVersion(zfVersion), getPrefixForVersion(zfVersion),
+				getFilenameForVersion(zfVersion, xmlProvider.getProfile()), metaDataVersion);
 
 			metadata.addSchema(zf);
 		}
 
-		XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, ZFVersion, attachZUGFeRDHeaders);
-		pdfaex.setZUGFeRDVersion(ZFVersion);
+		XMPSchemaPDFAExtensions pdfaex = new XMPSchemaPDFAExtensions(this, metadata, zfVersion, attachZUGFeRDHeaders);
+		pdfaex.setZUGFeRDVersion(zfVersion);
 		metadata.addSchema(pdfaex);
 	}
 
@@ -598,7 +595,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 						removeCIDSetFromPDResources(cidSet, xr);
 					}
 				}
-				
+
 				// Check for fonts in document-resources:
 				removeCIDSetFromPDResources(cidSet, res);
 			}
@@ -607,26 +604,19 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	private void removeCIDSetFromPDResources(COSName cidSet, PDResources res) throws IOException {
 		for (COSName fontName : res.getFontNames()) {
-			try {
-				PDFont pdFont = res.getFont(fontName);
-				if (pdFont instanceof PDType0Font) {
-					PDType0Font typedFont = (PDType0Font) pdFont;
+			PDFont pdFont = res.getFont(fontName);
+			if (pdFont instanceof PDType0Font) {
+				PDType0Font typedFont = (PDType0Font) pdFont;
 
-					if (typedFont.getDescendantFont() instanceof PDCIDFontType2) {
-						@SuppressWarnings("unused")
-						PDCIDFontType2 f = (PDCIDFontType2) typedFont.getDescendantFont();
-						PDFontDescriptor fontDescriptor = pdFont.getFontDescriptor();
-
-						fontDescriptor.getCOSObject().removeItem(cidSet);
-					}
+				if (typedFont.getDescendantFont() instanceof PDCIDFontType2) {
+					PDFontDescriptor fontDescriptor = pdFont.getFontDescriptor();
+					fontDescriptor.getCOSObject().removeItem(cidSet);
 				}
-			} catch (IOException e) {
-				throw e;
 			}
 			// do stuff with the font
 		}
 	}
-	
+
 	protected void prepareDocument() throws IOException {
 
 		PDDocumentCatalog cat = doc.getDocumentCatalog();
@@ -684,13 +674,13 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	public IExporter prepare() throws IOException {
 		prepareDocument();
 		xmlProvider.generateXML(trans);
-		String filename = getFilenameForVersion(ZFVersion, xmlProvider.getProfile());
+		String filename = getFilenameForVersion(zfVersion, xmlProvider.getProfile());
 
 		String relationship = "Alternative";
 		// ZUGFeRD 2.1.1 Technical Supplement | Part A | 2.2.2. Data Relationship
 		// See documentation ZUGFeRD211_EN/Documentation/ZUGFeRD-2.1.1 - Specification_TA_Part-A.pdf
 		// https://www.ferd-net.de/standards/zugferd-2.1.1/index.html
-		if ((this.profile != null) && (ZFVersion >= 2)) {
+		if ((this.profile != null) && (zfVersion >= 2)) {
 			if (this.profile.getName().equalsIgnoreCase(Profiles.getByName("MINIMUM").getName()) ||
 				this.profile.getName().equalsIgnoreCase(Profiles.getByName("BASICWL").getName())) {
 				relationship = "Data";
@@ -743,8 +733,9 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 */
 	protected void writeAdobePDFSchema(XMPMetadata xmp) {
 		AdobePDFSchema pdf = getAdobePDFSchema(xmp);
-		if (overwrite || isBlank(pdf.getProducer()))
+		if (overwrite || isBlank(pdf.getProducer())) {
 			pdf.setProducer(producer);
+		}
 	}
 
 	/**
@@ -756,11 +747,13 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 */
 	protected AdobePDFSchema getAdobePDFSchema(XMPMetadata xmp) {
 		AdobePDFSchema pdf = xmp.getAdobePDFSchema();
-		if (pdf != null)
-			if (overwrite)
+		if (pdf != null) {
+			if (overwrite) {
 				xmp.removeSchema(pdf);
-			else
+			} else {
 				return pdf;
+			}
+		}
 		return xmp.createAndAddAdobePDFSchema();
 	}
 
@@ -781,22 +774,27 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	protected PDFAIdentificationSchema getPDFAIdentificationSchema(XMPMetadata xmp) {
 		PDFAIdentificationSchema pdfaid = xmp.getPDFAIdentificationSchema();
-		if (pdfaid != null)
-			if (overwrite)
+		if (pdfaid != null) {
+			if (overwrite) {
 				xmp.removeSchema(pdfaid);
-			else
+			} else {
 				return pdfaid;
+			}
+		}
 		return xmp.createAndAddPDFAIdentificationSchema();
 	}
 
 	protected void writeDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = getDublinCoreSchema(xmp);
-		if (dc.getFormat() == null)
+		if (dc.getFormat() == null) {
 			dc.setFormat("application/pdf");
-		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null)
+		}
+		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null) {
 			dc.addCreator(creator);
-		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null)
+		}
+		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null) {
 			dc.addDate(Calendar.getInstance());
+		}
 
 		ArrayProperty titleProperty = dc.getTitleProperty();
 		if (titleProperty != null) {
@@ -814,49 +812,62 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = xmp.getDublinCoreSchema();
-		if (dc != null)
-			if (overwrite)
+		if (dc != null) {
+			if (overwrite) {
 				xmp.removeSchema(dc);
-			else
+			} else {
 				return dc;
+			}
+		}
 		return xmp.createAndAddDublinCoreSchema();
 	}
 
 	protected void writeXMLBasicSchema(XMPMetadata xmp) {
 		XMPBasicSchema xsb = getXmpBasicSchema(xmp);
-		if (overwrite || isBlank(xsb.getCreatorTool()) || "UnknownApplication".equals(xsb.getCreatorTool()))
+		if (overwrite || isBlank(xsb.getCreatorTool()) || "UnknownApplication".equals(xsb.getCreatorTool())) {
 			xsb.setCreatorTool(creatorTool);
-		if (overwrite || xsb.getCreateDate() == null)
+		}
+		if (overwrite || xsb.getCreateDate() == null) {
 			xsb.setCreateDate(Calendar.getInstance());
+		}
 	}
 
 	protected XMPBasicSchema getXmpBasicSchema(XMPMetadata xmp) {
 		XMPBasicSchema xsb = xmp.getXMPBasicSchema();
-		if (xsb != null)
-			if (overwrite)
+		if (xsb != null) {
+			if (overwrite) {
 				xmp.removeSchema(xsb);
-			else
+			} else {
 				return xsb;
+			}
+		}
 		return xmp.createAndAddXMPBasicSchema();
 	}
 
 	protected void writeDocumentInformation() {
 		String fullProducer = producer + " (via mustangproject.org " + Version.VERSION + ")";
 		PDDocumentInformation info = doc.getDocumentInformation();
-		if (overwrite || info.getCreationDate() == null)
+		if (overwrite || info.getCreationDate() == null) {
 			info.setCreationDate(Calendar.getInstance());
-		if (overwrite || info.getModificationDate() == null)
+		}
+		if (overwrite || info.getModificationDate() == null) {
 			info.setModificationDate(Calendar.getInstance());
-		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author)))
+		}
+		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author))) {
 			info.setAuthor(author);
-		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer)))
+		}
+		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer))) {
 			info.setProducer(fullProducer);
-		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator)))
+		}
+		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator))) {
 			info.setCreator(creator);
-		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title)))
+		}
+		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title))) {
 			info.setTitle(title);
-		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject)))
+		}
+		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject))) {
 			info.setSubject(subject);
+		}
 	}
 
 	/**
@@ -864,14 +875,12 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 *
 	 * @throws IOException if the ICC file cannot be read or attached to doc
 	 */
-	protected void addSRGBOutputIntend()
-		throws IOException {
+	protected void addSRGBOutputIntend() throws IOException {
 		if (!doc.getDocumentCatalog().getOutputIntents().isEmpty()) {
 			return;
 		}
 
-		try {
-			InputStream colorProfile = Thread.currentThread().getContextClassLoader().getResourceAsStream("sRGB.icc");
+		try (InputStream colorProfile = Thread.currentThread().getContextClassLoader().getResourceAsStream("sRGB.icc")) {
 			if (colorProfile != null) {
 				PDOutputIntent intent = new PDOutputIntent(doc, colorProfile);
 				intent.setInfo("sRGB IEC61966-2.1");
@@ -880,8 +889,6 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 				intent.setRegistryName("http://www.color.org");
 				doc.getDocumentCatalog().addOutputIntent(intent);
 			}
-		} catch (IOException e) {
-			throw e;
 		}
 	}
 
@@ -929,12 +936,12 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	}
 
 	public ZUGFeRDExporterFromA3 setZUGFeRDVersion(EStandard est, int version) {
-		this.ZFVersion = version;
+		this.zfVersion = version;
 		if ((version < 1) || (version > 2)) {
 			throw new IllegalArgumentException("Version not supported");
 		}
 		int generation = version;
-		if ((est == EStandard.facturx) && (version == 1)) {
+		if ((est == EStandard.FACTUR_X) && (version == 1)) {
 			generation = 2;
 		}
 		if (generation == 1) {
@@ -952,7 +959,7 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 	@Override
 	public ZUGFeRDExporterFromA3 setZUGFeRDVersion(int version) {
-		this.ZFVersion = version;
+		this.zfVersion = version;
 		if (version == 1) {
 			ZUGFeRD1PullProvider z1p = new ZUGFeRD1PullProvider();
 			disableFacturX();

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromPDFA.java
@@ -50,7 +50,7 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 
 	protected IZUGFeRDExporter theExporter;
 
-	protected boolean ignorePDFAErrors = false;
+	protected boolean ignorePDFAErrors;
 
 	public ZUGFeRDExporterFromPDFA ignorePDFAErrors() {
 		this.ignorePDFAErrors = true;
@@ -60,12 +60,12 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 		if (PDFAVersion == 3) {
 			theExporter = new ZUGFeRDExporterFromA3();
 			if (ignorePDFAErrors) {
-				((ZUGFeRDExporterFromA3)theExporter).ignorePDFAErrors();
+				((ZUGFeRDExporterFromA3) theExporter).ignorePDFAErrors();
 			}
 		} else if (PDFAVersion == 1) {
 			theExporter = new ZUGFeRDExporterFromA1();
 			if (ignorePDFAErrors) {
-				((ZUGFeRDExporterFromA1)theExporter).ignorePDFAErrors();
+				((ZUGFeRDExporterFromA1) theExporter).ignorePDFAErrors();
 			}
 		} else {
 			throw new IllegalArgumentException("PDF-A version not supported");
@@ -75,7 +75,7 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 	}
 
 	public IZUGFeRDExporter getExporter() {
-		if (theExporter==null) {
+		if (theExporter == null) {
 			throw new RuntimeException("In ZUGFeRDExporterFromPDFA, source must always be loaded before other operations are performed.");
 		}
 
@@ -88,7 +88,7 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 		}
 	}
 
-	protected byte[] inputstreamToByteArray(InputStream fileInputStream) throws IOException  {
+	protected byte[] inputstreamToByteArray(InputStream fileInputStream) throws IOException {
 		byte[] bytes = new byte[fileInputStream.available()];
 		try (DataInputStream dataInputStream = new DataInputStream(fileInputStream)) {
 			dataInputStream.readFully(bytes);
@@ -162,7 +162,7 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 	 * @throws IOException if anything is wrong with inputstream
 	 */
 	public IZUGFeRDExporter load(InputStream pdfSource) throws IOException {
-		byte[] byteArray=inputstreamToByteArray(pdfSource);
+		byte[] byteArray = inputstreamToByteArray(pdfSource);
 		determineAndSetExporter(getPDFAVersion(byteArray));
 		return theExporter.load(byteArray);
 	}
@@ -178,7 +178,7 @@ public class ZUGFeRDExporterFromPDFA implements IZUGFeRDExporter {
 
 	public IZUGFeRDExporter setProfile(String profileName) {
 		Profile p = Profiles.getByName(profileName);
-		if (p==null)  {
+		if (p == null) {
 			throw new RuntimeException("Profile not found.");
 		}
 		return getExporter().setProfile(p);

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -6,6 +6,8 @@
  * and limitations under the License.
  */
 package org.mustangproject.ZUGFeRD;
+import java.io.IOException;
+import java.io.InputStream;
 /**
  * Mustangproject's ZUGFeRD implementation ZUGFeRD importer Licensed under the APLv2
  *
@@ -13,25 +15,27 @@ package org.mustangproject.ZUGFeRD;
  * @version 1.1.0
  * @author jstaerk
  */
-import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 
-import org.mustangproject.*;
+import org.mustangproject.FileAttachment;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.SchemedID;
+import org.mustangproject.XMLTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ZUGFeRDImporter.class);
@@ -54,6 +58,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 	 * for XML embedded files please use ZUGFeRDInvoiceImporter.getFileAttachmentsXML
 	 * @return a ArrayList of FileAttachments, empty if none
 	 */
+	@Override
 	public List<FileAttachment> getFileAttachmentsPDF() {
 		return pdfAttachments;
 	}
@@ -205,7 +210,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 	 */
 	public String getBuyertradePartySpecifiedTaxRegistrationID() {
 		String id = null;
-		if  ((importedInvoice.getRecipient()!=null) && (importedInvoice.getRecipient().getLegalOrganisation()!=null)) {
+		if (importedInvoice.getRecipient() != null && importedInvoice.getRecipient().getLegalOrganisation() != null) {
 			// this *should* be the official result
 			id = importedInvoice.getRecipient().getLegalOrganisation().getSchemedID().getID();
 		}
@@ -276,11 +281,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 	 */
 	public String getTaxPointDate() {
 		try {
-			if (getVersion() == 1) {
-				return extractString("//*[local-name() = 'ActualDeliverySupplyChainEvent']//*[local-name() = 'OccurrenceDateTime']//*[local-name() = 'DateTimeString']");
-			} else {
-				return extractString("//*[local-name() = 'ActualDeliverySupplyChainEvent']//*[local-name() = 'OccurrenceDateTime']//*[local-name() = 'DateTimeString']");
-			}
+			return extractString("//*[local-name() = 'ActualDeliverySupplyChainEvent']//*[local-name() = 'OccurrenceDateTime']//*[local-name() = 'DateTimeString']");
 		} catch (final Exception e) {
 			// Exception was already logged
 			return "";
@@ -340,7 +341,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 	 * @return the sender's account IBAN code
 	 */
 	public String getIBAN() {
-		if ((importedInvoice==null)||(importedInvoice.getTradeSettlement()==null)) {
+		if (importedInvoice == null || importedInvoice.getTradeSettlement() == null) {
 			return null;
 		}
 		for (IZUGFeRDTradeSettlement settlement : importedInvoice.getTradeSettlement()) {
@@ -356,7 +357,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 
 
 	public String getHolder() {
-		if (importedInvoice!=null && importedInvoice.getTradeSettlement()!=null) {
+		if (importedInvoice != null && importedInvoice.getTradeSettlement() != null) {
 			for (IZUGFeRDTradeSettlement settlement : importedInvoice.getTradeSettlement()) {
 				if (settlement instanceof IZUGFeRDTradeSettlementPayment) {
 					String s = ((IZUGFeRDTradeSettlementPayment) settlement).getAccountName();
@@ -631,6 +632,8 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 									address.setCountrySubDivisionName(n.getFirstChild().getNodeValue());
 								}
 								break;
+							default:
+								break;
 						}
 					}
 				}
@@ -757,7 +760,7 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 							node = getNodeByName(nn.getChildNodes(), "ApplicableTradeTax");
 							if (node != null) {
 								node = getNodeByName(node.getChildNodes(), "CategoryCode");
-								if(node != null){
+								if (node != null) {
 									lineItem.getProduct().setTaxCategoryCode(XMLTools.getNodeValue(node));
 								}
 							}
@@ -803,6 +806,8 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 								node = getNodeByName(node.getChildNodes(), "LineTotalAmount");
 								lineItem.setLineTotalAmount(XMLTools.tryBigDecimal(node));
 							}
+							break;
+						default:
 							break;
 					}
 				}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -1,28 +1,5 @@
 package org.mustangproject.ZUGFeRD;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
-import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
-import org.apache.pdfbox.pdmodel.common.PDNameTreeNode;
-import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
-import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
-import org.mustangproject.*;
-import org.mustangproject.Exceptions.StructureException;
-import org.mustangproject.util.NodeMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -50,6 +27,45 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
+import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
+import org.apache.pdfbox.pdmodel.common.PDNameTreeNode;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDComplexFileSpecification;
+import org.apache.pdfbox.pdmodel.common.filespecification.PDEmbeddedFile;
+import org.mustangproject.Allowance;
+import org.mustangproject.BankDetails;
+import org.mustangproject.CalculatedInvoice;
+import org.mustangproject.CashDiscount;
+import org.mustangproject.Charge;
+import org.mustangproject.DirectDebit;
+import org.mustangproject.EStandard;
+import org.mustangproject.FileAttachment;
+import org.mustangproject.IncludedNote;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.LogisticsServiceCharge;
+import org.mustangproject.ReferencedDocument;
+import org.mustangproject.SchemedID;
+import org.mustangproject.TradeParty;
+import org.mustangproject.XMLTools;
+import org.mustangproject.Exceptions.StructureException;
+import org.mustangproject.util.NodeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 
 public class ZUGFeRDInvoiceImporter {
 
@@ -65,15 +81,15 @@ public class ZUGFeRDInvoiceImporter {
 	/**
 	 * if metadata has been found
 	 */
-	protected boolean containsMeta = false;
+	protected boolean containsMeta;
 	/**
 	 * Raw XML form of the extracted data - may be directly obtained.
 	 */
-	protected byte[] rawXML = null;
+	protected byte[] rawXML;
 	/**
 	 * XMP metadata
 	 */
-	protected String xmpString = null; // XMP metadata
+	protected String xmpString; // XMP metadata
 	/**
 	 * parsed Document
 	 */
@@ -83,10 +99,10 @@ public class ZUGFeRDInvoiceImporter {
 	 */
 	protected boolean parseAutomatically = true;
 	protected Integer version;
-	protected CalculatedInvoice importedInvoice = null;
-	protected boolean recalcPrice = false;
-	protected boolean ignoreCalculationErrors = false;
-	protected boolean containsAXMLFileAttachment = false;
+	protected CalculatedInvoice importedInvoice;
+	protected boolean recalcPrice;
+	protected boolean ignoreCalculationErrors;
+	protected boolean containsAXMLFileAttachment;
 
 	public ZUGFeRDInvoiceImporter() {
 		//constructor for extending classes
@@ -151,7 +167,7 @@ public class ZUGFeRDInvoiceImporter {
 					return;
 				}
 
-				try (final InputStream XMP = doc.getDocumentCatalog().getMetadata().exportXMPMetadata()) {
+				try (InputStream XMP = doc.getDocumentCatalog().getMetadata().exportXMPMetadata()) {
 					xmpString = new String(XMLTools.getBytesFromStream(XMP), StandardCharsets.UTF_8);
 				}
 
@@ -534,8 +550,8 @@ public class ZUGFeRDInvoiceImporter {
 		xpr = xpath.compile("//*[local-name()=\"SpecifiedTradeSettlementHeaderMonetarySummation\"]/*[local-name()=\"TaxTotalAmount\"]|//*[local-name()=\"TaxTotal\"]/*[local-name()=\"TaxAmount\"]");
 		NodeList taxTotalNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
 		if (taxTotalNodes.getLength() > 0) {
-			String taxTotalStr=XMLTools.trimOrNull(taxTotalNodes.item(0));
-			if ((zpp instanceof CalculatedInvoice)&&(taxTotalStr!=null)) {
+			String taxTotalStr = XMLTools.trimOrNull(taxTotalNodes.item(0));
+			if (zpp instanceof CalculatedInvoice && taxTotalStr != null) {
 				((CalculatedInvoice) zpp).setVATtotal(new BigDecimal(taxTotalStr));
 			}
 		}
@@ -641,7 +657,7 @@ public class ZUGFeRDInvoiceImporter {
 		}
 		zpp.addNotes(includedNotes);
 		String rootNode = extractString("local-name(/*)");
-		String potentialCashDiscountTerms=null;
+		String potentialCashDiscountTerms;
 		if (rootNode != null && Arrays.asList("Invoice", "CreditNote").contains(rootNode)) {
 			// UBL...
 			// //*[local-name()="Invoice" or local-name()="CreditNote"]
@@ -654,7 +670,7 @@ public class ZUGFeRDInvoiceImporter {
 			}
 
 			String tenderReference = extractString("/*[local-name()=\"Invoice\" or local-name()=\"CreditNote\"]/*[local-name()=\"OriginatorDocumentReference\"]/*[local-name()=\"ID\"]").trim();
-			if((tenderReference != null)&&(!tenderReference.isEmpty())){
+			if (tenderReference != null && !tenderReference.isEmpty()) {
 				zpp.setTenderReferencedDocument(tenderReference);
 			}
 
@@ -664,7 +680,7 @@ public class ZUGFeRDInvoiceImporter {
 			}
 			String deliveryDt = extractString("//*[local-name()=\"Delivery\"]/*[local-name()=\"ActualDeliveryDate\"]").trim();
 			if (!deliveryDt.isEmpty()) {
-				deliveryDate =  parseDate(deliveryDt, "yyyy-MM-dd");
+				deliveryDate = parseDate(deliveryDt, "yyyy-MM-dd");
 			}
 		} else {
 			//CII
@@ -672,7 +688,7 @@ public class ZUGFeRDInvoiceImporter {
 
 		}
 
-		String creditorReferenceID = extractString("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"CreditorReferenceID\"]").trim();//BT-90
+		String creditorReferenceID = extractString("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"CreditorReferenceID\"]").trim(); //BT-90
 		if (creditorReferenceID == null || creditorReferenceID.isEmpty()) {
 			//maybe it's there in UBL?
 			creditorReferenceID = extractString("//*[local-name()=\"AccountingSupplierParty\"]/*[local-name()=\"Party\"]/*[local-name()=\"PartyIdentification\"]/*[local-name()=\"ID\"]").trim();
@@ -824,7 +840,7 @@ public class ZUGFeRDInvoiceImporter {
 								zpp.setTenderReferencedDocument(referencedDocument);
 							}
 						} else if (typeC == 130) {
-							if (additionalReferencedDocumentID != null){
+							if (additionalReferencedDocumentID != null) {
 								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
 								referencedDocument.setName(additionalReferencedDocumentName);
 								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
@@ -832,7 +848,7 @@ public class ZUGFeRDInvoiceImporter {
 								zpp.setObjectIdentifierReferencedDocument(referencedDocument);
 							}
 						} else if (typeC == 916) {
-							if (additionalReferencedDocumentID != null){
+							if (additionalReferencedDocumentID != null) {
 								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
 								referencedDocument.setName(additionalReferencedDocumentName);
 								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
@@ -918,10 +934,10 @@ public class ZUGFeRDInvoiceImporter {
 						if ((paymentMeansChilds.item(paymentMeansChildIndex).getLocalName() != null) && (paymentMeansChilds.item(paymentMeansChildIndex).getLocalName().equals("PayeePartyCreditorFinancialAccount") || paymentMeansChilds.item(paymentMeansChildIndex).getLocalName().equals("PayerPartyDebtorFinancialAccount"))) {
 							NodeList accountChilds = paymentMeansChilds.item(paymentMeansChildIndex).getChildNodes();
 							for (int accountChildIndex = 0; accountChildIndex < accountChilds.getLength(); accountChildIndex++) {
-								if ((accountChilds.item(accountChildIndex).getLocalName() != null) && (accountChilds.item(accountChildIndex).getLocalName().equals("IBANID"))) {//CII
+								if (accountChilds.item(accountChildIndex).getLocalName() != null && accountChilds.item(accountChildIndex).getLocalName().equals("IBANID")) { //CII
 									IBAN = XMLTools.trimOrNull(accountChilds.item(accountChildIndex));
 								}
-								if ((accountChilds.item(accountChildIndex).getLocalName() != null) && (accountChilds.item(accountChildIndex).getLocalName().equals("AccountName"))) {//CII
+								if (accountChilds.item(accountChildIndex).getLocalName() != null && accountChilds.item(accountChildIndex).getLocalName().equals("AccountName")) { //CII
 									accountName = XMLTools.trimOrNull(accountChilds.item(accountChildIndex));
 								}
 							}
@@ -929,7 +945,7 @@ public class ZUGFeRDInvoiceImporter {
 						if ((paymentMeansChilds.item(paymentMeansChildIndex).getLocalName() != null) && (paymentMeansChilds.item(paymentMeansChildIndex).getLocalName().equals("PayeeSpecifiedCreditorFinancialInstitution"))) {
 							NodeList accountChilds = paymentMeansChilds.item(paymentMeansChildIndex).getChildNodes();
 							for (int accountChildIndex = 0; accountChildIndex < accountChilds.getLength(); accountChildIndex++) {
-								if ((accountChilds.item(accountChildIndex).getLocalName() != null) && (accountChilds.item(accountChildIndex).getLocalName().equals("BICID"))) {//CII
+								if (accountChilds.item(accountChildIndex).getLocalName() != null && accountChilds.item(accountChildIndex).getLocalName().equals("BICID")) { //CII
 									BIC = XMLTools.trimOrNull(accountChilds.item(accountChildIndex));
 								}
 							}
@@ -955,7 +971,7 @@ public class ZUGFeRDInvoiceImporter {
 
 							NodeList startPeriodChilds = periodChilds.item(periodChildIndex).getChildNodes();
 							for (int startPeriodIndex = 0; startPeriodIndex < startPeriodChilds.getLength(); startPeriodIndex++) {
-								if ((startPeriodChilds.item(startPeriodIndex).getLocalName() != null) && (startPeriodChilds.item(startPeriodIndex).getLocalName().equals("DateTimeString"))) {//CII
+								if (startPeriodChilds.item(startPeriodIndex).getLocalName() != null && startPeriodChilds.item(startPeriodIndex).getLocalName().equals("DateTimeString")) { //CII
 									deliveryPeriodStart = XMLTools.trimOrNull(startPeriodChilds.item(startPeriodIndex));
 								}
 							}
@@ -963,7 +979,7 @@ public class ZUGFeRDInvoiceImporter {
 						if ((periodChilds.item(periodChildIndex).getLocalName() != null) && (periodChilds.item(periodChildIndex).getLocalName().equals("EndDateTime"))) {
 							NodeList endPeriodChilds = periodChilds.item(periodChildIndex).getChildNodes();
 							for (int endPeriodIndex = 0; endPeriodIndex < endPeriodChilds.getLength(); endPeriodIndex++) {
-								if ((endPeriodChilds.item(endPeriodIndex).getLocalName() != null) && (endPeriodChilds.item(endPeriodIndex).getLocalName().equals("DateTimeString"))) {//CII
+								if (endPeriodChilds.item(endPeriodIndex).getLocalName() != null && endPeriodChilds.item(endPeriodIndex).getLocalName().equals("DateTimeString")) { //CII
 									deliveryPeriodEnd = XMLTools.trimOrNull(endPeriodChilds.item(endPeriodIndex));
 								}
 							}
@@ -1184,7 +1200,7 @@ public class ZUGFeRDInvoiceImporter {
 			// be read,
 			// so the invoice remains arithmetically correct
 			// -> parse document level charges+allowances
-			xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedTradeAllowanceCharge\"]|/*[local-name()=\"Invoice\" or local-name()=\"CreditNote\"]/*[local-name()=\"AllowanceCharge\"]");//CII and UBL
+			xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedTradeAllowanceCharge\"]|/*[local-name()=\"Invoice\" or local-name()=\"CreditNote\"]/*[local-name()=\"AllowanceCharge\"]"); //CII and UBL
 			NodeList chargeNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
 			for (int i = 0; i < chargeNodes.getLength(); i++) {
 				NodeList chargeNodeChilds = chargeNodes.item(i).getChildNodes();
@@ -1314,7 +1330,7 @@ public class ZUGFeRDInvoiceImporter {
 				}
 
 			}
-			xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedLogisticsServiceCharge\"]");// UBL unknown
+			xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeSettlement\"]/*[local-name()=\"SpecifiedLogisticsServiceCharge\"]"); // UBL unknown
 			chargeNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
 			for (int i = 0; i < chargeNodes.getLength(); i++) {
 				NodeList chargeNodeChilds = chargeNodes.item(i).getChildNodes();
@@ -1347,13 +1363,13 @@ public class ZUGFeRDInvoiceImporter {
 				}
 			}
 
-			xpr = xpath.compile("//*[local-name()=\"SpecifiedTradePaymentTerms\"]/*[local-name()=\"ApplicableTradePaymentDiscountTerms\"]");// cash discounts, UBL unknown
+			xpr = xpath.compile("//*[local-name()=\"SpecifiedTradePaymentTerms\"]/*[local-name()=\"ApplicableTradePaymentDiscountTerms\"]"); // cash discounts, UBL unknown
 			NodeList cashdiscountNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
 			for (int i = 0; i < cashdiscountNodes.getLength(); i++) {
 				NodeList cashDiscountNodeChilds = cashdiscountNodes.item(i).getChildNodes();
-				CashDiscount cd=new CashDiscount();
+				CashDiscount cd = new CashDiscount();
 				for (int cashDiscountChildIndex = 0; cashDiscountChildIndex < cashDiscountNodeChilds.getLength(); cashDiscountChildIndex++) {
-					Node currentNode=cashDiscountNodeChilds.item(cashDiscountChildIndex);
+					Node currentNode = cashDiscountNodeChilds.item(cashDiscountChildIndex);
 					String chargeChildName = currentNode.getLocalName();
 					if (chargeChildName != null) {
 						if (chargeChildName.equals("BasisPeriodMeasure")) {
@@ -1387,24 +1403,24 @@ public class ZUGFeRDInvoiceImporter {
 					}
 				}
 
-				if ((cd.getPercent() != null)&&(cd.getDays() != null)) {
+				if (cd.getPercent() != null && cd.getDays() != null) {
 					zpp.addCashDiscount(cd);
 				}
 			}
-			if ((potentialCashDiscountTerms!=null&&potentialCashDiscountTerms.length()>3)) {
-				for (String currentLine:potentialCashDiscountTerms.split("\\n")) {
+			if ((potentialCashDiscountTerms != null && potentialCashDiscountTerms.length() > 3)) {
+				for (String currentLine : potentialCashDiscountTerms.split("\\n")) {
 					if (currentLine.startsWith("#SKONTO#")) {
-						CashDiscount cd=new CashDiscount();
+						CashDiscount cd = new CashDiscount();
 						Pattern pattern = Pattern.compile("#TAGE=(.*?)#", Pattern.CASE_INSENSITIVE);
 						Matcher matcher = pattern.matcher(currentLine);
 						boolean daysFound = matcher.find();
-						String days=matcher.group(1);
+						String days = matcher.group(1);
 						pattern = Pattern.compile("#PROZENT=(.*?)#", Pattern.CASE_INSENSITIVE);
 						matcher = pattern.matcher(currentLine);
 						boolean percentFound = matcher.find();
-						String percent=matcher.group(1);
+						String percent = matcher.group(1);
 
-						if (daysFound&&percentFound) {
+						if (daysFound && percentFound) {
 							cd.setDays(Integer.valueOf(days));
 							cd.setPercent(new BigDecimal(percent));
 							zpp.addCashDiscount(cd);
@@ -1432,7 +1448,7 @@ public class ZUGFeRDInvoiceImporter {
 				throw new StructureException("Could not find out if it's an invoice, order, or delivery advice", 0);
 			}
 
-			if (whichType != EStandard.despatchadvice && !ignoreCalculationErrors) {
+			if (whichType != EStandard.DELIVER_X && !ignoreCalculationErrors) {
 				// Check calculation if document type allows it and calculation errors should not be ignored
 
 				String payableTotalFromXml = XMLTools.nDigitFormat(duePayableAmount != null ? duePayableAmount : expectedGrandTotal, 2);
@@ -1443,8 +1459,8 @@ public class ZUGFeRDInvoiceImporter {
 							+ Stream.of(tc.trans.getZFItems())
 							.map(item -> item.getCalculation().getItemTotalNetAmount().toPlainString())
 							.collect(Collectors.joining(" + "));
-						if (tc.trans.getRoundingAmount()!=null) {
-							moreDetails += " and rounding amount "+tc.trans.getRoundingAmount().toPlainString();
+						if (tc.trans.getRoundingAmount() != null) {
+							moreDetails += " and rounding amount " + tc.trans.getRoundingAmount().toPlainString();
 						}
 					} catch (Exception ignored) {
 						// ignore
@@ -1497,17 +1513,17 @@ public class ZUGFeRDInvoiceImporter {
 		final String head = getUTF8();
 		String rootNode = extractString("local-name(/*)");
 		if (rootNode.equals("CrossIndustryDocument")) {
-			return EStandard.zugferd;
+			return EStandard.ZUGFERD;
 		} else if (rootNode.equals("Invoice")) {
-			return EStandard.ubl;
+			return EStandard.UBL;
 		} else if (rootNode.equals("CreditNote")) {
-			return EStandard.ubl_creditnote;
+			return EStandard.UBL_CREDITNOTE;
 		} else if (rootNode.equals("CrossIndustryInvoice")) {
-			return EStandard.facturx;
+			return EStandard.FACTUR_X;
 		} else if (rootNode.equals("SCRDMCCBDACIDAMessageStructure")) {
-			return EStandard.despatchadvice;
+			return EStandard.DELIVER_X;
 		} else if (head.contains("<rsm:SCRDMCCBDACIOMessageStructure")) {
-			return EStandard.orderx;
+			return EStandard.ORDER_X;
 		}
 
 		throw new Exception("ZUGFeRD version could not be determined");

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -21,10 +21,13 @@
 package org.mustangproject.ZUGFeRD;
 
 import com.helger.commons.io.stream.StreamHelper;
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.io.IOUtils;
-import org.apache.fop.apps.*;
+import org.apache.fop.apps.FOPException;
+import org.apache.fop.apps.FOUserAgent;
+import org.apache.fop.apps.Fop;
+import org.apache.fop.apps.FopFactory;
+import org.apache.fop.apps.FopFactoryBuilder;
 import org.apache.fop.apps.io.ResourceResolverFactory;
 import org.apache.fop.configuration.Configuration;
 import org.apache.fop.configuration.ConfigurationException;
@@ -40,11 +43,30 @@ import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.*;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.*;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumMap;
 import java.util.Optional;
@@ -74,13 +96,13 @@ public class ZUGFeRDVisualizer {
 	// }
 	// return result;
 	// }
-	private TransformerFactory mFactory = null;
-	private Templates mXsltXRTemplate = null;
-	private Templates mXsltUBLTemplate = null;
-	private Templates mXsltCIOTemplate = null;
-	private EnumMap<Language, Templates> mXsltHTMLTemplates = null;
-	private Templates mXsltPDFTemplate = null;
-	private Templates mXsltZF1HTMLTemplate = null;
+	private TransformerFactory mFactory;
+	private Templates mXsltXRTemplate;
+	private Templates mXsltUBLTemplate;
+	private Templates mXsltCIOTemplate;
+	private EnumMap<Language, Templates> mXsltHTMLTemplates;
+	private Templates mXsltPDFTemplate;
+	private Templates mXsltZF1HTMLTemplate;
 
 	public ZUGFeRDVisualizer() {
 		mFactory = XMLTools.getTransformerFactory();
@@ -106,15 +128,15 @@ public class ZUGFeRDVisualizer {
 			Document doc = db.parse(new InputSource(fis));
 			Element root = doc.getDocumentElement();
 			if (root.getLocalName().equals(zf1Signature)) {
-				return EStandard.zugferd;
+				return EStandard.ZUGFERD;
 			} else if (root.getLocalName().equals(zf2Signature)) {
-				return EStandard.facturx;
+				return EStandard.FACTUR_X;
 			} else if (root.getLocalName().equals(ublSignature)) {
-				return EStandard.ubl;
+				return EStandard.UBL;
 			} else if (root.getLocalName().equals(ublCreditNoteSignature)) {
-				return EStandard.ubl_creditnote;
+				return EStandard.UBL_CREDITNOTE;
 			} else if (root.getLocalName().equals(cioSignature)) {
-				return EStandard.orderx;
+				return EStandard.ORDER_X;
 			}
 		} catch (Exception e) {
 			LOGGER.error("Failed to recognize standard", e);
@@ -140,19 +162,19 @@ public class ZUGFeRDVisualizer {
 
 		ByteArrayInputStream xmlContentStream = new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8));
 
-		if (thestandard == EStandard.zugferd) {
+		if (thestandard == EStandard.ZUGFERD) {
 			applyZF1XSLT(xmlContentStream, htmlOutput);
 			return htmlOutput.toString(StandardCharsets.UTF_8);
-		} else if (thestandard == EStandard.facturx) {
+		} else if (thestandard == EStandard.FACTUR_X) {
 			//zf2 or fx
 			applyZF2XSLT(xmlContentStream, htmlOutput);
-		} else if (thestandard == EStandard.ubl) {
+		} else if (thestandard == EStandard.UBL) {
 			//zf2 or fx
 			applyUBL2XSLT(xmlContentStream, htmlOutput);
-		} else if (thestandard == EStandard.ubl_creditnote) {
+		} else if (thestandard == EStandard.UBL_CREDITNOTE) {
 			//zf2 or fx
 			applyUBLCreditNote2XSLT(xmlContentStream, htmlOutput);
-		} else if (thestandard == EStandard.orderx) {
+		} else if (thestandard == EStandard.ORDER_X) {
 			//zf2 or fx
 			applyCIO2XSLT(xmlContentStream, htmlOutput);
 		} else {
@@ -207,10 +229,7 @@ public class ZUGFeRDVisualizer {
 		if (mXsltHTMLTemplates == null) {
 			mXsltHTMLTemplates = new EnumMap<>(Language.class);
 		}
-		if (mXsltHTMLTemplates.get(lang) == null) {
-			Templates mXsltHTMLTemplate = mFactory.newTemplates(new StreamSource(CLASS_LOADER.getResourceAsStream(RESOURCE_PATH + "stylesheets/xrechnung-html." + lang.name().toLowerCase() + ".xsl")));
-			mXsltHTMLTemplates.put(lang, mXsltHTMLTemplate);
-		}
+		mXsltHTMLTemplates.putIfAbsent(lang, mFactory.newTemplates(new StreamSource(CLASS_LOADER.getResourceAsStream(RESOURCE_PATH + "stylesheets/xrechnung-html." + lang.name().toLowerCase() + ".xsl"))));
 		if (mXsltZF1HTMLTemplate == null) {
 			mXsltZF1HTMLTemplate = mFactory.newTemplates(new StreamSource(
 				CLASS_LOADER.getResourceAsStream(RESOURCE_PATH + "stylesheets/ZUGFeRD_1p0_c1p0_s1p0.xslt")));
@@ -223,7 +242,7 @@ public class ZUGFeRDVisualizer {
 		try (FileInputStream fis = new FileInputStream(xmlFilename)) {
 			theStandard = findOutStandardFromRootNode(fis);
 		}
-		
+
 		try (FileInputStream fis = new FileInputStream(xmlFilename)) {
 			return toFOP(fis, theStandard, lang);
 		}
@@ -244,11 +263,11 @@ public class ZUGFeRDVisualizer {
 		ByteArrayOutputStream iaos = new ByteArrayOutputStream();
 
 		//zf2 or fx
-		if (theStandard == EStandard.facturx) {
+		if (theStandard == EStandard.FACTUR_X) {
 			applyZF2XSLT(is, iaos);
-		} else if (theStandard == EStandard.ubl) {
+		} else if (theStandard == EStandard.UBL) {
 			applyUBL2XSLT(is, iaos);
-		} else if (theStandard == EStandard.ubl_creditnote) {
+		} else if (theStandard == EStandard.UBL_CREDITNOTE) {
 			applyUBLCreditNote2XSLT(is, iaos);
 		}
 
@@ -264,7 +283,7 @@ public class ZUGFeRDVisualizer {
 	public void toPDF(String xmlFilename, String pdfFilename) {
 		toPDF(xmlFilename, pdfFilename, Language.DE);
 	}
-	
+
 	public void toPDF(String xmlFilename, String pdfFilename, Language lang) {
 
 		// the writing part
@@ -280,7 +299,7 @@ public class ZUGFeRDVisualizer {
 		} catch (TransformerException | IOException | ParserConfigurationException e) {
 			LOGGER.error("Failed to apply FOP", e);
 		}
-		
+
 		toPDFfromFOP(fopInput, () -> {
 				try {
 					return new FileOutputStream(pdfFilename);
@@ -288,13 +307,13 @@ public class ZUGFeRDVisualizer {
 					LOGGER.error("Failed to create PDF", e);
 				}
 			return null;
-		}, (OutputStream out) -> {});
+		}, (OutputStream out) -> { });
 	}
 
 	public byte[] toPDF(String xmlContent) {
 		return toPDF(xmlContent, Language.DE);
 	}
-	
+
 	public byte[] toPDF(String xmlContent, Language lang) {
 
 		String fopInput = null;
@@ -305,8 +324,8 @@ public class ZUGFeRDVisualizer {
 		try {
 			ByteArrayInputStream fis = new ByteArrayInputStream(xmlContent.getBytes(StandardCharsets.UTF_8));
 			EStandard theStandard = findOutStandardFromRootNode(fis);
-			fis = new ByteArrayInputStream(xmlContent.getBytes(StandardCharsets.UTF_8));//rewind :-(
-			
+			fis = new ByteArrayInputStream(xmlContent.getBytes(StandardCharsets.UTF_8)); //rewind :-(
+
 			fopInput = toFOP(fis, theStandard, lang);
 		} catch (TransformerException | IOException | ParserConfigurationException e) {
 			LOGGER.error("Failed to apply FOP", e);
@@ -315,7 +334,7 @@ public class ZUGFeRDVisualizer {
 		AtomicReference<byte[]> byteHolder = new AtomicReference<>();
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
 		toPDFfromFOP(fopInput, () -> new BufferedOutputStream(os), (OutputStream out) -> {
-			
+
 			try {
 				out.flush();
 			} catch (IOException e) {
@@ -323,10 +342,10 @@ public class ZUGFeRDVisualizer {
 			}
 			byteHolder.set(os.toByteArray());
 		});
-		
+
 		return byteHolder.get();
 	}
-	
+
 	private void toPDFfromFOP(String fopInput, Supplier<OutputStream> outputStreamDelegate, Consumer<OutputStream> consumerDelegate) {
 
 		DefaultConfigurationBuilder cfgBuilder = new DefaultConfigurationBuilder();
@@ -342,7 +361,7 @@ public class ZUGFeRDVisualizer {
 // Step 1: Construct a FopFactory by specifying a reference to the configuration file
 // (reuse if you plan to render multiple documents!)
 
-		FopFactory fopFactory = builder.build();//FopFactory.newInstance(new File("c:\\Users\\jstaerk\\temp\\fop-config.xconf"));
+		FopFactory fopFactory = builder.build(); //FopFactory.newInstance(new File("c:\\Users\\jstaerk\\temp\\fop-config.xconf"));
 
 		fopFactory.getFontManager().setResourceResolver(
 			ResourceResolverFactory.createInternalResourceResolver(
@@ -362,8 +381,7 @@ public class ZUGFeRDVisualizer {
 			Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
 
 			// Step 4: Setup JAXP using identity transformer
-			TransformerFactory factory = TransformerFactory.newInstance();
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			TransformerFactory factory = XMLTools.getTransformerFactory();
 			Transformer transformer = factory.newTransformer(); // identity transformer
 
 			// Step 5: Setup input and output for XSLT transformation
@@ -375,7 +393,7 @@ public class ZUGFeRDVisualizer {
 
 			// Step 6: Start XSLT transformation and FOP processing
 			transformer.transform(src, res);
-			
+
 			consumerDelegate.accept(out);
 
 		} catch (FOPException | IOException | TransformerException e) {

--- a/library/src/main/java/org/mustangproject/util/NodeMap.java
+++ b/library/src/main/java/org/mustangproject/util/NodeMap.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -106,7 +105,7 @@ public class NodeMap {
 	 * @return the text content of the matching node, converted to BigDecimal
 	 */
 	public Optional<BigDecimal> getAsBigDecimal(String... localNames) {
-		return getNode(localNames).map(Node::getTextContent).map(s->{
+		return getNode(localNames).map(Node::getTextContent).map(s -> {
 			try {
 				return new BigDecimal(s.trim());
 			} catch (NumberFormatException e) {

--- a/library/src/main/java/org/mustangproject/util/StringUtils.java
+++ b/library/src/main/java/org/mustangproject/util/StringUtils.java
@@ -1,11 +1,12 @@
 package org.mustangproject.util;
 
-public class StringUtils {
-	private StringUtils() {}
+public final class StringUtils {
+	private StringUtils() { }
 
 	public static boolean isBlank(String str) {
 		return str == null || str.isBlank();
 	}
+
 	public static boolean isNotBlank(String str) {
 		return !isBlank(str);
 	}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DXTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DXTest.java
@@ -332,7 +332,7 @@ public class DXTest extends MustangReaderTestCase {
 		Invoice i = createDA(recipient);
 
 		DAPullProvider zf2p = new DAPullProvider();
-		zf2p.setProfile(Profiles.getByName(EStandard.despatchadvice,"Pilot",1));
+		zf2p.setProfile(Profiles.getByName(EStandard.DELIVER_X,"Pilot",1));
 		zf2p.generateXML(i);
 		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
 		try {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -46,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 
 import static org.xmlunit.assertj.XmlAssert.assertThat;
 
@@ -231,7 +230,7 @@ public class XRTest extends TestCase {
 			.evaluate(taxNode2);
 		Assertions.assertTrue(BigDecimal.valueOf(5).compareTo(new BigDecimal(basisAmount2)) == 0);
 	}
-	
+
 	public void testXRExportWithoutStreet() {
 
 		// the writing part
@@ -260,7 +259,7 @@ public class XRTest extends TestCase {
 		}
 
 	}
-	
+
 	public void testTaxExemptionReasonIssue() {
 		String orgname = "Test company";
 		String number = "123";
@@ -289,7 +288,7 @@ public class XRTest extends TestCase {
 			.asInt()
 			.isEqualTo(2);
 	}
-	
+
 
 	public void testApplicablePercentInUntaxedService() {
 

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -349,7 +349,7 @@ public class ZF2PushTest extends TestCase {
 	public void testItemAllowanceChargePercentBasisExport() {
 		Invoice invoice = new Invoice().setNumber("1").setIssueDate(new Date()).setDueDate(new Date())
 			.setSender(new TradeParty("Seller", "Street", "12345", "City", "DE").addVATID("DE123456789"))
-			.setRecipient(new TradeParty("Buyer", "Street", "12345", "City", "DE"))
+			.setRecipient(new TradeParty("Buyer", "Street", "12345", "City", "DE").setVATID("DE123456789"))
 			.addItem(new Item(new Product("Item", "", "C62", new BigDecimal("19")), new BigDecimal("80.00"), new BigDecimal("5"))
 				.addAllowance(new Allowance(new BigDecimal("40.00"))
 					.setPercent(new BigDecimal("10.00"))
@@ -612,7 +612,7 @@ public class ZF2PushTest extends TestCase {
 			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile(Profiles.getByName("en16931"));
 			ze.setTransaction(new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
-				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE08154711"))
 				.setNumber(number)
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
@@ -393,10 +393,11 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		int version=-1;
 		try {
 			zii.fromXML(new String(Files.readAllBytes(Paths.get("./target/testout-XR-Edge.xml")), StandardCharsets.UTF_8));
-			version=zii.getVersion();
+			version = zii.getVersion();
 		} catch (IOException e) {
 			hasExceptions = true;
 		} catch (Exception e) {
+			e.printStackTrace();
 			throw new RuntimeException(e);
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
             </plugins>
         </pluginManagement>
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -156,7 +155,23 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>verify-style</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/validator/src/main/java/org/mustangproject/validator/IrrecoverableValidationError.java
+++ b/validator/src/main/java/org/mustangproject/validator/IrrecoverableValidationError.java
@@ -3,9 +3,10 @@ package org.mustangproject.validator;
 public class IrrecoverableValidationError extends Exception {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
+
 	public IrrecoverableValidationError(String message) {
 		super(message);
 	}

--- a/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Map.Entry;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
@@ -20,9 +21,9 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.mustangproject.util.ByteArraySearcher;
 import org.mustangproject.XMLTools;
 import org.mustangproject.ZUGFeRD.ZUGFeRDImporter;
+import org.mustangproject.util.ByteArraySearcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.verapdf.features.FeatureExtractorConfig;
@@ -47,13 +48,25 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 public class PDFValidator extends Validator {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PDFValidator.class.getCanonicalName()); // log output
+
+	private static final PDFAFlavour[] PDF_A_3_FLAVOURS = {PDFAFlavour.PDFA_3_A, PDFAFlavour.PDFA_3_B, PDFAFlavour.PDFA_3_U};
+
+	private String pdfFilename;
+
+	private byte[] fileContents;
+
+	private String pdfReport;
+
+	private ProcessorResult processorResult;
+
+	private String signature;
+
+	private String zfXML;
 
 	public PDFValidator(ValidationContext ctx) {
 		super(ctx);
 	}
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(PDFValidator.class.getCanonicalName()); // log output
-	private static final PDFAFlavour[] PDF_A_3_FLAVOURS = {PDFAFlavour.PDFA_3_A, PDFAFlavour.PDFA_3_B, PDFAFlavour.PDFA_3_U};
 
 	private static String escapeXmlSpecialChars(String value) {
 		if (value == null || value.isEmpty()) {
@@ -67,25 +80,12 @@ public class PDFValidator extends Validator {
 			.replace("'", "&apos;");
 	}
 
-	private String pdfFilename;
-
-	private byte[] fileContents;
-
-	private String pdfReport;
-	private ProcessorResult processorResult = null;
-
-	private String Signature;
-
-	private String zfXML = null;
-	protected boolean autoload = true;
-
 	protected static boolean stringArrayContains(String[] arr, String targetValue) {
 		return Arrays.asList(arr).contains(targetValue);
 	}
 
 	@Override
 	public void validate() throws IrrecoverableValidationError {
-
 		zfXML = null;
 		// file existence must have been checked before
 		if (!ByteArraySearcher.startsWith(fileContents, new byte[]{'%', 'P', 'D', 'F'})) {
@@ -124,19 +124,19 @@ public class PDFValidator extends Validator {
 			ItemDetails itemDetails = ItemDetails.fromValues(pdfFilename);
 			inputStream.mark(Integer.MAX_VALUE);
 			processorResult = processor.process(itemDetails, inputStream);
-			pdfReport = escapeXmlSpecialChars(processorResult.getValidationResult().toString().replaceAll(
+			pdfReport = escapeXmlSpecialChars(processorResult.getValidationResult().toString().replace(
 				"<\\?xml version=\"1\\.0\" encoding=\"utf-8\"\\?>",
 				""
 			));
 			inputStream.reset();
 		} catch (final Exception excep) {
 			context.addResultItem(new ValidationResultItem(ESeverity.exception, excep.getMessage()).setSection(7)
-				.setPart(EPart.pdf).setStacktrace(excep.getStackTrace().toString()));
+				.setPart(EPart.pdf).setStacktrace(Arrays.toString(excep.getStackTrace())));
 		}
 
 		// step 2 validate XMP
 		final ZUGFeRDImporter zi = new ZUGFeRDImporter();
-		zi.doIgnoreCalculationErrors();//of course the calculation will still be schematron checked
+		zi.doIgnoreCalculationErrors(); //of course the calculation will still be schematron checked
 		zi.setInputStream(inputStream);
 
 		String xmp;
@@ -304,39 +304,39 @@ public class PDFValidator extends Validator {
 		final byte[] sevdeskSignature = "sevdesk".getBytes(StandardCharsets.UTF_8);
 
 		if (ByteArraySearcher.contains(fileContents, symtraxSignature)) {
-			Signature = "Symtrax";
+			signature = "Symtrax";
 		} else if (ByteArraySearcher.contains(fileContents, mustangSignature)) {
-			Signature = "Mustang";
+			signature = "Mustang";
 		} else if (ByteArraySearcher.contains(fileContents, facturxpythonSignature)) {
-			Signature = "Factur/X Python";
+			signature = "Factur/X Python";
 		} else if (ByteArraySearcher.contains(fileContents, intarsysSignature)) {
-			Signature = "Intarsys";
+			signature = "Intarsys";
 		} else if (ByteArraySearcher.contains(fileContents, konikSignature)) {
-			Signature = "Konik";
+			signature = "Konik";
 		} else if (ByteArraySearcher.contains(fileContents, pdfMachineSignature)) {
-			Signature = "pdfMachine";
+			signature = "pdfMachine";
 		} else if (ByteArraySearcher.contains(fileContents, ghostscriptSignature)) {
-			Signature = "Ghostscript";
+			signature = "Ghostscript";
 		} else if (ByteArraySearcher.contains(fileContents, cibpdfbrewerSignature)) {
-			Signature = "CIB pdf brewer";
+			signature = "CIB pdf brewer";
 		} else if (ByteArraySearcher.contains(fileContents, lexofficeSignature)) {
-			Signature = "Lexware office";
+			signature = "Lexware office";
 		} else if (ByteArraySearcher.contains(fileContents, s2IndustriesSignature)) {
-			Signature = "ZUGFeRD.PDF-csharp";
+			signature = "ZUGFeRD.PDF-csharp";
 		} else if (ByteArraySearcher.contains(fileContents, factoorSharpSignature)) {
-			Signature = "FactoorSharp";
+			signature = "FactoorSharp";
 		} else if (ByteArraySearcher.contains(fileContents, sevdeskSignature)) {
-			Signature = "sevdesk";
+			signature = "sevdesk";
 		}
 
-		context.setSignature(Signature);
+		context.setSignature(signature);
 
 		// step 4:validate additional data
 		final HashMap<String, byte[]> additionalData = zi.getAdditionalData();
-		for (final String filename : additionalData.keySet()) {
+		for (final Entry<String, byte[]> entry : additionalData.entrySet()) {
 			// validating xml in byte[]	additionalData.get(filename)
-			LOGGER.info("validating additionalData {}", filename);
-			validateSchema(additionalData.get(filename), "ad/basic/additional_data_base_schema.xsd", 2, EPart.pdf);
+			LOGGER.info("validating additionalData {}", entry.getKey());
+			validateSchema(additionalData.get(entry.getKey()), "ad/basic/additional_data_base_schema.xsd", 2, EPart.pdf);
 		}
 
 
@@ -388,7 +388,7 @@ public class PDFValidator extends Validator {
 	}
 
 	public String getSignature() {
-		return Signature;
+		return signature;
 	}
 
 }

--- a/validator/src/main/java/org/mustangproject/validator/ValidationContext.java
+++ b/validator/src/main/java/org/mustangproject/validator/ValidationContext.java
@@ -9,13 +9,14 @@ import org.slf4j.Logger;
 public class ValidationContext {
 	protected Vector<ValidationResultItem> results;
 	protected String customXML = "";
-	private String format = "CII";// CII or UBL
-	private String generation = null; // generation 1 is ZF1, gen 2 is ZF2, XRechnung, Factur-X or UBL
-	private String profile = null;
-	private String signature = null;
-	private boolean isValid = true;
-	private boolean hasPDF = false;
 	protected Logger logger;
+
+	private String format = "CII"; // CII or UBL
+	private String generation; // generation 1 is ZF1, gen 2 is ZF2, XRechnung, Factur-X or UBL
+	private String profile;
+	private String signature;
+	private boolean isValid = true;
+	private boolean hasPDF;
 	private String filename;
 
 	public ValidationContext(Logger log) {
@@ -24,7 +25,7 @@ public class ValidationContext {
 	}
 
 	public void setHasPDF() {
-		hasPDF=true;
+		hasPDF = true;
 	}
 
 	public boolean hasPDF() {
@@ -60,7 +61,7 @@ public class ValidationContext {
 	public void clearCustomXML() {
 		customXML = "";
 	}
-	
+
 	public void addCustomXML(String XML) {
 		customXML += XML;
 	}
@@ -70,7 +71,7 @@ public class ValidationContext {
 	}
 
 	public void setFormat(String format) {
-		this.format=format;
+		this.format = format;
 	}
 
 	public ValidationContext setGeneration(String version) {
@@ -108,10 +109,6 @@ public class ValidationContext {
 		results.clear();
 		isValid = true;
 		clearCustomXML();
-		generation = null;
-		profile = null;
-		signature = null;
-
 	}
 
 	public String getXMLResult() {
@@ -135,7 +132,7 @@ public class ValidationContext {
 	public String getCSVResult() {
 		final ArrayList<String> errorcodes = new ArrayList<>();
 		for (final ValidationResultItem validationResultItem : results) {
-			final String errorCodeStr=Integer.toString(validationResultItem.getSection());
+			final String errorCodeStr = Integer.toString(validationResultItem.getSection());
 			errorcodes.add(errorCodeStr);
 		}
 		return String.join(",", errorcodes);
@@ -149,7 +146,7 @@ public class ValidationContext {
 		final ArrayList<String> errorIDs = new ArrayList<>();
 		for (final ValidationResultItem validationResultItem : results) {
 			if (!validationResultItem.getID().isEmpty()) {
-				final String errorID=validationResultItem.getID();
+				final String errorID = validationResultItem.getID();
 				errorIDs.add(errorID);
 
 			}
@@ -162,10 +159,10 @@ public class ValidationContext {
 	}
 
 	public void setFilename(String filename) {
-		this.filename=filename;
+		this.filename = filename;
 	}
 	public String getFilename() {
-		if (filename==null) {
+		if (filename == null) {
 			return "";
 		} else {
 			return filename;

--- a/validator/src/main/java/org/mustangproject/validator/ValidationResultItem.java
+++ b/validator/src/main/java/org/mustangproject/validator/ValidationResultItem.java
@@ -1,26 +1,19 @@
 package org.mustangproject.validator;
 
 import org.mustangproject.XMLTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ValidationResultItem {
-	private static final Logger LOGGER = LoggerFactory.getLogger(ValidationResultItem.class.getCanonicalName()); // log output is
-	// ignored for the
-	// time being
-
-	
-	protected String message, location=null;
-	protected int section =-1;
-	protected String id =""; // e.g. "FX-SCH-A-000026"
+	protected String message, location;
+	protected int section = -1;
+	protected String id = ""; // e.g. "FX-SCH-A-000026"
 
 
-	private ESeverity severity=ESeverity.error;
-	private String criterion=null;
+	private ESeverity severity = ESeverity.error;
+	private String criterion;
 
 
-	private String stacktrace=null;
-	private boolean hasBeenOutputted=false;
+	private String stacktrace;
+	private boolean hasBeenOutputted;
 
 
 	private EPart part;
@@ -29,65 +22,65 @@ public class ValidationResultItem {
 	public ValidationResultItem(ESeverity sev, String msg) {
 		setSeverity(sev);
 		setMessage(msg);
-		xt=new XMLTools();
+		xt = new XMLTools();
 	}
 	public ValidationResultItem setMessage(String msg) {
-		message=msg;
+		message = msg;
 		return this;
 	}
 
 	public ValidationResultItem setSection(int sec) {
-		section=sec;
+		section = sec;
 		return this;
-	}	
+	}
 	public ValidationResultItem setLocation(String loc) {
-		location=loc;
+		location = loc;
 		return this;
 	}
 	public ValidationResultItem setPart(EPart loc) {
-		part=loc;
+		part = loc;
 		return this;
 	}
 	public EPart getPart() {
 		return part;
 	}
 	public ValidationResultItem setSeverity(ESeverity sev) {
-		severity=sev;
+		severity = sev;
 		return this;
 	}
 	public ValidationResultItem setStacktrace(String stack) {
-		stacktrace=stack;
+		stacktrace = stack;
 		return this;
 	}
-	
-	
+
+
 	public String getXML() {
-		String tagname="error";
-		if (severity==ESeverity.exception) {
-			tagname="exception";
-		} else if (severity==ESeverity.warning) {
-			tagname="warning";
-		} else if (severity==ESeverity.notice) {
-			tagname="notice";
-		} 
-		String additionalAttributes="";
-		String additionalContents="";
-		if (section!=-1) {
-			additionalAttributes+=" type=\""+section+"\"";
+		String tagname = "error";
+		if (severity == ESeverity.exception) {
+			tagname = "exception";
+		} else if (severity == ESeverity.warning) {
+			tagname = "warning";
+		} else if (severity == ESeverity.notice) {
+			tagname = "notice";
 		}
-		if (location!=null) {
-			additionalAttributes+=" location=\""+xt.escapeAttributeEntities(location)+"\"";
+		String additionalAttributes = "";
+		String additionalContents = "";
+		if (section != -1) {
+			additionalAttributes += " type=\"" + section + "\"";
 		}
-		if (criterion!=null) {
-			additionalAttributes+=" criterion=\""+xt.escapeAttributeEntities(criterion)+"\"";
+		if (location != null) {
+			additionalAttributes += " location=\"" + xt.escapeAttributeEntities(location) + "\"";
 		}
-		if (stacktrace!=null) {
-			additionalContents+="<stacktrace>"+xt.escapeAttributeEntities(stacktrace)+"</stacktrace>";
+		if (criterion != null) {
+			additionalAttributes += " criterion=\"" + xt.escapeAttributeEntities(criterion) + "\"";
 		}
-		hasBeenOutputted=true;
-		return "<"+tagname+additionalAttributes+">"+xt.escapeElementEntities(message+additionalContents)+"</"+tagname+">";
+		if (stacktrace != null) {
+			additionalContents += "<stacktrace>" + xt.escapeAttributeEntities(stacktrace) + "</stacktrace>";
+		}
+		hasBeenOutputted = true;
+		return "<" + tagname + additionalAttributes + ">" + xt.escapeElementEntities(message + additionalContents) + "</" + tagname + ">";
 	}
-	
+
 	public String getXMLOnce() {
 		if (!hasBeenOutputted) {
 			return getXML();
@@ -95,7 +88,7 @@ public class ValidationResultItem {
 			return "";
 		}
 	}
-	
+
 	public ValidationResultItem setCriterion(String test) {
 		 criterion = test;
 		 return this;
@@ -105,7 +98,7 @@ public class ValidationResultItem {
 	}
 
 	public ValidationResultItem setID(String id) {
-		this.id=id;
+		this.id = id;
 		return this;
 	}
 

--- a/validator/src/main/java/org/mustangproject/validator/Validator.java
+++ b/validator/src/main/java/org/mustangproject/validator/Validator.java
@@ -16,14 +16,15 @@ import org.xml.sax.SAXException;
 //abstract class
 public abstract class Validator {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Validator.class.getCanonicalName()); // log output
-	
+
 	protected ValidationContext context;
-	protected boolean autoload=true;
-	
-	public Validator(ValidationContext ctx){
-		this.context=ctx;
+
+	protected boolean autoload = true;
+
+	protected Validator(ValidationContext ctx) {
+		this.context = ctx;
 	}
-	
+
 	//abstract method
 
 	/***
@@ -46,7 +47,7 @@ public abstract class Validator {
 	public String getXMLResult() {
 		return context.getXMLResult();
 	}
-	
+
 	/***
 	 * validates a schema, which can only be needed in XML validation - and in pdf validation for additional data
 	 * @param xmlRawData the XML to be validated
@@ -79,7 +80,6 @@ public abstract class Validator {
 	public void setAutoload(boolean autoload) {
 		this.autoload = autoload;
 	}
-
 
 
 }

--- a/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/XMLValidator.java
@@ -50,11 +50,11 @@ public class XMLValidator extends Validator {
 
 	protected String zfXML = "";
 	protected String filename = "";
-	int firedRules = 0;
-	int failedRules = 0;
-	boolean disableNotices = false;
-	boolean disableArithmeticCheck = false;
-	ISchematronResource aResSCH = null;
+	int firedRules;
+	int failedRules;
+	boolean disableNotices;
+	boolean disableArithmeticCheck;
+	ISchematronResource aResSCH;
 
 
 	public XMLValidator(ValidationContext ctx) {
@@ -77,8 +77,8 @@ public class XMLValidator extends Validator {
 
 				final ValidationResultItem vri = new ValidationResultItem(ESeverity.exception, e.getMessage()).setSection(9)
 					.setPart(EPart.fx);
-				try (final StringWriter sw = new StringWriter();
-					 final PrintWriter pw = new PrintWriter(sw)) {
+				try (StringWriter sw = new StringWriter();
+					 PrintWriter pw = new PrintWriter(sw)) {
 					e.printStackTrace(pw);
 					vri.setStacktrace(sw.toString());
 					context.addResultItem(vri);
@@ -193,7 +193,6 @@ public class XMLValidator extends Validator {
 					context.setProfile(booking.getNodeValue());
 				}
 				boolean isOrderX = false;
-				boolean isDespatchAdvice = false;
 				boolean isMiniumum = false;
 				boolean isBasic = false;
 				boolean isBasicWithoutLines = false;
@@ -201,7 +200,7 @@ public class XMLValidator extends Validator {
 				boolean isExtended = false;
 				boolean isXRechnung = false;
 				String currentZFVersionDir = "ZF_250";
-				String currentXPZ12VersionDir ="XP_Z12_012";
+				String currentXPZ12VersionDir = "XP_Z12_012";
 				int mainSchematronSectionErrorTypeCode = 4;
 				String xsltFilename = null;
 				boolean runFrenchCiiSchematron = false;
@@ -221,7 +220,7 @@ public class XMLValidator extends Validator {
 					isExtended = contextProfile.contains("extended");
 					validateSchema(zfXML.getBytes(StandardCharsets.UTF_8), "OX_10/comfort/SCRDMCCBDACIOMessageStructure_100pD20B.xsd", 99, EPart.ox);
 					xsltFilename = "/xslt/OX_10/comfort/SCRDMCCBDACIOMessageStructure_100pD20B_COMFORT.xslt";
-					
+
 				} else if (root.getLocalName().equalsIgnoreCase("CrossIndustryInvoice")) { // ZUGFeRD 2.0 or Factur-X
 					context.setGeneration("2");
 					final String sellerCountry = getXPathString(doc,
@@ -234,7 +233,7 @@ public class XMLValidator extends Validator {
 					isBasic = contextProfile.contains("basic");
 					isBasicWithoutLines = contextProfile.contains("basicwl");
 					if (isBasicWithoutLines) {
-						isBasic = false;// basicwl also contains the string basic...
+						isBasic = false; // basicwl also contains the string basic...
 					}
 					isEN16931 = Arrays.asList(
 							"urn:cen.eu:en16931:2017:compliant:factur-x.eu:1p0:en16931",
@@ -247,7 +246,7 @@ public class XMLValidator extends Validator {
 					isXRechnung = contextProfile.contains("xrechnung");
 
 					if ((isExtended) || (isXRechnung)) {
-						isEN16931 = false;// the uri for extended is urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p0:extended and thus contains en16931...
+						isEN16931 = false; // the uri for extended is urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p0:extended and thus contains en16931...
 					}
 					if (isMiniumum) {
 						LOGGER.debug("is Minimum");
@@ -305,7 +304,7 @@ public class XMLValidator extends Validator {
 						* */
 						//validateSchema(zfXML.getBytes(StandardCharsets.UTF_8), "ZF_211/EN16931/FACTUR-X_EN16931.xsd", 18, EPart.fx);
 						String xrVersion = contextProfile.substring(contextProfile.length() - 3).replace(".", "");
-						
+
 						List<String> supportedVersions = Arrays.asList("12", "20", "21", "22", "23", "30");
 						if (!supportedVersions.contains(xrVersion)) {
 							throw new Exception("Unsupported XR version");
@@ -355,7 +354,7 @@ public class XMLValidator extends Validator {
 					} else /** v1 */ {
 						if (isOrderX) {
 							//order-x 1.0
-							if(Arrays.asList(
+							if (Arrays.asList(
 								"urn:order-x.eu:1p0:basic",
 								"urn:order-x.eu:1p0:comfort",
 								"urn:order-x.eu:1p0:extended"
@@ -453,10 +452,10 @@ public class XMLValidator extends Validator {
 	}
 
 	private void checkArithmetics(ValidationContext context) {
-		ZUGFeRDInvoiceImporter zi=new ZUGFeRDInvoiceImporter();
+		ZUGFeRDInvoiceImporter zi = new ZUGFeRDInvoiceImporter();
 		try {
 			zi.fromXML(zfXML);
-			CalculatedInvoice ci=new CalculatedInvoice();
+			CalculatedInvoice ci = new CalculatedInvoice();
 			zi.extractInto(ci);
 
 			// check sub invoice line hierarchy if present
@@ -464,7 +463,7 @@ public class XMLValidator extends Validator {
 
 		} catch ( ArithmeticException e) {
 			try {
-				context.addResultItem(new ValidationResultItem(ESeverity.warning, "Arithmetical issue:"+e.getMessage()).setSection(10));
+				context.addResultItem(new ValidationResultItem(ESeverity.warning, "Arithmetical issue:" + e.getMessage()).setSection(10));
 
 			} catch (IrrecoverableValidationError ie) {
 				LOGGER.error(ie.getMessage(), ie);

--- a/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/ZUGFeRDValidator.java
@@ -29,7 +29,6 @@ import org.mustangproject.XMLTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
 import com.helger.commons.io.stream.StreamHelper;
@@ -46,11 +45,11 @@ public class ZUGFeRDValidator {
 	protected boolean displayXMLValidationOutput;
 	protected long startTime;
 	protected boolean optionsRecognized;
-	protected boolean disableNotices = false;
-	protected boolean disableArithmeticCheck = false;
-	protected String Signature;
-	protected boolean wasCompletelyValid = false;
-	protected String logAppend = null;
+	protected boolean disableNotices;
+	protected boolean disableArithmeticCheck;
+	protected String signature;
+	protected boolean wasCompletelyValid;
+	protected String logAppend;
 
 	/***
 	 * within the validation it turned out something in the options was wrong, e.g.
@@ -91,7 +90,7 @@ public class ZUGFeRDValidator {
 		SimpleDateFormat isoDF = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 		Date date = new Date();
 		startTime = Calendar.getInstance().getTimeInMillis();
-		context.setFilename(contextFilename);// fallback to provided name
+		context.setFilename(contextFilename); // fallback to provided name
 		finalStringResult.append("<validation filename='").append(contextFilename).append("' datetime='").append(isoDF.format(date)).append("'>");
 
 		boolean isPDF = false;
@@ -160,8 +159,8 @@ public class ZUGFeRDValidator {
 						InputSource is = new InputSource(new StringReader(xmlAsString));
 						Document doc = db.parse(is);
 
-						Element root = doc.getDocumentElement();
-						isXML = true;//no exception so far
+						doc.getDocumentElement();
+						isXML = true; //no exception so far
 
 					} catch (Exception ex) {
 						// probably no xml file, sth like SAXParseException content not allowed in prolog
@@ -276,8 +275,8 @@ public class ZUGFeRDValidator {
 		finalStringResult.append(pdfv.getXMLResult());
 		pdfValidity = context.isValid();
 
-		Signature = context.getSignature();
-		context.clear();// clear sets valid to true again
+		signature = context.getSignature();
+		context.clear(); // clear sets valid to true again
 		if (pdfv.getRawXML() != null) {
 			xv.setStringContent(pdfv.getRawXML());
 			displayXMLValidationOutput = true;
@@ -324,9 +323,9 @@ public class ZUGFeRDValidator {
 
 
 		LOGGER.info("Parsed PDF:" + pdfResult + " XML:" + (xmlValidity ? "valid" : "invalid")
-			+ " Signature:" + Signature + " Checksum:" + sha1Checksum + " Profile:" + context.getProfile()
+			+ " Signature:" + signature + " Checksum:" + sha1Checksum + " Profile:" + context.getProfile()
 			+ " Version:" + context.getGeneration() + " Took:" + duration + "ms Errors:[" + context.getCSVResult()
-			+ "] ErrorIDs: [" + context.getCSVIDResult()  + "]" + toBeAppended);
+			+ "] ErrorIDs: [" + context.getCSVIDResult() + "]" + toBeAppended);
 		wasCompletelyValid = xmlValidity;
 		return sw.toString();
 	}

--- a/validator/src/test/java/org/mustangproject/validator/MiscValidatorTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/MiscValidatorTest.java
@@ -13,24 +13,24 @@ public class MiscValidatorTest extends ResourceCase  {
 		ZUGFeRDValidator zfv=new ZUGFeRDValidator();
 
 		String res=zfv.validate(null);
-    assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" + 
-        "\n" + 
-        "<validation filename=\"\" datetime=\".*?\">\n" + 
-        "  <messages>\n" + 
-        "    <error type=\"10\">Filename not specified</error> \n" + 
-        "  </messages>\n" + 
-        "  <summary status=\"invalid\"/>\n" + 
-        "</validation>\n" + 
+    assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" +
+        "\n" +
+        "<validation filename=\"\" datetime=\".*?\">\n" +
+        "  <messages>\n" +
+        "    <error type=\"10\">Filename not specified</error> \n" +
+        "  </messages>\n" +
+        "  <summary status=\"invalid\"/>\n" +
+        "</validation>\n" +
         ""));
 
 		res=zfv.validate("/dhfkbv/sfjkh");
-		assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" + 
-				"\n" + 
-				"<validation filename=\"sfjkh\" datetime=\".*?\">\n" + 
-				"  <messages>\n" + 
-				"    <error type=\"1\">File not found</error> \n" + 
-				"  </messages>\n" + 
-				"  <summary status=\"invalid\"/>\n" + 
+		assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" +
+				"\n" +
+				"<validation filename=\"sfjkh\" datetime=\".*?\">\n" +
+				"  <messages>\n" +
+				"    <error type=\"1\">File not found</error> \n" +
+				"  </messages>\n" +
+				"  <summary status=\"invalid\"/>\n" +
 				"</validation>\n"));
 
 		boolean noExceptionOccurred=true;
@@ -43,17 +43,17 @@ public class MiscValidatorTest extends ResourceCase  {
 		assertTrue(noExceptionOccurred);
 
 		res=zfv.validate(tempFile.getAbsolutePath());
-		assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" + 
-				"\n" + 
-				"<validation filename=\".*\" datetime=\".*\">\n" + 
-				"  <messages>\n" + 
-				"    <error type=\"5\">File too small</error> \n" + 
-				"  </messages>\n" + 
-				"  <summary status=\"invalid\"/>\n" + 
-				"</validation>\n" + 
+		assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" +
+				"\n" +
+				"<validation filename=\".*\" datetime=\".*\">\n" +
+				"  <messages>\n" +
+				"    <error type=\"5\">File too small</error> \n" +
+				"  </messages>\n" +
+				"  <summary status=\"invalid\"/>\n" +
+				"</validation>\n" +
 				""));
-		
-		
+
+
 		String fileContent = "ladhvkdbfk  wkhfbkhdhkb svbkfsvbksfbvk sdvsdvbksjdvbkfdsv sdvbskdvbsjhkvbfskh dvbskfvbkfsbvke"
 				+ "ladhvkdbfk  wkhfbkhdhkb svbkfsvbksfbvk sdvsdvbksjdvbkfdsv sdvbskdvbsjhkvbfskh dvbskfvbkfsbvke";
 		noExceptionOccurred=true;
@@ -66,23 +66,23 @@ public class MiscValidatorTest extends ResourceCase  {
 			noExceptionOccurred=false;
 		}
 		assertTrue(noExceptionOccurred);
- 
 
-		res=zfv.validate(tempFile.getAbsolutePath());
-		assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" + 
-				"\n" + 
-				"<validation filename=\".*\" datetime=\".*\">\n" + 
-				"  <messages>\n" + 
-				"    <exception type=\"8\">File does not look like PDF nor XML \\(contains neither %PDF nor &lt;\\?xml\\)</exception> \n" + 
-				"  </messages>\n" + 
-				"  <summary status=\"invalid\"/>\n" + 
-				"</validation>\n" + 
+
+		res = zfv.validate(tempFile.getAbsolutePath());
+		assertTrue(res.matches("<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n" +
+				"\n" +
+				"<validation filename=\".*\" datetime=\".*\">\n" +
+				"  <messages>\n" +
+				"    <exception type=\"8\">File does not look like PDF nor XML \\(contains neither %PDF nor &lt;\\?xml\\)</exception> \n" +
+				"  </messages>\n" +
+				"  <summary status=\"invalid\"/>\n" +
+				"</validation>\n" +
 				""));
 
-		
+
 		// clean up
 		tempFile.delete();
-		
+
 	}
-	
+
 }


### PR DESCRIPTION
Added maven-checkstyle-plugin to the root pom.
Active in all sub projects, library, validator and CLI, after compile.
On error, build aborts.

checkstyle.xml is the configuration file for the list of checks to execute.

Example:
```
[INFO] --- compiler:3.13.0:compile (default-compile) @ Mustang-CLI ---
[INFO] Recompiling the module because of changed dependency.
[INFO] Compiling 5 source files with javac [debug release 11] to target\classes
[INFO]
[INFO] --- checkstyle:3.6.0:check (verify-style) @ Mustang-CLI ---
[INFO] There is 1 error reported by Checkstyle 9.3 with checkstyle.xml ruleset.
[ERROR] src\main\java\org\mustangproject\commandline\Main.java:[64,9] (blocks) LeftCurly: '{' an Position 2 sollte in der vorherigen Zeile stehen.
```