### PR TITLE
Refactoring of Invoices DocumentReferences.

### DIFF
--- a/library/src/main/java/org/mustangproject/BankDetails.java
+++ b/library/src/main/java/org/mustangproject/BankDetails.java
@@ -101,14 +101,14 @@ public class BankDetails implements IZUGFeRDTradeSettlementPayment {
 	I'd really like to get rid of all those getOwn... methods some time but in this case they are in the interface :-(
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.15.1")
 	@JsonIgnore
 	public String getOwnBIC() {
 		return getBIC();
 	}
 
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.15.1")
 	@JsonIgnore
 	public String getOwnIBAN() {
 		return getIBAN();

--- a/library/src/main/java/org/mustangproject/Charge.java
+++ b/library/src/main/java/org/mustangproject/Charge.java
@@ -85,6 +85,7 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	/**
 	 * @return the sequenceNumeric
 	 */
+	@Override
 	public Integer getSequenceNumeric() {
 		return sequenceNumeric;
 	}
@@ -215,7 +216,8 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	/**
 	 * @deprecated use getTaxRateApplicablePercent() instead.
 	 */
-	@Deprecated
+	@SuppressWarnings("deprecation")
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	@JsonIgnore
 	@Override
 	public BigDecimal getTaxPercent() {
@@ -228,7 +230,7 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	 * @param percent
 	 * @return
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Charge setTaxPercent(BigDecimal percent) {
 		this.setTaxRateApplicablePercent(percent);
 		return this;
@@ -237,7 +239,8 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	/**
 	 * @deprecated use getTaxCategoryCode() instead.
 	 */
-	@Deprecated
+	@SuppressWarnings("deprecation")
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	@JsonIgnore
 	@Override
 	public String getCategoryCode() {
@@ -249,7 +252,7 @@ public class Charge extends TradeTax implements IZUGFeRDAllowanceCharge {
 	 * @param taxCategoryCode
 	 * @return
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Charge setCategoryCode(String taxCategoryCode) {
 		this.setTaxCategoryCode(taxCategoryCode);
 		return this;

--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -50,16 +50,17 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 public class Invoice implements IExportableTransaction {
 
 	protected boolean testIndicator;
-	protected String documentName, documentCode, number, ownOrganisationFullPlaintextInfo, referenceNumber, shipToOrganisationID, shipToOrganisationName, shipToStreet, shipToZIP, shipToLocation, shipToCountry, buyerOrderReferencedDocumentID, ownForeignOrganisationID, ownOrganisationName, currency, paymentTermDescription;
+	protected String documentName, documentCode, number, ownOrganisationFullPlaintextInfo, referenceNumber, shipToOrganisationID, shipToOrganisationName, shipToStreet, shipToZIP, shipToLocation, shipToCountry, ownForeignOrganisationID, ownOrganisationName, currency, paymentTermDescription;
 	protected String deliveryTypeCode;
-	protected Date issueDate, dueDate, deliveryDate, buyerOrderReferencedDocumentIssueDateTime;
+	protected Date issueDate, dueDate, deliveryDate;
 	protected TradeParty sender, recipient, deliveryAddress, endCustomerDeliveryAddress, payee, invoicer, invoicee;
 	protected ArrayList<CashDiscount> cashDiscounts;
 	@JsonDeserialize(contentAs = Item.class)
 	protected List<IZUGFeRDExportableItem> zfItems;
 	protected ArrayList<String> notes;
-	protected String sellerOrderReferencedDocumentID;
-	protected String contractReferencedDocument;
+	protected ReferencedDocument sellerOrderReferencedDocument;
+	protected ReferencedDocument buyerOrderReferencedDocument;
+	protected ReferencedDocument contractReferencedDocument;
 	protected ArrayList<FileAttachment> xmlEmbeddedFiles;
 
 	protected BigDecimal totalPrepaidAmount;
@@ -73,16 +74,13 @@ public class Invoice implements IExportableTransaction {
 	protected ArrayList<IZUGFeRDLogisticsServiceCharge> logisticsServiceCharges = new ArrayList<>();
 	protected ArrayList<IZUGFeRDPaymentTerms> paymentTerms = new ArrayList<>();
 
-	protected String invoiceReferencedDocumentID;
-	protected Date invoiceReferencedIssueDate;
 	// New field for storing Invoiced Object Identifier (BG-3)
 	protected List<ReferencedDocument> invoiceReferencedDocuments;
 
 	protected String specifiedProcuringProjectID;
 	protected String specifiedProcuringProjectName;
-	protected String despatchAdviceReferencedDocumentID;
-	protected String deliveryNoteReferencedDocumentID;
-	protected Date deliveryNoteReferencedDocumentDate;
+	protected ReferencedDocument despatchAdviceReferencedDocument;
+	protected ReferencedDocument deliveryNoteReferencedDocument;
 	protected String vatDueDateTypeCode;
 	protected String creditorReferenceID; // required when direct debit is used.
 
@@ -113,7 +111,7 @@ public class Invoice implements IExportableTransaction {
 	}
 
 	@Override
-	public String getContractReferencedDocument() {
+	public ReferencedDocument getContractReferencedDocument() {
 		return contractReferencedDocument;
 	}
 
@@ -404,19 +402,38 @@ public class Invoice implements IExportableTransaction {
 		return this;
 	}
 
-	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getBuyerOrderReferencedDocumentID() {
-		return buyerOrderReferencedDocumentID;
+		if (buyerOrderReferencedDocument == null) {
+			return null;
+		} else {
+			return buyerOrderReferencedDocument.getIssuerAssignedID();
+		}
 	}
 
-	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getSellerOrderReferencedDocumentID() {
-		return sellerOrderReferencedDocumentID;
+		if (sellerOrderReferencedDocument == null) {
+			return null;
+		} else {
+			return sellerOrderReferencedDocument.getIssuerAssignedID();
+		}
 	}
 
-
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setSellerOrderReferencedDocumentID(String sellerOrderReferencedDocumentID) {
-		this.sellerOrderReferencedDocumentID = sellerOrderReferencedDocumentID;
+		if (sellerOrderReferencedDocument == null) {
+			sellerOrderReferencedDocument = new ReferencedDocument();
+		}
+		this.sellerOrderReferencedDocument.setIssuerAssignedID(sellerOrderReferencedDocumentID);
+		return this;
+	}
+
+	/**
+	 * @param sellerOrderReferencedDocument the sellerOrderReferencedDocument to set
+	 */
+	public Invoice setSellerOrderReferencedDocument(ReferencedDocument sellerOrderReferencedDocument) {
+		this.sellerOrderReferencedDocument = sellerOrderReferencedDocument;
 		return this;
 	}
 
@@ -425,9 +442,31 @@ public class Invoice implements IExportableTransaction {
 	 * @param buyerOrderReferencedDocumentID string with number
 	 * @return fluent setter
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setBuyerOrderReferencedDocumentID(String buyerOrderReferencedDocumentID) {
-		this.buyerOrderReferencedDocumentID = buyerOrderReferencedDocumentID;
+		if (buyerOrderReferencedDocument == null) {
+			buyerOrderReferencedDocument = new ReferencedDocument();
+		}
+		this.buyerOrderReferencedDocument.setIssuerAssignedID(buyerOrderReferencedDocumentID);
 		return this;
+	}
+
+	@Override
+	public ReferencedDocument getBuyerOrderReferencedDocument() {
+		return buyerOrderReferencedDocument;
+	}
+
+	/**
+	 * @param buyerOrderReferencedDocument the buyerOrderReferencedDocument to set
+	 */
+	public Invoice setBuyerOrderReferencedDocument(ReferencedDocument buyerOrderReferencedDocument) {
+		this.buyerOrderReferencedDocument = buyerOrderReferencedDocument;
+		return this;
+	}
+
+	@Override
+	public ReferencedDocument getSellerOrderReferencedDocument() {
+		return sellerOrderReferencedDocument;
 	}
 
 	/***
@@ -435,31 +474,61 @@ public class Invoice implements IExportableTransaction {
 	 * @param invoiceReferencedDocumentID string with number
 	 * @return fluent setter
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setInvoiceReferencedDocumentID(String invoiceReferencedDocumentID) {
-		this.invoiceReferencedDocumentID = invoiceReferencedDocumentID;
+		if (invoiceReferencedDocuments == null) {
+			invoiceReferencedDocuments = new ArrayList<>();
+		}
+		if (invoiceReferencedDocuments.isEmpty()) {
+			invoiceReferencedDocuments.add(new ReferencedDocument());
+		}
+		this.invoiceReferencedDocuments.get(0).setIssuerAssignedID(invoiceReferencedDocumentID);
 		return this;
 	}
 
 	@Deprecated
 	@Override
+	@SuppressWarnings("removal")
 	public String getInvoiceReferencedDocumentID() {
-		return invoiceReferencedDocumentID;
+		if (this.invoiceReferencedDocuments == null || this.invoiceReferencedDocuments.isEmpty() ) {
+			return null;
+		} else {
+			return this.invoiceReferencedDocuments.get(0).getIssuerAssignedID();
+		}
 	}
 
 	@Deprecated
 	@Override
+	@SuppressWarnings("removal")
 	public Date getInvoiceReferencedIssueDate() {
-		return invoiceReferencedIssueDate;
+		if (this.invoiceReferencedDocuments == null || this.invoiceReferencedDocuments.isEmpty() ) {
+			return null;
+		} else {
+			return this.invoiceReferencedDocuments.get(0).getFormattedIssueDateTime();
+		}
 	}
 
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setInvoiceReferencedIssueDate(Date issueDate) {
-		this.invoiceReferencedIssueDate = issueDate;
+		if (invoiceReferencedDocuments == null) {
+			invoiceReferencedDocuments = new ArrayList<>();
+		}
+		if (invoiceReferencedDocuments.isEmpty()) {
+			invoiceReferencedDocuments.add(new ReferencedDocument());
+		}
+		this.invoiceReferencedDocuments.get(0).setFormattedIssueDateTime(issueDate);
 		return this;
 	}
 
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
+	@SuppressWarnings("removal")
 	public Date getBuyerOrderReferencedDocumentIssueDateTime() {
-		return buyerOrderReferencedDocumentIssueDateTime;
+		if (this.buyerOrderReferencedDocument == null ) {
+			return null;
+		} else {
+			return this.buyerOrderReferencedDocument.getFormattedIssueDateTime();
+		}
 	}
 
 
@@ -484,7 +553,10 @@ public class Invoice implements IExportableTransaction {
 	 * @return fluent setter
 	 */
 	public Invoice setBuyerOrderReferencedDocumentIssueDateTime(Date buyerOrderReferencedDocumentIssueDateTime) {
-		this.buyerOrderReferencedDocumentIssueDateTime = buyerOrderReferencedDocumentIssueDateTime;
+		if (buyerOrderReferencedDocument == null) {
+			buyerOrderReferencedDocument = new ReferencedDocument();
+		}
+		this.buyerOrderReferencedDocument.setFormattedIssueDateTime(buyerOrderReferencedDocumentIssueDateTime);
 		return this;
 	}
 
@@ -1002,8 +1074,8 @@ public class Invoice implements IExportableTransaction {
 	 * @param s the contract number
 	 * @return fluent setter
 	 */
-	public Invoice setContractReferencedDocument(String s) {
-		contractReferencedDocument = s;
+	public Invoice setContractReferencedDocument(ReferencedDocument rd) {
+		contractReferencedDocument = rd;
 		return this;
 	}
 
@@ -1199,39 +1271,121 @@ public class Invoice implements IExportableTransaction {
 		return this;
 	}
 
+	/**
+	 * @deprecated use getDespatchAdviceReferenced.getIssuerAssignedID
+	 */
+	@SuppressWarnings("removal")
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getDespatchAdviceReferencedDocumentID() {
-		return despatchAdviceReferencedDocumentID;
+		if (this.despatchAdviceReferencedDocument == null) {
+			return null;
+		} else {
+			return despatchAdviceReferencedDocument.getIssuerAssignedID();
+		}
 	}
 
-
+	/**
+	 * @deprecated use setDespatchAdviceReferenced / getDespatchAdviceReferenced.setIssuerAssignedID
+	 * @param despatchAdviceReferencedDocumentID
+	 * @return
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setDespatchAdviceReferencedDocumentID(String despatchAdviceReferencedDocumentID) {
-		this.despatchAdviceReferencedDocumentID = despatchAdviceReferencedDocumentID;
+		if (this.despatchAdviceReferencedDocument == null) {
+			this.despatchAdviceReferencedDocument = new ReferencedDocument();
+		}
+		this.despatchAdviceReferencedDocument.setIssuerAssignedID(despatchAdviceReferencedDocumentID);
 		return this;
 	}
 
+	/**
+	 * @deprecated use getDeliveryNoteReferencedDocument.getIssuerAssignedID
+	 */
+	@SuppressWarnings("removal")
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getDeliveryNoteReferencedDocumentID() {
-		return deliveryNoteReferencedDocumentID;
+		if (this.deliveryNoteReferencedDocument == null) {
+			return null;
+		} else {
+			return deliveryNoteReferencedDocument.getIssuerAssignedID();
+		}
 	}
 
-
+	/**
+	 * @deprecated use setDeliveryNoteReferenced / getDeliveryNoteReferenced.setIssuerAssignedID
+	 * @param deliveryNoteReferencedDocumentID
+	 * @return
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setDeliveryNoteReferencedDocumentID(String deliveryNoteReferencedDocumentID) {
-		this.deliveryNoteReferencedDocumentID = deliveryNoteReferencedDocumentID;
+		if (this.deliveryNoteReferencedDocument == null) {
+			this.deliveryNoteReferencedDocument = new ReferencedDocument();
+		}
+		this.deliveryNoteReferencedDocument.setIssuerAssignedID(deliveryNoteReferencedDocumentID);
 		return this;
 	}
 
+	/**
+	 * @deprecated use getDeliveryNoteReferenced.getFormattedIssueDateTime
+	 */
+	@SuppressWarnings("removal")
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Date getDeliveryNoteReferencedDocumentDate() {
-		return deliveryNoteReferencedDocumentDate;
+		if (this.deliveryNoteReferencedDocument == null) {
+			return null;
+		} else {
+			return deliveryNoteReferencedDocument.getFormattedIssueDateTime();
+		}
 	}
 
-
+	/**
+	 * @deprecated use setDeliveryNoteReferenced / getDeliveryNoteReferenced.setFormattedIssueDateTime
+	 * @param deliveryNoteReferencedDocumentDate
+	 * @return
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Invoice setDeliveryNoteReferencedDocumentDate(Date deliveryNoteReferencedDocumentDate) {
-		this.deliveryNoteReferencedDocumentDate = deliveryNoteReferencedDocumentDate;
+		if (this.deliveryNoteReferencedDocument == null) {
+			this.deliveryNoteReferencedDocument = new ReferencedDocument();
+		}
+		this.deliveryNoteReferencedDocument.setFormattedIssueDateTime(deliveryNoteReferencedDocumentDate);
 		return this;
 	}
 
+	/**
+	 * @return the despatchAdviceReferencedDocument
+	 */
+	@Override
+	public ReferencedDocument getDespatchAdviceReferencedDocument() {
+		return despatchAdviceReferencedDocument;
+	}
+
+	/**
+	 * @param despatchAdviceReferencedDocument the despatchAdviceReferencedDocument to set
+	 */
+	public Invoice setDespatchAdviceReferencedDocument(ReferencedDocument despatchAdviceReferencedDocument) {
+		this.despatchAdviceReferencedDocument = despatchAdviceReferencedDocument;
+		return this;
+	}
+
+	/**
+	 * @return the deliveryNoteReferencedDocument
+	 */
+	@Override
+	public ReferencedDocument getDeliveryNoteReferencedDocument() {
+		return deliveryNoteReferencedDocument;
+	}
+
+	/**
+	 * @param deliveryNoteReferencedDocument the deliveryNoteReferencedDocument to set
+	 */
+	public Invoice setDeliveryNoteReferencedDocument(ReferencedDocument deliveryNoteReferencedDocument) {
+		this.deliveryNoteReferencedDocument = deliveryNoteReferencedDocument;
+		return this;
+	}
 
 	@Override
 	public String getSpecifiedProcuringProjectName() {

--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -33,8 +33,9 @@ public class Item implements IZUGFeRDExportableItem {
 	protected Date detailedDeliveryPeriodFrom;
 	protected Date detailedDeliveryPeriodTo;
 	protected String id;
-	protected String buyerOrderReferencedDocumentLineID;
-	protected String buyerOrderReferencedDocumentID;
+	protected ReferencedDocument sellerOrderReferencedDocument;
+	protected ReferencedDocument buyerOrderReferencedDocument;
+	protected ReferencedDocument contractReferencedDocument;
 	protected Product product;
 	protected ArrayList<String> notes;
 	protected ArrayList<ReferencedDocument> referencedDocuments;
@@ -46,10 +47,8 @@ public class Item implements IZUGFeRDExportableItem {
 	protected String parentLineID;
 	protected String lineStatusReasonCode;
  	protected TradeParty lineSeller;
-	protected String deliveryNoteReferencedDocumentID;
-	protected Date deliveryNoteReferencedDocumentDate;
-	protected String deliveryNoteReferencedDocumentLineID;
-	//protected HashMap<String, String> attributes = new HashMap<>();
+	protected ReferencedDocument despatchAdviceReferencedDocument;
+	protected ReferencedDocument deliveryNoteReferencedDocument;
 
 	/***
 	 * default constructor
@@ -159,7 +158,7 @@ public class Item implements IZUGFeRDExportableItem {
 			});
 		});
 
-		itemMap.getNode(new String[]{"InvoicedQuantity", "CreditedQuantity"}).ifPresent(icn -> {
+		itemMap.getNode("InvoicedQuantity", "CreditedQuantity").ifPresent(icn -> {
 			// ubl
 			setQuantity(new BigDecimal(icn.getTextContent().trim()));
 			product.setUnit(icn.getAttributes().getNamedItem("unitCode").getNodeValue());
@@ -185,22 +184,14 @@ public class Item implements IZUGFeRDExportableItem {
 			.ifPresent(this::setAccountingReference);
 
 		if (product == null) { // CII
-			if (itemMap.getNode("SpecifiedTradeProduct").isPresent()) {
-				product = new Product(itemMap.getNode("SpecifiedTradeProduct").get());
-			} else {
-				product = new Product();
-			}
+			itemMap.getNode("SpecifiedTradeProduct").ifPresentOrElse(p -> product = new Product(p), () -> product = new Product());
 		}
 
 
 		itemMap.getAsNodeMap("SpecifiedLineTradeAgreement", "SpecifiedSupplyChainTradeAgreement").ifPresent(icnm -> {
-			icnm.getAsNodeMap("BuyerOrderReferencedDocument")
-				.flatMap(bordNodes -> bordNodes.getAsString("LineID"))
-				.ifPresent(this::addBuyerOrderReferencedDocumentLineID);
-
-			icnm.getAsNodeMap("BuyerOrderReferencedDocument")
-				.flatMap(bordNodes -> bordNodes.getAsString("IssuerAssignedID"))
-				.ifPresent(this::addBuyerOrderReferencedDocumentID);
+			icnm.getNode("SellerOrderReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(this::setSellerOrderReferencedDocument);
+			icnm.getNode("BuyerOrderReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(this::setBuyerOrderReferencedDocument);
+			icnm.getNode("ContractReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(this::setContractReferencedDocument);
 
 			icnm.getAsNodeMap("NetPriceProductTradePrice").ifPresent(npptpNodes -> {
 				npptpNodes.getAsBigDecimal("ChargeAmount").ifPresent(this::setPrice);
@@ -242,22 +233,14 @@ public class Item implements IZUGFeRDExportableItem {
 				}
 			});
 
-		itemMap.getAsNodeMap("SpecifiedLineTradeDelivery").ifPresent(icnm ->
-			icnm.getAsNodeMap("DeliveryNoteReferencedDocument").ifPresent(dn -> {
-				dn.getAsString("IssuerAssignedID")
-					.ifPresent(this::setDeliveryNoteReferencedDocumentID);
-
-				dn.getAsString("LineID")
-						.ifPresent(this::setDeliveryNoteReferencedDocumentLineID);
-
-				dn.getAsNodeMap("FormattedIssueDateTime")
-					.flatMap(fdt -> fdt.getNode("DateTimeString"))
-					.map(XMLTools::getNodeValue)
-					.map(XMLTools::tryDate)
-					.ifPresent(this::setDeliveryNoteReferencedDocumentDate);
-			})
-		);
-
+		itemMap.getAsNodeMap("SpecifiedLineTradeDelivery").flatMap(icnm -> icnm.getNode("DespatchAdviceReferencedDocument")).map(ReferencedDocument::fromNode).ifPresent(this::setDespatchAdviceReferencedDocument);
+		itemMap.getAsNodeMap("SpecifiedLineTradeDelivery").flatMap(icnm -> icnm.getNode("DeliveryNoteReferencedDocument")).map(ReferencedDocument::fromNode).ifPresent(this::setDeliveryNoteReferencedDocument);
+/*
+		itemMap.getAsNodeMap("SpecifiedLineTradeDelivery").ifPresent(icnm -> {
+			icnm.getNode("DespatchAdviceReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(this::setDespatchAdviceReferencedDocument);
+			icnm.getNode("DeliveryNoteReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(this::setDeliveryNoteReferencedDocument);
+		});
+*/
 		itemMap.getAsNodeMap("SpecifiedLineTradeSettlement", "SpecifiedSupplyChainTradeSettlement").ifPresent(icnm -> {
 			icnm.getAsNodeMap("ApplicableTradeTax")
 				.flatMap(cnm -> cnm.getAsBigDecimal("RateApplicablePercent", "ApplicablePercent"))
@@ -430,29 +413,93 @@ public class Item implements IZUGFeRDExportableItem {
 		}
 	}
 
+	/**
+	 * @deprecated	use setBuyerOrderReferencedDocument
+	 * @param s		the lineID
+	 * @return fluent setter
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Item addBuyerOrderReferencedDocumentLineID(String s) {
-		buyerOrderReferencedDocumentLineID = s;
+		if (buyerOrderReferencedDocument == null) {
+			buyerOrderReferencedDocument = new ReferencedDocument();
+		}
+		buyerOrderReferencedDocument.setLineID(s);
 		return this;
 	}
 
-	@Override
+	/**
+	 * @deprecated	use getBuyerOrderReferencedDocument::getIssuerAssigneID
+	 * @return buyerOrderReferencedDocument.issuerAssignedID
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getBuyerOrderReferencedDocumentID() {
-		return buyerOrderReferencedDocumentID;
+		if (buyerOrderReferencedDocument == null) {
+			return null;
+		} else {
+			return buyerOrderReferencedDocument.getIssuerAssignedID();
+		}
 	}
 
+	/**
+	 * @deprecated	use setBuyerOrderReferencedDocument
+	 * @param s		the issuerAssignedID
+	 * @return fluent setter
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Item addBuyerOrderReferencedDocumentID(String s) {
-		buyerOrderReferencedDocumentID = s;
+		if (buyerOrderReferencedDocument == null) {
+			buyerOrderReferencedDocument = new ReferencedDocument();
+		}
+		buyerOrderReferencedDocument.setIssuerAssignedID(s);
 		return this;
 	}
 
 	/***
 	 * BT 132 (issue https://github.com/ZUGFeRD/mustangproject/issues/247)
+	 * @deprecated	use getBuyerOrderReferencedDocument().getLineID()
 	 * @return the line ID of the order (BT132)
 	 */
+	@SuppressWarnings("removal")
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getBuyerOrderReferencedDocumentLineID() {
-		return buyerOrderReferencedDocumentLineID;
+		if (buyerOrderReferencedDocument == null) {
+			return null;
+		} else {
+			return buyerOrderReferencedDocument.getLineID();
+		}
 	}
+
+	@Override
+	public ReferencedDocument getSellerOrderReferencedDocument() {
+		return sellerOrderReferencedDocument;
+	}
+
+	public Item setSellerOrderReferencedDocument(ReferencedDocument rd) {
+		sellerOrderReferencedDocument = rd;
+		return this;
+	}
+
+	@Override
+	public ReferencedDocument getBuyerOrderReferencedDocument() {
+		return buyerOrderReferencedDocument;
+	}
+
+	public Item setBuyerOrderReferencedDocument(ReferencedDocument rd) {
+		buyerOrderReferencedDocument = rd;
+		return this;
+	}
+
+	@Override
+	public ReferencedDocument getContractReferencedDocument() {
+		return contractReferencedDocument;
+	}
+
+	public Item setContractReferencedDocument(ReferencedDocument rd) {
+		contractReferencedDocument = rd;
+		return this;
+	}
+
 
 	@Override
 	public BigDecimal getLineTotalAmount() {
@@ -796,46 +843,123 @@ public class Item implements IZUGFeRDExportableItem {
 	 * @param seller The line seller
 	 * @return fluent setter
 	 */
-    public Item setLineSeller(TradeParty seller) {
-        this.lineSeller = seller;
-        return this;
-    }
-    @Override
-    public TradeParty getLineSeller() {
-        return this.lineSeller;
-    }
-
+	public Item setLineSeller(TradeParty seller) {
+		this.lineSeller = seller;
+		return this;
+	}
 	@Override
+	public TradeParty getLineSeller() {
+		return this.lineSeller;
+	}
+
+	/**
+	 * @deprecated use getDeliveryNoteReferencedDocument.getIssuerAssignedID
+	 */
+	@SuppressWarnings("removal")
+	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getDeliveryNoteReferencedDocumentID() {
-		return deliveryNoteReferencedDocumentID;
+		if (this.deliveryNoteReferencedDocument == null) {
+			return null;
+		} else {
+			return deliveryNoteReferencedDocument.getIssuerAssignedID();
+		}
 	}
 
-
+	/**
+	 * @deprecated use setDeliveryNoteReferencedDocument / getDeliveryNoteReferencedDocument.setIssuerAssignedID
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Item setDeliveryNoteReferencedDocumentID(String deliveryNoteReferencedDocumentID) {
-		this.deliveryNoteReferencedDocumentID = deliveryNoteReferencedDocumentID;
+		if (this.deliveryNoteReferencedDocument == null) {
+			this.deliveryNoteReferencedDocument = new ReferencedDocument();
+		}
+		this.deliveryNoteReferencedDocument.setIssuerAssignedID(deliveryNoteReferencedDocumentID);
 		return this;
 	}
 
+	/**
+	 * @deprecated use getDeliveryNoteReferencedDocument.getIssuerAssignedID
+	 */
+	@SuppressWarnings("removal")
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Date getDeliveryNoteReferencedDocumentDate() {
-		return deliveryNoteReferencedDocumentDate;
+		if (this.deliveryNoteReferencedDocument == null) {
+			return null;
+		} else {
+			return deliveryNoteReferencedDocument.getFormattedIssueDateTime();
+		}
 	}
 
 
+	/**
+	 * @deprecated use setDeliveryNoteReferencedDocument / getDeliveryNoteReferencedDocument.setFormattedIssueDateTime
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Item setDeliveryNoteReferencedDocumentDate(Date deliveryNoteReferencedDocumentDate) {
-		this.deliveryNoteReferencedDocumentDate = deliveryNoteReferencedDocumentDate;
+		if (this.deliveryNoteReferencedDocument == null) {
+			this.deliveryNoteReferencedDocument = new ReferencedDocument();
+		}
+		this.deliveryNoteReferencedDocument.setFormattedIssueDateTime(deliveryNoteReferencedDocumentDate);
 		return this;
 	}
 
+	/**
+	 * @deprecated use getDeliveryNoteReferencedDocument.getLineID
+	 */
+	@SuppressWarnings("removal")
 	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public String getDeliveryNoteReferencedDocumentLineID() {
-		return deliveryNoteReferencedDocumentLineID;
+		if (this.deliveryNoteReferencedDocument == null) {
+			return null;
+		} else {
+			return deliveryNoteReferencedDocument.getLineID();
+		}
 	}
 
-
+	/**
+	 * @deprecated use setDeliveryNoteReferencedDocument / getDeliveryNoteReferencedDocument.setLineID
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	public Item setDeliveryNoteReferencedDocumentLineID(String deliveryNoteReferencedDocumentLineID) {
-		this.deliveryNoteReferencedDocumentLineID = deliveryNoteReferencedDocumentLineID;
+		if (this.deliveryNoteReferencedDocument == null) {
+			this.deliveryNoteReferencedDocument = new ReferencedDocument();
+		}
+		this.deliveryNoteReferencedDocument.setLineID(deliveryNoteReferencedDocumentLineID);
 		return this;
 	}
 
+	/**
+	 * @return the despatchAdviceReferencedDocument
+	 */
+	@Override
+	public ReferencedDocument getDespatchAdviceReferencedDocument() {
+		return despatchAdviceReferencedDocument;
+	}
+
+	/**
+	 * @param despatchAdviceReferencedDocument the despatchAdviceReferencedDocument to set
+	 */
+	public Item setDespatchAdviceReferencedDocument(ReferencedDocument despatchAdviceReferencedDocument) {
+		this.despatchAdviceReferencedDocument = despatchAdviceReferencedDocument;
+		return this;
+	}
+
+	/**
+	 * @return the deliveryNoteReferencedDocument
+	 */
+	@Override
+	public ReferencedDocument getDeliveryNoteReferencedDocument() {
+		return deliveryNoteReferencedDocument;
+	}
+
+	/**
+	 * @param deliveryNoteReferencedDocument the deliveryNoteReferencedDocument to set
+	 */
+	public Item setDeliveryNoteReferencedDocument(ReferencedDocument deliveryNoteReferencedDocument) {
+		this.deliveryNoteReferencedDocument = deliveryNoteReferencedDocument;
+		return this;
+	}
 }

--- a/library/src/main/java/org/mustangproject/Product.java
+++ b/library/src/main/java/org/mustangproject/Product.java
@@ -27,7 +27,7 @@ public class Product implements IZUGFeRDExportableProduct {
 	private static final HashMap<String, HashMap<String, String>> unitAbbrevs = new HashMap<>();
 
 	protected String unit, name, sellerAssignedID, buyerAssignedID;
-	protected String description = "";
+	protected String description;
 	protected String taxExemptionReason;
 	protected String taxExemptionReasonCode;
 	protected String taxCategoryCode;

--- a/library/src/main/java/org/mustangproject/ReferencedDocument.java
+++ b/library/src/main/java/org/mustangproject/ReferencedDocument.java
@@ -1,12 +1,16 @@
 package org.mustangproject;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 
 import org.mustangproject.ZUGFeRD.IReferencedDocument;
 import org.mustangproject.util.NodeMap;
+import org.mustangproject.util.StringUtils;
 import org.w3c.dom.Node;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -14,8 +18,11 @@ import org.w3c.dom.Node;
 public class ReferencedDocument implements IReferencedDocument {
 
 	private String issuerAssignedID;
+	private String uriID;
+	private String lineID;
 	private String typeCode;
 	private String name;
+	private FileAttachment attachmentBinaryObject;
 	private String referenceTypeCode;
 	private Date formattedIssueDateTime;
 
@@ -44,7 +51,9 @@ public class ReferencedDocument implements IReferencedDocument {
 	}
 
 	public ReferencedDocument(String issuerAssignedID) {
-		this.issuerAssignedID = issuerAssignedID;
+		if (StringUtils.isNotBlank(issuerAssignedID)) {
+			this.issuerAssignedID = issuerAssignedID;
+		}
 	}
 
 	/***
@@ -53,6 +62,23 @@ public class ReferencedDocument implements IReferencedDocument {
 	 */
 	public ReferencedDocument setIssuerAssignedID(String issuerAssignedID) {
 		this.issuerAssignedID = issuerAssignedID;
+		return this;
+	}
+
+	/**
+	 * @param uriID the uriID to set
+	 */
+	public ReferencedDocument setUriID(String uriID) {
+		this.uriID = uriID;
+		return this;
+	}
+
+	/***
+	 * sets an ID assigned by the sender
+	 * @param issuerAssignedID the ID as a string :-)
+	 */
+	public ReferencedDocument setLineID(String lineID) {
+		this.lineID = lineID;
 		return this;
 	}
 
@@ -76,6 +102,14 @@ public class ReferencedDocument implements IReferencedDocument {
 	}
 
 	/**
+	 * @param attachmentBinaryObject the attachmentBinaryObject to set
+	 */
+	public ReferencedDocument setAttachmentBinaryObject(FileAttachment attachmentBinaryObject) {
+		this.attachmentBinaryObject = attachmentBinaryObject;
+		return this;
+	}
+
+	/**
 	 * type of the reference of this line, a UNTDID 1153 code
 	 *
 	 * @param referenceTypeCode three uppercase character reference type code as string
@@ -90,13 +124,26 @@ public class ReferencedDocument implements IReferencedDocument {
 	 *
 	 * @param formattedIssueDateTime as Date
 	 */
-	public void setFormattedIssueDateTime(Date formattedIssueDateTime) {
+	public ReferencedDocument setFormattedIssueDateTime(Date formattedIssueDateTime) {
 		this.formattedIssueDateTime = formattedIssueDateTime;
+		return this;
 	}
 
 	@Override
 	public String getIssuerAssignedID() {
 		return issuerAssignedID;
+	}
+
+	/**
+	 * @return the uriID
+	 */
+	public String getUriID() {
+		return uriID;
+	}
+
+	@Override
+	public String getLineID() {
+		return lineID;
 	}
 
 	@Override
@@ -107,6 +154,13 @@ public class ReferencedDocument implements IReferencedDocument {
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	/**
+	 * @return the attachmentBinaryObject
+	 */
+	public FileAttachment getAttachmentBinaryObject() {
+		return attachmentBinaryObject;
 	}
 
 	@Override
@@ -126,18 +180,63 @@ public class ReferencedDocument implements IReferencedDocument {
 		NodeMap nodes = new NodeMap(node);
 		ReferencedDocument rd = new ReferencedDocument(nodes.getAsStringOrNull("IssuerAssignedID", "ID"),
 			nodes.getAsStringOrNull("TypeCode", "DocumentTypeCode"),
-			nodes.getAsStringOrNull("ReferenceTypeCode"),
-			XMLTools.tryDate(nodes.getAsStringOrNull("FormattedIssueDateTime")));
+			nodes.getAsStringOrNull("ReferenceTypeCode"));
+
+		nodes.getNode("URIID").ifPresent(childNode -> rd.setUriID(childNode.getTextContent()));
+		nodes.getNode("LineID").ifPresent(childNode -> rd.setLineID(childNode.getTextContent()));
+		nodes.getNode("Name").ifPresent(childNode -> rd.setName(childNode.getTextContent()));
+		nodes.getNode("AttachmentBinaryObject").ifPresent(childNode -> rd.setAttachmentBinaryObject(new FileAttachment(childNode.getAttributes().getNamedItem("filename").getNodeValue(), childNode.getAttributes().getNamedItem("mimeCode").getNodeValue(), "Data", Base64.getMimeDecoder().decode(XMLTools.trimOrNull(childNode)))));
+		nodes.getAsNodeMap("FormattedIssueDateTime")
+			.flatMap(fdt -> fdt.getNode("DateTimeString"))
+			.map(XMLTools::getNodeValue)
+			.map(XMLTools::tryDate)
+			.ifPresent(d -> rd.setFormattedIssueDateTime(d));
+
 		if (nodes.getAsStringOrNull("ID") != null) {
-			//sure sign for UBL: here ReferenceTypeCode is no element but a "schemeID" attribute to ID
-			Node idNode = nodes.getNode("ID").get();
-			if (idNode != null) {
-				Node schemeIDAttr = idNode.getAttributes().getNamedItem("schemeID");
+			// sure sign for UBL: here ReferenceTypeCode is no element but a "schemeID" attribute to ID
+			Node childNode = nodes.getNode("ID").get();
+			if (childNode != null) {
+				Node schemeIDAttr = childNode.getAttributes().getNamedItem("schemeID");
 				if (schemeIDAttr != null) {
 					rd.setReferenceTypeCode(schemeIDAttr.getNodeValue());
 				}
 			}
 		}
 		return rd;
+	}
+	/***
+	 * @return this particular ReferencedDocument industry invoice XML
+	 */
+	@JsonIgnore
+	public String getAsCII() {
+		StringBuilder xml = new StringBuilder();
+		if (StringUtils.isNotBlank(this.getIssuerAssignedID())) {
+			xml.append("<ram:IssuerAssignedID>" + XMLTools.encodeXML(this.getIssuerAssignedID()) + "</ram:IssuerAssignedID>" );
+		}
+		if (StringUtils.isNotBlank(this.getUriID())) {
+			xml.append("<ram:URIID>" + XMLTools.encodeXML(this.getLineID()) + "</ram:URIID>" );
+		}
+		if (StringUtils.isNotBlank(this.getLineID())) {
+			xml.append("<ram:LineID>" + XMLTools.encodeXML(this.getLineID()) + "</ram:LineID>" );
+		}
+		if (StringUtils.isNotBlank(this.getTypeCode())) {
+			xml.append("<ram:TypeCode>" + XMLTools.encodeXML(this.getTypeCode()) + "</ram:TypeCode>");
+		}
+		if (StringUtils.isNotBlank(this.getName())) {
+			xml.append("<ram:name>" + XMLTools.encodeXML(this.getName()) + "</ram:Name>");
+		}
+		if (this.getAttachmentBinaryObject() != null) {
+			FileAttachment f = this.getAttachmentBinaryObject();
+			String documentContent = Base64.getEncoder().encodeToString(f.getData());
+			xml.append("<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\" " + " filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>");
+		}
+		if (StringUtils.isNotBlank(this.getReferenceTypeCode())) {
+			xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(this.getReferenceTypeCode()) + "</ram:ReferenceTypeCode>");
+		}
+		if (this.getFormattedIssueDateTime() != null) {
+			final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
+			xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(this.getFormattedIssueDateTime())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
+		}
+		return xml.toString();
 	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DAPullProvider.java
@@ -22,7 +22,6 @@ package org.mustangproject.ZUGFeRD;
 
 import static org.mustangproject.ZUGFeRD.ZUGFeRDDateFormat.DATE;
 
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
@@ -100,30 +99,6 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 				xml.append("<ram:BuyerAssignedID>"
 						+ XMLTools.encodeXML(currentItem.getProduct().getBuyerAssignedID()) + "</ram:BuyerAssignedID>");
 			}
-			// Product-level (GrossPrice / product section): ActualAmount must be per-unit (BT-147)
-			final IZUGFeRDExportableItem itemForProduct = currentItem;
-			IAbsoluteValueProvider perUnitProvider = new IAbsoluteValueProvider() {
-				@Override
-				public BigDecimal getValue() {
-					return itemForProduct.getPrice();
-				}
-				@Override
-				public BigDecimal getQuantity() {
-					return BigDecimal.ONE;
-				}
-			};
-			String allowanceChargeStr = "";
-			if (currentItem.getItemAllowances() != null) {
-				for (final IZUGFeRDAllowanceCharge allowance : currentItem.getItemAllowances()) {
-					allowanceChargeStr += getAllowanceChargeStr(allowance, perUnitProvider);
-				}
-			}
-			if (currentItem.getItemCharges() != null) {
-				for (final IZUGFeRDAllowanceCharge charge : currentItem.getItemCharges()) {
-					allowanceChargeStr += getAllowanceChargeStr(charge, perUnitProvider);
-				}
-			}
-
 
 			xml.append("<ram:Name>" + XMLTools.encodeXML(currentItem.getProduct().getName()) + "</ram:Name>"
 					+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
@@ -174,23 +149,20 @@ public class DAPullProvider extends ZUGFeRD2PullProvider {
 		xml.append(getTradePartyAsXML(trans.getRecipient(), false, false));
 		xml.append("</ram:BuyerTradeParty>");
 
-		if (trans.getSellerOrderReferencedDocumentID() != null) {
+		if (trans.getSellerOrderReferencedDocument() != null && trans.getSellerOrderReferencedDocument().getIssuerAssignedID() != null) {
 			xml.append("<ram:SellerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:SellerOrderReferencedDocument>");
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getSellerOrderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:SellerOrderReferencedDocument>");
 		}
-		if (trans.getBuyerOrderReferencedDocumentID() != null) {
+		if (trans.getBuyerOrderReferencedDocument() != null && trans.getBuyerOrderReferencedDocument().getIssuerAssignedID() != null) {
 			xml.append("<ram:BuyerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:BuyerOrderReferencedDocument>");
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getBuyerOrderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:BuyerOrderReferencedDocument>");
 		}
-		if (trans.getContractReferencedDocument() != null) {
+		if (trans.getContractReferencedDocument() != null && trans.getContractReferencedDocument().getIssuerAssignedID() != null) {
 			xml.append("<ram:ContractReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
-					+ "</ram:ContractReferencedDocument>");
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getContractReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:ContractReferencedDocument>");
 		}
 
 		// Additional Documents of XRechnung (Rechnungsbegruendende Unterlagen - BG-24 XRechnung)

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/DXExporterFromA3.java
@@ -42,7 +42,6 @@ import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
-import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
 import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.common.PDMetadata;
@@ -56,7 +55,6 @@ import org.apache.xmpbox.schema.AdobePDFSchema;
 import org.apache.xmpbox.schema.DublinCoreSchema;
 import org.apache.xmpbox.schema.PDFAIdentificationSchema;
 import org.apache.xmpbox.schema.XMPBasicSchema;
-import org.apache.xmpbox.type.ArrayProperty;
 import org.apache.xmpbox.type.BadFieldValueException;
 import org.apache.xmpbox.xml.DomXmpParser;
 import org.apache.xmpbox.xml.XmpParsingException;
@@ -64,7 +62,6 @@ import org.apache.xmpbox.xml.XmpSerializer;
 import org.mustangproject.EStandard;
 import org.mustangproject.FileAttachment;
 import static org.mustangproject.util.StringUtils.isBlank;
-import static org.mustangproject.util.StringUtils.isNotBlank;
 
 import jakarta.activation.DataSource;
 import jakarta.activation.FileDataSource;
@@ -576,33 +573,6 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-	protected void writeDublinCoreSchema(XMPMetadata xmp) {
-		DublinCoreSchema dc = getDublinCoreSchema(xmp);
-		if (dc.getFormat() == null) {
-			dc.setFormat("application/pdf");
-		}
-		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null) {
-			dc.addCreator(creator);
-		}
-		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null) {
-			dc.addDate(Calendar.getInstance());
-		}
-
-		ArrayProperty titleProperty = dc.getTitleProperty();
-		if (titleProperty != null) {
-			if (overwrite && isNotBlank(title)) {
-				dc.removeProperty(titleProperty);
-				dc.setTitle(title);
-			} else if (titleProperty.getElementsAsString().stream().anyMatch("Untitled"::equalsIgnoreCase)) {
-				// remove unfitting ghostscript default
-				dc.removeProperty(titleProperty);
-			}
-		} else if (isNotBlank(title)) {
-			dc.setTitle(title);
-		}
-	}
-
-	@Override
 	protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = xmp.getDublinCoreSchema();
 		if (dc != null) {
@@ -637,34 +607,6 @@ public class DXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 			}
 		}
 		return xmp.createAndAddXMPBasicSchema();
-	}
-
-	// TODO this method does the same as the inherited one - deletion possible
-	@Override
-	protected void writeDocumentInformation() {
-		String fullProducer = producer + " (via mustangproject.org " + Version.VERSION + ")";
-		PDDocumentInformation info = doc.getDocumentInformation();
-		if (overwrite || info.getCreationDate() == null) {
-			info.setCreationDate(Calendar.getInstance());
-		}
-		if (overwrite || info.getModificationDate() == null) {
-			info.setModificationDate(Calendar.getInstance());
-		}
-		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author))) {
-			info.setAuthor(author);
-		}
-		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer))) {
-			info.setProducer(fullProducer);
-		}
-		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator))) {
-			info.setCreator(creator);
-		}
-		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title))) {
-			info.setTitle(title);
-		}
-		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject))) {
-			info.setSubject(subject);
-		}
 	}
 
 	/**

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -113,7 +113,7 @@ public interface IExportableTransaction {
 		return null;
 	}
 
-	default String getContractReferencedDocument() {
+	default IReferencedDocument getContractReferencedDocument() {
 		return null;
 	}
 
@@ -458,7 +458,7 @@ public interface IExportableTransaction {
 	 *
 	 * @return the ID of the document
 	 */
-	default String getSellerOrderReferencedDocumentID() {
+	default IReferencedDocument getSellerOrderReferencedDocument() {
 		return null;
 	}
 
@@ -468,21 +468,33 @@ public interface IExportableTransaction {
 	 *
 	 * @return the ID of the document
 	 */
-	default String getBuyerOrderReferencedDocumentID() {
+	default IReferencedDocument getBuyerOrderReferencedDocument() {
+		return null;
+	}
+
+	default IReferencedDocument getDespatchAdviceReferencedDocument() {
+		return null;
+	}
+
+	default IReferencedDocument getDeliveryNoteReferencedDocument() {
 		return null;
 	}
 
 	/**
 	 * get the ID of the preceding invoice, which is e.g. to be corrected if this is a correction
-	 *
+	 * @deprecated use getInvoiceReferencedDocument.getIssuerAssignedID
 	 * @return the ID of the document
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getInvoiceReferencedDocumentID() {
 		return null;
 	}
 
-	@Deprecated
+	/**
+	 * @deprecated use getInvoiceReferencedDocument.getFormattedIssueDateTime
+	 * @return
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default Date getInvoiceReferencedIssueDate() {
 		return null;
 	}
@@ -498,9 +510,10 @@ public interface IExportableTransaction {
 	/**
 	 * get the issue timestamp of the BuyerOrderReferencedDocument, which sits in
 	 * the ApplicableSupplyChainTradeAgreement
-	 *
+	 * @deprecated use getBuyerOrderReferencedDocument.getFormattedIssueDateTime
 	 * @return the IssueDateTime in format CCYY-MM-DDTHH:MM:SS
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default Date getBuyerOrderReferencedDocumentIssueDateTime() {
 		return null;
 	}
@@ -593,6 +606,11 @@ public interface IExportableTransaction {
 		return null;
 	}
 
+	/**
+	 * @deprecated use
+	 * @return getDespatchAdviceReferencedDocument.getIssuerAssignedID
+	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getDespatchAdviceReferencedDocumentID() {
 		return null;
 	}
@@ -600,9 +618,10 @@ public interface IExportableTransaction {
 	/**
 	 * get delivery note document ID
 	 * ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/IssuerAssignedID
-	 *
+	 * @deprecated getDeliveryNoteReferencedDocument.getIssuerAssignedID
 	 * @return the ID of the delivery note document
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getDeliveryNoteReferencedDocumentID() {
 		return null;
 	}
@@ -610,9 +629,10 @@ public interface IExportableTransaction {
 	/**
 	 * get delivery note document date
 	 * ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/FormattedIssueDateTime
-	 *
+	 * @deprecated use getDeliveryNoteReferenced.getFormattedIssueDateTime
 	 * @return the date of the delivery note document
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default Date getDeliveryNoteReferencedDocumentDate() {
 		return null;
 	}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IReferencedDocument.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IReferencedDocument.java
@@ -11,6 +11,12 @@ public interface IReferencedDocument {
 	String getIssuerAssignedID();
 
 	/***
+	 * sets a line ID assigned by the sender
+	 * @return String of a lineID
+	 */
+	String getLineID();
+
+	/***
 	 * which type is the document? e.g. "916" for additional invoice related
 	 * @return string of a most likely numeric code
 	 */
@@ -38,4 +44,8 @@ public interface IReferencedDocument {
 	 */
 	Date getFormattedIssueDateTime();
 
+	/***
+	 * @return this particular cash discount as cross industry invoice XML
+	 */
+	String getAsCII();
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceCharge.java
@@ -101,7 +101,7 @@ public interface IZUGFeRDAllowanceCharge extends IZUGFeRDTradeTax {
 	/**
 	 * @deprecated use getTaxCategoryCode() instead.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getCategoryCode() {
 		return getTaxCategoryCode();
 	}
@@ -109,7 +109,7 @@ public interface IZUGFeRDAllowanceCharge extends IZUGFeRDTradeTax {
 	/**
 	 * @deprecated use getTaxRateApplicablePercent() instead.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default BigDecimal getTaxPercent() {
 		return getTaxRateApplicablePercent();
 	}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IZUGFeRDExportableItem.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import org.mustangproject.IncludedNote;
 import org.mustangproject.Item;
+import org.mustangproject.ReferencedDocument;
 import org.mustangproject.TradeParty;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -63,17 +64,35 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	}
 
 	/***
-	 * buyer order reference document id
+	 * buyer order reference document
+	 * @return  the document (defaults to {@code null})
+	 */
+	default ReferencedDocument getBuyerOrderReferencedDocument() {
+		return null;
+	}
+
+	/***
+	 * seller order reference document
 	 * @return  the document id (defaults to {@code null})
 	 */
-	default String getBuyerOrderReferencedDocumentID() {
+	default ReferencedDocument getSellerOrderReferencedDocument() {
+		return null;
+	}
+
+	/***
+	 * contract reference document
+	 * @return  the document id (defaults to {@code null})
+	 */
+	default ReferencedDocument getContractReferencedDocument() {
 		return null;
 	}
 
 	/***
 	 * BT 132 (issue https://github.com/ZUGFeRD/mustangproject/issues/247)
+	 * @deprecated use getBuyerOrderReferencedDocument.getLineID
 	 * @return the line ID of the order (BT-132)
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getBuyerOrderReferencedDocumentLineID() {
 		return null;
 	}
@@ -86,11 +105,15 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	 */
 	BigDecimal getPrice();
 
+	/**
+	 * @deprecated use getPrice
+	 */
 	@Override
 	@Deprecated
 	default BigDecimal getValue() {
 		return getPrice();
 	}
+
 	/**
 	 * how many get billed
 	 *
@@ -226,9 +249,10 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	/**
 	 * get delivery note document ID (per Item - ZUGFeRD EXTENDED)
 	 * rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/IssuerAssignedID
-	 *
+	 * @deprecated use getDeliveryNoteReferencedDocument.getIssuerAssignedID
 	 * @return the ID of the delivery note document
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getDeliveryNoteReferencedDocumentID() {
 		return null;
 	}
@@ -236,9 +260,10 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	/**
 	 * get delivery note document date (per Item - ZUGFeRD EXTENDED)
 	 * rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/FormattedIssueDateTime
-	 *
+	 * @deprecated use getDeliveryNoteReferencedDocument.getFormattedIssueDateTime
 	 * @return the date of the delivery note document
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default Date getDeliveryNoteReferencedDocumentDate() {
 		return null;
 	}
@@ -246,10 +271,31 @@ public interface IZUGFeRDExportableItem extends IAbsoluteValueProvider {
 	/**
 	 * get delivery note document LineID (per Item - ZUGFeRD EXTENDED)
 	 * rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/LineID
-	 *
+	 * @deprecated use getDeliveryNoteReferencedDocument.getLineID
 	 * @return the LineID of the delivery note document item
 	 */
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	default String getDeliveryNoteReferencedDocumentLineID() {
+		return null;
+	}
+
+	/**
+	 * get despatch advice document (per Item - ZUGFeRD EXTENDED)
+	 * rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeDelivery/ram:DespatchAdviceReferencedDocument
+	 *
+	 * @return the ID of the despatch advice document
+	 */
+	default ReferencedDocument getDespatchAdviceReferencedDocument() {
+		return null;
+	}
+
+	/**
+	 * get delivery note document (per Item - ZUGFeRD EXTENDED)
+	 * rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem/ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/
+	 *
+	 * @return the ID of the delivery note document
+	 */
+	default ReferencedDocument getDeliveryNoteReferencedDocument() {
 		return null;
 	}
 }

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXExporterFromA3.java
@@ -42,7 +42,6 @@ import org.apache.pdfbox.cos.COSObject;
 import org.apache.pdfbox.io.IOUtils;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentCatalog;
-import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
 import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
 import org.apache.pdfbox.pdmodel.common.PDMetadata;
@@ -56,7 +55,6 @@ import org.apache.xmpbox.schema.AdobePDFSchema;
 import org.apache.xmpbox.schema.DublinCoreSchema;
 import org.apache.xmpbox.schema.PDFAIdentificationSchema;
 import org.apache.xmpbox.schema.XMPBasicSchema;
-import org.apache.xmpbox.type.ArrayProperty;
 import org.apache.xmpbox.type.BadFieldValueException;
 import org.apache.xmpbox.xml.DomXmpParser;
 import org.apache.xmpbox.xml.XmpParsingException;
@@ -64,7 +62,6 @@ import org.apache.xmpbox.xml.XmpSerializer;
 import org.mustangproject.EStandard;
 import org.mustangproject.FileAttachment;
 import static org.mustangproject.util.StringUtils.isBlank;
-import static org.mustangproject.util.StringUtils.isNotBlank;
 
 import jakarta.activation.DataSource;
 import jakarta.activation.FileDataSource;
@@ -563,33 +560,6 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 	}
 
 	@Override
-	protected void writeDublinCoreSchema(XMPMetadata xmp) {
-		DublinCoreSchema dc = getDublinCoreSchema(xmp);
-		if (dc.getFormat() == null) {
-			dc.setFormat("application/pdf");
-		}
-		if ((overwrite || dc.getCreators() == null || dc.getCreators().isEmpty()) && creator != null) {
-			dc.addCreator(creator);
-		}
-		if ((overwrite || dc.getDates() == null || dc.getDates().isEmpty()) && creator != null) {
-			dc.addDate(Calendar.getInstance());
-		}
-
-		ArrayProperty titleProperty = dc.getTitleProperty();
-		if (titleProperty != null) {
-			if (overwrite && isNotBlank(title)) {
-				dc.removeProperty(titleProperty);
-				dc.setTitle(title);
-			} else if (titleProperty.getElementsAsString().stream().anyMatch("Untitled"::equalsIgnoreCase)) {
-				// remove unfitting ghostscript default
-				dc.removeProperty(titleProperty);
-			}
-		} else if (isNotBlank(title)) {
-			dc.setTitle(title);
-		}
-	}
-
-	@Override
 	protected DublinCoreSchema getDublinCoreSchema(XMPMetadata xmp) {
 		DublinCoreSchema dc = xmp.getDublinCoreSchema();
 		if (dc != null) {
@@ -624,33 +594,6 @@ public class OXExporterFromA3 extends ZUGFeRDExporterFromA3 {
 			}
 		}
 		return xmp.createAndAddXMPBasicSchema();
-	}
-
-	@Override
-	protected void writeDocumentInformation() {
-		String fullProducer = producer + " (via mustangproject.org " + Version.VERSION + ")";
-		PDDocumentInformation info = doc.getDocumentInformation();
-		if (overwrite || info.getCreationDate() == null) {
-			info.setCreationDate(Calendar.getInstance());
-		}
-		if (overwrite || info.getModificationDate() == null) {
-			info.setModificationDate(Calendar.getInstance());
-		}
-		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author))) {
-			info.setAuthor(author);
-		}
-		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer))) {
-			info.setProducer(fullProducer);
-		}
-		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator))) {
-			info.setCreator(creator);
-		}
-		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title))) {
-			info.setTitle(title);
-		}
-		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject))) {
-			info.setSubject(subject);
-		}
 	}
 
 	/**

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/OXPullProvider.java
@@ -150,23 +150,11 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 					+ "<ram:Description>" + XMLTools.encodeXML(currentItem.getProduct().getDescription())
 					+ "</ram:Description>"
 					+ "</ram:SpecifiedTradeProduct>"
-
 					+ "<ram:SpecifiedLineTradeAgreement>");
-		/*	if (currentItem.getReferencedDocuments() != null) {
-				for (IReferencedDocument currentReferencedDocument : currentItem.getReferencedDocuments()) {
-					xml.append("<ram:AdditionalReferencedDocument>\n" +
-							"<ram:IssuerAssignedID>" + XMLTools.encodeXML(currentReferencedDocument.getIssuerAssignedID()) + "</ram:IssuerAssignedID>\n" +
-							"<ram:TypeCode>" + XMLTools.encodeXML(currentReferencedDocument.getTypeCode()) + "</ram:TypeCode>\n" +
-							"<ram:ReferenceTypeCode>" + XMLTools.encodeXML(currentReferencedDocument.getReferenceTypeCode()) + "</ram:ReferenceTypeCode>\n" +
-							"</ram:AdditionalReferencedDocument>\n");
 
-
-				}
-
-			}*/
-			if (currentItem.getBuyerOrderReferencedDocumentLineID() != null) {
-				xml.append("<ram:BuyerOrderReferencedDocument> \n"
-						+ "<ram:LineID>" + XMLTools.encodeXML(currentItem.getBuyerOrderReferencedDocumentLineID()) + "</ram:LineID>"
+			if (currentItem.getBuyerOrderReferencedDocument() != null && currentItem.getBuyerOrderReferencedDocument().getLineID() != null) {
+				xml.append("<ram:BuyerOrderReferencedDocument>"
+						+ "<ram:LineID>" + XMLTools.encodeXML(currentItem.getBuyerOrderReferencedDocument().getLineID()) + "</ram:LineID>"
 						+ "</ram:BuyerOrderReferencedDocument>");
 
 			}
@@ -243,23 +231,20 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 		xml.append(getTradePartyAsXML(trans.getRecipient(), false, false));
 		xml.append("</ram:BuyerTradeParty>");
 
-		if (trans.getSellerOrderReferencedDocumentID() != null) {
+		if (trans.getSellerOrderReferencedDocument() != null && trans.getSellerOrderReferencedDocument().getIssuerAssignedID() != null) {
 			xml.append("<ram:SellerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:SellerOrderReferencedDocument>");
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getSellerOrderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:SellerOrderReferencedDocument>");
 		}
-		if (trans.getBuyerOrderReferencedDocumentID() != null) {
+		if (trans.getBuyerOrderReferencedDocument() != null && trans.getBuyerOrderReferencedDocument().getIssuerAssignedID() != null) {
 			xml.append("<ram:BuyerOrderReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
-					+ "</ram:BuyerOrderReferencedDocument>");
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getBuyerOrderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:BuyerOrderReferencedDocument>");
 		}
-		if (trans.getContractReferencedDocument() != null) {
+		if (trans.getContractReferencedDocument() != null && trans.getContractReferencedDocument().getIssuerAssignedID() != null) {
 			xml.append("<ram:ContractReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
-					+ "</ram:ContractReferencedDocument>");
+				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getContractReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
+				+ "</ram:ContractReferencedDocument>");
 		}
 
 		// Additional Documents of XRechnung (Rechnungsbegruendende Unterlagen - BG-24 XRechnung)
@@ -317,15 +302,6 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 	//			+ "<ram:PaymentReference>" + XMLTools.encodeXML(trans.getNumber()) + "</ram:PaymentReference>"
 				+ "<ram:OrderCurrencyCode>" + trans.getCurrency() + "</ram:OrderCurrencyCode>");
 
-		if (trans.getTradeSettlementPayment() != null) {
-			for (final IZUGFeRDTradeSettlementPayment payment : trans.getTradeSettlementPayment()) {
-				if (payment != null) {
-					hasDueDate = true;
-                    break;
-                    //	xml.append(payment.getSettlementXML());
-                }
-			}
-		}
 		if (trans.getTradeSettlement() != null) {
 			for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement()) {
 				if (payment != null) {
@@ -337,9 +313,9 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 			}
 		}
 		if (trans.getDocumentCode() != null) {
-  		if ((trans.getDocumentCode().equals(CORRECTEDINVOICE))/*||(trans.getDocumentCode().equals (DocumentCodeTypeConstants.CREDITNOTE))*/) {
-  			hasDueDate = false;
-  		}
+			if (trans.getDocumentCode().equals(CORRECTEDINVOICE) /* ||(trans.getDocumentCode().equals (DocumentCodeTypeConstants.CREDITNOTE))*/) {
+				hasDueDate = false;
+			}
 		}
 
 		final Map<BigDecimal, VATAmount> VATPercentAmountMap = calc.getVATPercentAmountMap();
@@ -412,7 +388,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 							"<ram:CategoryCode>" + VATPercentAmountMap.get(currentTaxPercent).getCategoryCode() + "</ram:CategoryCode>" +
 							"<ram:RateApplicablePercent>" + vatFormat(currentTaxPercent) + "</ram:RateApplicablePercent>" +
 							"</ram:CategoryTradeTax>" +
-							"</ram:SpecifiedTradeAllowanceCharge>	\n");
+							"</ram:SpecifiedTradeAllowanceCharge>");
 				}
 			}
 		}
@@ -427,7 +403,7 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 
 			if (trans.getTradeSettlement() != null) {
 				for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement()) {
-					if (payment != null && payment instanceof IZUGFeRDTradeSettlementDebit) {
+					if (payment instanceof IZUGFeRDTradeSettlementDebit) {
 		//not in order-x				xml.append(payment.getPaymentXML());
 					}
 				}
@@ -458,27 +434,13 @@ public class OXPullProvider extends ZUGFeRD2PullProvider {
 				//+ "<ram:TotalPrepaidAmount>" + currencyFormat(calc.getTotalPrepaid()) + "</ram:TotalPrepaidAmount>"
 				//+ "<ram:DuePayableAmount>" + currencyFormat(calc.getGrandTotal().subtract(calc.getTotalPrepaid())) + "</ram:DuePayableAmount>"
 				+ "</ram:SpecifiedTradeSettlementHeaderMonetarySummation>");
-		if (trans.getInvoiceReferencedDocumentID() != null) {
-			xml.append("<ram:InvoiceReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getInvoiceReferencedDocumentID()) + "</ram:IssuerAssignedID>");
-			if (trans.getInvoiceReferencedIssueDate() != null) {
-				xml.append("<ram:FormattedIssueDateTime>"
-						+ DATE.qdtFormat(trans.getInvoiceReferencedIssueDate())
-						+ "</ram:FormattedIssueDateTime>");
-			}
-			xml.append("</ram:InvoiceReferencedDocument>");
-		}
 		if (trans.getInvoiceReferencedDocuments() != null) {
 			for (ReferencedDocument doc : trans.getInvoiceReferencedDocuments()) {
 				xml.append("<ram:InvoiceReferencedDocument>"
-						+ "<ram:IssuerAssignedID>"
-						+ XMLTools.encodeXML(doc.getIssuerAssignedID()) + "</ram:IssuerAssignedID>");
-				if (doc.getFormattedIssueDateTime() != null) {
-					xml.append("<ram:FormattedIssueDateTime>"
-							+ DATE.qdtFormat(doc.getFormattedIssueDateTime())
-							+ "</ram:FormattedIssueDateTime>");
-				}
+						+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(doc.getIssuerAssignedID()) + "</ram:IssuerAssignedID>");
+					if (doc.getFormattedIssueDateTime() != null) {
+						xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(doc.getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
+					}
 				xml.append("</ram:InvoiceReferencedDocument>");
 			}
 		}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/UBLDAPullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/UBLDAPullProvider.java
@@ -76,7 +76,7 @@ public class UBLDAPullProvider implements IXMLProvider {
 							"    <cbc:ID>" + XMLTools.encodeXML(Integer.toString(i++)) + "</cbc:ID>\n" +
 							"    <cbc:DeliveredQuantity unitCode=\"" + XMLTools.encodeXML(item.getProduct().getUnit()) + "\">" + item.getQuantity() + "</cbc:DeliveredQuantity>\n" +
 							"    <cac:OrderLineReference>\n" +
-							"      <cbc:LineID>" + XMLTools.encodeXML(item.getBuyerOrderReferencedDocumentLineID()) + "</cbc:LineID>\n" +
+							"      <cbc:LineID>" + XMLTools.encodeXML(item.getBuyerOrderReferencedDocument().getLineID()) + "</cbc:LineID>\n" +
 							"    </cac:OrderLineReference>\n" +
 							"    <cac:Item>\n" +
 							"      <cbc:Name>" + XMLTools.encodeXML(item.getProduct().getName()) + "</cbc:Name>\n" +
@@ -124,10 +124,10 @@ public class UBLDAPullProvider implements IXMLProvider {
 		try {
 			final OutputFormat format = OutputFormat.createPrettyPrint();
 			format.setTrimText(false);
-			final XMLWriter writer = new XMLWriter(sw, format);
-			writer.write(document);
-			res = sw.toString().getBytes(StandardCharsets.UTF_8);
-
+			try ( XMLWriter writer = new XMLWriter(sw, format) ) {
+				writer.write(document);
+				res = sw.toString().getBytes(StandardCharsets.UTF_8);
+			}
 		} catch (final IOException e) {
 			LOGGER.error ("Failed to write XML", e);
 		}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/VATAmount.java
@@ -115,27 +115,6 @@ public class VATAmount {
 		return this;
 	}
 
-	/**
-	 *
-	 * @deprecated Use {@link #getCategoryCode() instead}
-	 * @return String with category code
-	 */
-	@Deprecated
-	public String getDocumentCode() {
-		return categoryCode;
-	}
-
-	/**
-     * @param documentCode as String
-	 * @deprecated Use {@link #setCategoryCode(String)} instead
-	 * @return fluent setter
-	 */
-	@Deprecated
-	public VATAmount setDocumentCode(String documentCode) {
-		this.categoryCode = documentCode;
-		return this;
-	}
-
 	public String getCategoryCode() {
 		return categoryCode;
 	}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ValidationLogVisualizer.java
@@ -10,7 +10,6 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
-import javax.xml.XMLConstants;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
@@ -90,71 +89,68 @@ public class ValidationLogVisualizer {
 		return baos.toString(StandardCharsets.UTF_8);
 	}
 
+	@SuppressWarnings("unchecked")
 	public byte[] createPDFBytes(String xmlLogfileContent) {
 
 		// the writing part
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-		String result = null;
-
-			/* remove file endings so that tests can also pass after checking
-			   out from git with arbitrary options (which may include CSRF changes)
-			 */
+		/* remove file endings so that tests can also pass after checking
+		   out from git with arbitrary options (which may include CSRF changes)
+		 */
 		try {
-			result = this.toFOP(xmlLogfileContent);
+			String result = this.toFOP(xmlLogfileContent);
+			DefaultConfigurationBuilder cfgBuilder = new DefaultConfigurationBuilder();
+
+			Configuration cfg = null;
+			try {
+				cfg = cfgBuilder.build(CLASS_LOADER.getResourceAsStream("fop-config.xconf"));
+			} catch (ConfigurationException e) {
+				throw new RuntimeException(e);
+			}
+
+			FopFactoryBuilder builder = new FopFactoryBuilder(new File(".").toURI(), new ClasspathResolverURIAdapter()).setConfiguration(cfg);
+			// Step 1: Construct a FopFactory by specifying a reference to the configuration file
+			// (reuse if you plan to render multiple documents!)
+
+			FopFactory fopFactory = builder.build();
+
+			fopFactory.getFontManager().setResourceResolver(
+				ResourceResolverFactory.createInternalResourceResolver(
+					new File(".").toURI(),
+					new ClasspathResolverURIAdapter()));
+
+			FOUserAgent userAgent = fopFactory.newFOUserAgent();
+
+			userAgent.getRendererOptions().put("pdf-a-mode", "PDF/A-3b");
+
+			// Step 2: Set up output stream.
+			// Note: Using BufferedOutputStream for performance reasons (helpful with FileOutputStreams).
+
+			try (OutputStream out = new BufferedOutputStream(baos)) {
+
+				// Step 3: Construct fop with desired output format
+				Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
+
+				// Step 4: Setup JAXP using identity transformer
+				TransformerFactory factory = XMLTools.getTransformerFactory();
+				Transformer transformer = factory.newTransformer(); // identity transformer
+
+				// Step 5: Setup input and output for XSLT transformation
+				// Setup input stream
+				Source src = new StreamSource(new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8)));
+
+				// Resulting SAX events (the generated FO) must be piped through to FOP
+				Result res = new SAXResult(fop.getDefaultHandler());
+
+				// Step 6: Start XSLT transformation and FOP processing
+				transformer.transform(src, res);
+
+			} catch (FOPException | IOException | TransformerException e) {
+				LOGGER.error("Failed to create PDF", e);
+			}
 		} catch ( TransformerException e) {
 			LOGGER.error("Failed to apply FOP", e);
-		}
-		DefaultConfigurationBuilder cfgBuilder = new DefaultConfigurationBuilder();
-
-		Configuration cfg = null;
-		try {
-			cfg = cfgBuilder.build(CLASS_LOADER.getResourceAsStream("fop-config.xconf"));
-		} catch (ConfigurationException e) {
-			throw new RuntimeException(e);
-		}
-
-		FopFactoryBuilder builder = new FopFactoryBuilder(new File(".").toURI(), new ClasspathResolverURIAdapter()).setConfiguration(cfg);
-// Step 1: Construct a FopFactory by specifying a reference to the configuration file
-// (reuse if you plan to render multiple documents!)
-
-		FopFactory fopFactory = builder.build();
-
-		fopFactory.getFontManager().setResourceResolver(
-			ResourceResolverFactory.createInternalResourceResolver(
-				new File(".").toURI(),
-				new ClasspathResolverURIAdapter()));
-
-		FOUserAgent userAgent = fopFactory.newFOUserAgent();
-
-		userAgent.getRendererOptions().put("pdf-a-mode", "PDF/A-3b");
-
-// Step 2: Set up output stream.
-// Note: Using BufferedOutputStream for performance reasons (helpful with FileOutputStreams).
-
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		try (OutputStream out = new BufferedOutputStream(baos)) {
-
-			// Step 3: Construct fop with desired output format
-			Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out);
-
-			// Step 4: Setup JAXP using identity transformer
-			TransformerFactory factory = TransformerFactory.newInstance();
-
-			factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			Transformer transformer = factory.newTransformer(); // identity transformer
-
-			// Step 5: Setup input and output for XSLT transformation
-			// Setup input stream
-			Source src = new StreamSource(new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8)));
-
-			// Resulting SAX events (the generated FO) must be piped through to FOP
-			Result res = new SAXResult(fop.getDefaultHandler());
-
-			// Step 6: Start XSLT transformation and FOP processing
-			transformer.transform(src, res);
-
-		} catch (FOPException | IOException | TransformerException e) {
-			LOGGER.error("Failed to create PDF", e);
 		}
 		return baos.toByteArray();
 	}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD1PullProvider.java
@@ -140,16 +140,16 @@ public class ZUGFeRD1PullProvider extends ZUGFeRD2PullProvider {
 
 		xml.append("</ram:BuyerTradeParty>");
 
-		if (trans.getSellerOrderReferencedDocumentID() != null) {
+		if (trans.getSellerOrderReferencedDocument() != null) {
 			xml.append("<ram:SellerOrderReferencedDocument>"
 					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+					+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
 					+ "</ram:SellerOrderReferencedDocument>");
 		}
-		if (trans.getBuyerOrderReferencedDocumentID() != null) {
+		if (trans.getBuyerOrderReferencedDocument() != null) {
 			xml.append("<ram:BuyerOrderReferencedDocument>"
 					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+					+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
 					+ "</ram:BuyerOrderReferencedDocument>");
 		}
 		xml.append("</ram:ApplicableSupplyChainTradeAgreement>"

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -30,6 +30,7 @@ import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -153,9 +154,8 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					xml.append("<ram:ID>" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getID()) + "</ram:ID>");
 				} else {
 					String schemeAttribute = "";
-					if ((party.getLegalOrganisation().getSchemedID().getScheme() != null) && (party.getLegalOrganisation().getSchemedID().getScheme().length() > 0)) {
+					if (party.getLegalOrganisation().getSchemedID().getScheme() != null && !party.getLegalOrganisation().getSchemedID().getScheme().isEmpty()) {
 						schemeAttribute = "schemeID=\"" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getScheme()) + "\"";
-
 					}
 					xml.append("<ram:ID " + schemeAttribute + ">" + XMLTools.encodeXML(party.getLegalOrganisation().getSchemedID().getID()) + "</ram:ID>");
 				}
@@ -365,8 +365,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 
 		if ((profile == Profiles.getByName("XRechnung")) && (trans.getCashDiscounts() != null) && (trans.getCashDiscounts().length > 0)) {
-			for (IZUGFeRDCashDiscount discount : trans.getCashDiscounts()
-			) {
+			for (IZUGFeRDCashDiscount discount : trans.getCashDiscounts() ) {
 				if (paymentTermsDescription == null) {
 					paymentTermsDescription = "";
 				}
@@ -374,11 +373,10 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			}
 		} else if (paymentTermsDescription == null
 			&& !DocumentCodeTypeConstants.CORRECTEDINVOICE.equals(trans.getDocumentCode())
-			&& !DocumentCodeTypeConstants.CREDITNOTE.equals(trans.getDocumentCode())
-		) {
-			if (trans.getDueDate() != null) {
-				paymentTermsDescription = "Please remit until " + germanDateFormat.format(trans.getDueDate());
-			}
+			&& !DocumentCodeTypeConstants.CREDITNOTE.equals(trans.getDocumentCode()) ) {
+				if (trans.getDueDate() != null) {
+					paymentTermsDescription = "Please remit until " + germanDateFormat.format(trans.getDueDate());
+				}
 		}
 
 
@@ -495,34 +493,32 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				if (currentItem.getProduct().getCountryOfOrigin() != null) {
 					xml.append("<ram:OriginTradeCountry><ram:ID>" + XMLTools.encodeXML(currentItem.getProduct().getCountryOfOrigin()) + "</ram:ID></ram:OriginTradeCountry>");
 				}
-				xml.append("</ram:SpecifiedTradeProduct>" + "<ram:SpecifiedLineTradeAgreement>");
+				xml.append("</ram:SpecifiedTradeProduct>");
+
+				xml.append("<ram:SpecifiedLineTradeAgreement>");
+				if (currentItem.getSellerOrderReferencedDocument() != null && !currentItem.getSellerOrderReferencedDocument().getAsCII().isEmpty()) {
+					xml.append("<ram:SellerOrderReferencedDocument>"
+						+ currentItem.getSellerOrderReferencedDocument().getAsCII()
+						+ "</ram:SellerOrderReferencedDocument>");
+				}
+				if (currentItem.getBuyerOrderReferencedDocument() != null && !currentItem.getBuyerOrderReferencedDocument().getAsCII().isEmpty()) {
+					xml.append("<ram:BuyerOrderReferencedDocument>"
+						+ currentItem.getBuyerOrderReferencedDocument().getAsCII()
+						+ "</ram:BuyerOrderReferencedDocument>");
+				}
+				if (currentItem.getContractReferencedDocument() != null && !currentItem.getContractReferencedDocument().getAsCII().isEmpty()) {
+					xml.append("<ram:ContractReferencedDocument>"
+						+ currentItem.getContractReferencedDocument().getAsCII()
+						+ "</ram:ContractReferencedDocument>");
+				}
 				if (currentItem.getReferencedDocuments() != null) {
 					for (final IReferencedDocument currentReferencedDocument : currentItem.getReferencedDocuments()) {
-						xml.append("<ram:AdditionalReferencedDocument>" +
-							"<ram:IssuerAssignedID>" + XMLTools.encodeXML(currentReferencedDocument.getIssuerAssignedID()) + "</ram:IssuerAssignedID>" +
-							"<ram:TypeCode>" + XMLTools.encodeXML(currentReferencedDocument.getTypeCode()) + "</ram:TypeCode>");
-						if (currentReferencedDocument.getName() != null) {
-							xml.append("<ram:name>" + XMLTools.encodeXML(currentReferencedDocument.getName()) + "</ram:Name>");
+						if (!currentReferencedDocument.getAsCII().isEmpty()) {
+							xml.append("<ram:AdditionalReferencedDocument>"
+								+ currentReferencedDocument.getAsCII()
+								+ "</ram:AdditionalReferencedDocument>");
 						}
-						if (currentReferencedDocument.getReferenceTypeCode() != null) {
-							xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(currentReferencedDocument.getReferenceTypeCode()) + "</ram:ReferenceTypeCode>");
-						}
-						if (currentReferencedDocument.getFormattedIssueDateTime() != null) {
-							final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-							xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(currentReferencedDocument.getFormattedIssueDateTime())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
-						}
-						xml.append("</ram:AdditionalReferencedDocument>");
 					}
-				}
-				if ((currentItem.getBuyerOrderReferencedDocumentLineID() != null) || (currentItem.getBuyerOrderReferencedDocumentID() != null)) {
-					xml.append("<ram:BuyerOrderReferencedDocument> ");
-					if (currentItem.getBuyerOrderReferencedDocumentID() != null) {
-						xml.append("<ram:IssuerAssignedID>" + XMLTools.encodeXML(currentItem.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>");
-					}
-					if (currentItem.getBuyerOrderReferencedDocumentLineID() != null) {
-						xml.append("<ram:LineID>" + XMLTools.encodeXML(currentItem.getBuyerOrderReferencedDocumentLineID()) + "</ram:LineID>");
-					}
-					xml.append("</ram:BuyerOrderReferencedDocument>");
 				}
 
 				// Per-unit provider for product-level: ActualAmount must be per-unit (BT-147)
@@ -570,32 +566,32 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "\">" + quantityFormat(currentItem.getBasisQuantity()) + "</ram:BasisQuantity>"
 					+ "</ram:NetPriceProductTradePrice>");
 
-                if (currentItem.getLineSeller() != null) {
-                    xml.append("<ram:ItemSellerTradeParty>" + getTradePartyAsXML(currentItem.getLineSeller(), true, false) + "</ram:ItemSellerTradeParty>");
+				if (currentItem.getLineSeller() != null) {
+					xml.append("<ram:ItemSellerTradeParty>" + getTradePartyAsXML(currentItem.getLineSeller(), true, false) + "</ram:ItemSellerTradeParty>");
+				}
 
-                }
 				xml.append("</ram:SpecifiedLineTradeAgreement>"
 					+ "<ram:SpecifiedLineTradeDelivery>"
 					+ "<ram:BilledQuantity unitCode=\"" + XMLTools.encodeXML(currentItem.getProduct().getUnit()) + "\">"
 					+ quantityFormat(currentItem.getQuantity()) + "</ram:BilledQuantity>");
 
-					if (currentItem.getDeliveryNoteReferencedDocumentID() != null && !currentItem.getDeliveryNoteReferencedDocumentID().trim().isEmpty()) {
-						xml.append("<ram:DeliveryNoteReferencedDocument>");
-						xml.append("<ram:IssuerAssignedID>" + XMLTools.encodeXML(currentItem.getDeliveryNoteReferencedDocumentID()) + "</ram:IssuerAssignedID>");
-						if (currentItem.getDeliveryNoteReferencedDocumentLineID() != null && !currentItem.getDeliveryNoteReferencedDocumentLineID().trim().isEmpty()) {
-							xml.append("<ram:LineID>" + XMLTools.encodeXML(currentItem.getDeliveryNoteReferencedDocumentLineID()) + "</ram:LineID>");
-						}
-						if (currentItem.getDeliveryNoteReferencedDocumentDate() != null) {
-							final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-							xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(currentItem.getDeliveryNoteReferencedDocumentDate())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
-						}
-						xml.append("</ram:DeliveryNoteReferencedDocument>");
-
+				if (getProfile() == Profiles.getByName("Extended")) {
+					if (currentItem.getDespatchAdviceReferencedDocument() != null && !currentItem.getDespatchAdviceReferencedDocument().getAsCII().isEmpty()) {
+						xml.append("<ram:DespatchAdviceReferencedDocument>");
+						xml.append(currentItem.getDespatchAdviceReferencedDocument().getAsCII());
+						xml.append("</ram:DespatchAdviceReferencedDocument>");
 					}
 
-					xml.append("</ram:SpecifiedLineTradeDelivery>"
-					+ "<ram:SpecifiedLineTradeSettlement>"
-					+ "<ram:ApplicableTradeTax>");
+					if (currentItem.getDeliveryNoteReferencedDocument() != null && !currentItem.getDeliveryNoteReferencedDocument().getAsCII().isEmpty()) {
+						xml.append("<ram:DeliveryNoteReferencedDocument>");
+						xml.append(currentItem.getDeliveryNoteReferencedDocument().getAsCII());
+						xml.append("</ram:DeliveryNoteReferencedDocument>");
+					}
+				}
+
+				xml.append("</ram:SpecifiedLineTradeDelivery>");
+				xml.append("<ram:SpecifiedLineTradeSettlement>");
+				xml.append("<ram:ApplicableTradeTax>");
 				// <CalculatedAmount/>
 				xml.append("<ram:TypeCode>VAT</ram:TypeCode>");
 				if (profile != Profiles.getByName("EN16931") && currentItem.getProduct().getTaxExemptionReason() != null) {
@@ -664,20 +660,14 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "</ram:SpecifiedTradeSettlementLineMonetarySummation>");
 				if (currentItem.getAdditionalReferences() != null) {
 					for (final IReferencedDocument currentReference : currentItem.getAdditionalReferences()) {
-						xml.append("<ram:AdditionalReferencedDocument>" +
-							"<ram:IssuerAssignedID>" + XMLTools.encodeXML(currentReference.getIssuerAssignedID()) + "</ram:IssuerAssignedID>" +
-							"<ram:TypeCode>130</ram:TypeCode>");
-						if (currentReference.getName() != null) {
-							xml.append("<ram:name>" + XMLTools.encodeXML(currentReference.getName()) + "</ram:Name>");
+						if (!currentReference.getAsCII().isEmpty()) {
+							if (currentReference instanceof ReferencedDocument) {
+								((ReferencedDocument) currentReference).setTypeCode("130");
+							}
+							xml.append("<ram:AdditionalReferencedDocument>"
+								+ currentReference.getAsCII()
+								+ "</ram:AdditionalReferencedDocument>");
 						}
-						if (currentReference.getReferenceTypeCode() != null) {
-							xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(currentReference.getReferenceTypeCode()) + "</ram:ReferenceTypeCode>");
-						}
-						if (currentReference.getFormattedIssueDateTime() != null) {
-							final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-							xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(currentReference.getFormattedIssueDateTime())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
-						}
-						xml.append("</ram:AdditionalReferencedDocument>");
 					}
 				}
 				if (currentItem.getAccountingReference() != null && !currentItem.getAccountingReference().trim().isEmpty()) {
@@ -706,22 +696,19 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				+ "</ram:DeliveryTypeCode>"
 				+ "</ram:ApplicableTradeDeliveryTerms>");
 		}
-		if (trans.getSellerOrderReferencedDocumentID() != null && !trans.getSellerOrderReferencedDocumentID().trim().isEmpty()) {
+		if (trans.getSellerOrderReferencedDocument() != null && !trans.getSellerOrderReferencedDocument().getAsCII().isEmpty()) {
 			xml.append("<ram:SellerOrderReferencedDocument>"
-				+ "<ram:IssuerAssignedID>"
-				+ XMLTools.encodeXML(trans.getSellerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+				+ trans.getSellerOrderReferencedDocument().getAsCII()
 				+ "</ram:SellerOrderReferencedDocument>");
 		}
-		if (trans.getBuyerOrderReferencedDocumentID() != null && !trans.getBuyerOrderReferencedDocumentID().trim().isEmpty()) {
+		if (trans.getBuyerOrderReferencedDocument() != null && !trans.getBuyerOrderReferencedDocument().getAsCII().isEmpty()) {
 			xml.append("<ram:BuyerOrderReferencedDocument>"
-				+ "<ram:IssuerAssignedID>"
-				+ XMLTools.encodeXML(trans.getBuyerOrderReferencedDocumentID()) + "</ram:IssuerAssignedID>"
+				+ trans.getBuyerOrderReferencedDocument().getAsCII()
 				+ "</ram:BuyerOrderReferencedDocument>");
 		}
-		if (trans.getContractReferencedDocument() != null && !trans.getContractReferencedDocument().trim().isEmpty()) {
+		if (trans.getContractReferencedDocument() != null && !trans.getContractReferencedDocument().getAsCII().isEmpty()) {
 			xml.append("<ram:ContractReferencedDocument>"
-				+ "<ram:IssuerAssignedID>"
-				+ XMLTools.encodeXML(trans.getContractReferencedDocument()) + "</ram:IssuerAssignedID>"
+				+ trans.getContractReferencedDocument().getAsCII()
 				+ "</ram:ContractReferencedDocument>");
 		}
 
@@ -733,64 +720,34 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 					+ "<ram:IssuerAssignedID>" + f.getFilename() + "</ram:IssuerAssignedID>"
 					+ "<ram:TypeCode>916</ram:TypeCode>"
 					+ "<ram:Name>" + f.getDescription() + "</ram:Name>"
-					+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\"\n"
-					+ "filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
+					+ "<ram:AttachmentBinaryObject mimeCode=\"" + f.getMimetype() + "\""
+					+ " filename=\"" + f.getFilename() + "\">" + documentContent + "</ram:AttachmentBinaryObject>"
 					+ "</ram:AdditionalReferencedDocument>");
 			}
 		}
-		if (trans.getObjectIdentifierReferencedDocument() != null) {
-			xml.append("<ram:AdditionalReferencedDocument>"
-				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getObjectIdentifierReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
-				+ "<ram:TypeCode>130</ram:TypeCode>");
-		    String name = trans.getObjectIdentifierReferencedDocument().getName();
-		    if (name != null && !name.isEmpty()) {
-		        xml.append("<ram:Name>" + XMLTools.encodeXML(name) + "</ram:Name>");
-		    }
-		    // NEW: BT-18-1 scheme identifier
-		    String rtc = trans.getObjectIdentifierReferencedDocument().getReferenceTypeCode();
-		    if (rtc != null && !rtc.isEmpty()) {
-		        xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
-		    }
-			if (trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime() != null) {
-				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getObjectIdentifierReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
+		if (trans.getObjectIdentifierReferencedDocument() != null && !trans.getObjectIdentifierReferencedDocument().getAsCII().isEmpty()) {
+			if (trans.getObjectIdentifierReferencedDocument() instanceof ReferencedDocument) {
+				((ReferencedDocument) trans.getObjectIdentifierReferencedDocument()).setTypeCode("130");
 			}
-			xml.append("</ram:AdditionalReferencedDocument>");
+			xml.append("<ram:AdditionalReferencedDocument>"
+				+ trans.getObjectIdentifierReferencedDocument().getAsCII()
+				+ "</ram:AdditionalReferencedDocument>");
 		}
-		if (trans.getTenderReferencedDocument() != null) {
-			xml.append("<ram:AdditionalReferencedDocument>"
-				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getTenderReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
-				+ "<ram:TypeCode>50</ram:TypeCode>");
-		    String name = trans.getTenderReferencedDocument().getName();
-		    if (name != null && !name.isEmpty()) {
-		        xml.append("<ram:Name>" + XMLTools.encodeXML(name) + "</ram:Name>");
-		    }
-		    // NEW: BT-18-1 scheme identifier
-		    String rtc = trans.getTenderReferencedDocument().getReferenceTypeCode();
-		    if (rtc != null && !rtc.isEmpty()) {
-		    	xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
-		    }
-			if (trans.getTenderReferencedDocument().getFormattedIssueDateTime() != null) {
-				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getTenderReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
+		if (trans.getTenderReferencedDocument() != null && !trans.getTenderReferencedDocument().getAsCII().isEmpty()) {
+			if (trans.getTenderReferencedDocument() instanceof ReferencedDocument) {
+				((ReferencedDocument) trans.getTenderReferencedDocument()).setTypeCode("50");
 			}
-			xml.append("</ram:AdditionalReferencedDocument>");
+			xml.append("<ram:AdditionalReferencedDocument>"
+				+ trans.getTenderReferencedDocument().getAsCII()
+				+ "</ram:AdditionalReferencedDocument>");
 		}
-		if (trans.getRelatedReferencedDocument() != null) {
-			xml.append("<ram:AdditionalReferencedDocument>"
-				+ "<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getRelatedReferencedDocument().getIssuerAssignedID()) + "</ram:IssuerAssignedID>"
-				+ "<ram:TypeCode>916</ram:TypeCode>");
-		    String name = trans.getRelatedReferencedDocument().getName();
-		    if (name != null && !name.isEmpty()) {
-		        xml.append("<ram:Name>" + XMLTools.encodeXML(name) + "</ram:Name>");
-		    }
-		    // NEW: BT-18-1 scheme identifier
-		    String rtc = trans.getRelatedReferencedDocument().getReferenceTypeCode();
-		    if (rtc != null && !rtc.isEmpty()) {
-		    	xml.append("<ram:ReferenceTypeCode>" + XMLTools.encodeXML(rtc) + "</ram:ReferenceTypeCode>");
-		    }
-			if (trans.getRelatedReferencedDocument().getFormattedIssueDateTime() != null) {
-				xml.append("<ram:FormattedIssueDateTime>" + DATE.qdtFormat(trans.getRelatedReferencedDocument().getFormattedIssueDateTime()) + "</ram:FormattedIssueDateTime>");
+		if (trans.getRelatedReferencedDocument() != null && !trans.getRelatedReferencedDocument().getAsCII().isEmpty()) {
+			if (trans.getRelatedReferencedDocument() instanceof ReferencedDocument) {
+				((ReferencedDocument) trans.getRelatedReferencedDocument()).setTypeCode("916");
 			}
-			xml.append("</ram:AdditionalReferencedDocument>");
+			xml.append("<ram:AdditionalReferencedDocument>"
+				+ trans.getRelatedReferencedDocument().getAsCII()
+				+ "</ram:AdditionalReferencedDocument>");
 		}
 		if (trans.getSpecifiedProcuringProjectID() != null) {
 			xml.append("<ram:SpecifiedProcuringProject>"
@@ -821,20 +778,18 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 				+ "</ram:ActualDeliverySupplyChainEvent>");
 		}
 
-		if (trans.getDespatchAdviceReferencedDocumentID() != null && !trans.getDespatchAdviceReferencedDocumentID().trim().isEmpty()) {
+		if (trans.getDespatchAdviceReferencedDocument() != null && !trans.getDespatchAdviceReferencedDocument().getAsCII().isEmpty()) {
 			xml.append("<ram:DespatchAdviceReferencedDocument>");
-			xml.append("<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getDespatchAdviceReferencedDocumentID()) + "</ram:IssuerAssignedID>");
+			xml.append(trans.getDespatchAdviceReferencedDocument().getAsCII());
 			xml.append("</ram:DespatchAdviceReferencedDocument>");
 		}
 
-		if (trans.getDeliveryNoteReferencedDocumentID() != null && !trans.getDeliveryNoteReferencedDocumentID().trim().isEmpty()) {
-			xml.append("<ram:DeliveryNoteReferencedDocument>");
-			xml.append("<ram:IssuerAssignedID>" + XMLTools.encodeXML(trans.getDeliveryNoteReferencedDocumentID()) + "</ram:IssuerAssignedID>");
-			if (trans.getDeliveryNoteReferencedDocumentDate() != null) {
-				final SimpleDateFormat dateFormat102 = new SimpleDateFormat("yyyyMMdd");
-				xml.append("<ram:FormattedIssueDateTime><qdt:DateTimeString format=\"102\">" + XMLTools.encodeXML(dateFormat102.format(trans.getDeliveryNoteReferencedDocumentDate())) + "</qdt:DateTimeString></ram:FormattedIssueDateTime>");
+		if (getProfile() == Profiles.getByName("Extended")) {
+			if (trans.getDeliveryNoteReferencedDocument() != null && !trans.getDeliveryNoteReferencedDocument().getAsCII().isEmpty()) {
+				xml.append("<ram:DeliveryNoteReferencedDocument>");
+				xml.append(trans.getDeliveryNoteReferencedDocument().getAsCII());
+				xml.append("</ram:DeliveryNoteReferencedDocument>");
 			}
-			xml.append("</ram:DeliveryNoteReferencedDocument>");
 		}
 
 		xml.append("</ram:ApplicableHeaderTradeDelivery>");
@@ -1139,8 +1094,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			xml.append(buildPaymentTermsXml());
 		}
 		if (profile == Profiles.getByName("Extended") && trans.getCashDiscounts() != null) {
-			for (IZUGFeRDCashDiscount discount : trans.getCashDiscounts()
-			) {
+			for (IZUGFeRDCashDiscount discount : trans.getCashDiscounts()) {
 				xml.append(discount.getAsCII());
 			}
 		}
@@ -1173,28 +1127,13 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		}
 		xml.append("<ram:DuePayableAmount>" + currencyFormat(calc.getDuePayable()) + "</ram:DuePayableAmount>"
 			+ "</ram:SpecifiedTradeSettlementHeaderMonetarySummation>");
-		if (trans.getInvoiceReferencedDocumentID() != null && !trans.getInvoiceReferencedDocumentID().trim().isEmpty()) {
-			xml.append("<ram:InvoiceReferencedDocument>"
-				+ "<ram:IssuerAssignedID>"
-				+ XMLTools.encodeXML(trans.getInvoiceReferencedDocumentID()) + "</ram:IssuerAssignedID>");
-			if (trans.getInvoiceReferencedIssueDate() != null) {
-				xml.append("<ram:FormattedIssueDateTime>"
-					+ DATE.qdtFormat(trans.getInvoiceReferencedIssueDate())
-					+ "</ram:FormattedIssueDateTime>");
-			}
-			xml.append("</ram:InvoiceReferencedDocument>");
-		}
 		if (trans.getInvoiceReferencedDocuments() != null) {
 			for (ReferencedDocument doc : trans.getInvoiceReferencedDocuments()) {
-				xml.append("<ram:InvoiceReferencedDocument>"
-					+ "<ram:IssuerAssignedID>"
-					+ XMLTools.encodeXML(doc.getIssuerAssignedID()) + "</ram:IssuerAssignedID>");
-				if (doc.getFormattedIssueDateTime() != null) {
-					xml.append("<ram:FormattedIssueDateTime>"
-						+ DATE.qdtFormat(doc.getFormattedIssueDateTime())
-						+ "</ram:FormattedIssueDateTime>");
+				if (!doc.getAsCII().isEmpty()) {
+					xml.append("<ram:InvoiceReferencedDocument>"
+						+ doc.getAsCII()
+						+ "</ram:InvoiceReferencedDocument>");
 				}
-				xml.append("</ram:InvoiceReferencedDocument>");
 			}
 		}
 
@@ -1267,14 +1206,12 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 			// add extended payment terms (except the first one which is already added above)
 			{
 				IZUGFeRDPaymentTerms[] extendedPaymentTerms = trans.getExtendedPaymentTerms();
-				for (int i = 1; i < extendedPaymentTerms.length; i++) {
-					paymentTerms.add(extendedPaymentTerms[i]);
-				}
+				paymentTerms.addAll(Arrays.asList(extendedPaymentTerms));
 			}
 		}
 
 		String paymentTermsXml = "";
-		if (paymentTerms.size() == 0) {
+		if (paymentTerms.isEmpty()) {
 			return "";
 		}
 
@@ -1300,7 +1237,7 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 
 			if (trans.getTradeSettlement() != null) {
 				for (final IZUGFeRDTradeSettlement payment : trans.getTradeSettlement()) {
-					if ((payment != null) && (payment instanceof IZUGFeRDTradeSettlementDebit)) {
+					if (payment instanceof IZUGFeRDTradeSettlementDebit) {
 						paymentTermsXml += payment.getPaymentXML();
 					}
 				}

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDExporterFromA3.java
@@ -106,22 +106,6 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 	 */
 	protected String creatorTool = "mustangproject";
 
-	/**
-	 * @deprecated author is never set yet
-	 */
-	@Deprecated
-	protected String author;
-	/**
-	 * @deprecated title is never set yet
-	 */
-	@Deprecated
-	protected String title;
-	/**
-	 * @deprecated subject is never set yet
-	 */
-	@Deprecated
-	protected String subject;
-
 	protected PDDocument doc;
 
 	protected int zfVersion = defaultZUGFeRDVersion;
@@ -798,15 +782,10 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 
 		ArrayProperty titleProperty = dc.getTitleProperty();
 		if (titleProperty != null) {
-			if (overwrite && isNotBlank(title)) {
-				dc.removeProperty(titleProperty);
-				dc.setTitle(title);
-			} else if (titleProperty.getElementsAsString().stream().anyMatch("Untitled"::equalsIgnoreCase)) {
+			if (titleProperty.getElementsAsString().stream().anyMatch("Untitled"::equalsIgnoreCase)) {
 				// remove unfitting ghostscript default
 				dc.removeProperty(titleProperty);
 			}
-		} else if (isNotBlank(title)) {
-			dc.setTitle(title);
 		}
 	}
 
@@ -853,20 +832,11 @@ public class ZUGFeRDExporterFromA3 extends XRExporter implements IZUGFeRDExporte
 		if (overwrite || info.getModificationDate() == null) {
 			info.setModificationDate(Calendar.getInstance());
 		}
-		if (overwrite || (isBlank(info.getAuthor()) && isNotBlank(author))) {
-			info.setAuthor(author);
-		}
 		if (overwrite || (isBlank(info.getProducer()) && isNotBlank(fullProducer))) {
 			info.setProducer(fullProducer);
 		}
 		if (overwrite || (isBlank(info.getCreator()) && isNotBlank(creator))) {
 			info.setCreator(creator);
-		}
-		if (overwrite || (isBlank(info.getTitle()) && isNotBlank(title))) {
-			info.setTitle(title);
-		}
-		if (overwrite || (isBlank(info.getSubject()) && isNotBlank(subject))) {
-			info.setSubject(subject);
 		}
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDImporter.java
@@ -30,8 +30,10 @@ import javax.xml.xpath.XPathFactory;
 import org.mustangproject.FileAttachment;
 import org.mustangproject.Item;
 import org.mustangproject.Product;
+import org.mustangproject.ReferencedDocument;
 import org.mustangproject.SchemedID;
 import org.mustangproject.XMLTools;
+import org.mustangproject.util.NodeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
@@ -661,7 +663,6 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 			for (int i = 0; i < nl.getLength(); i++) {
 				final Node nn = nl.item(i);
 				Node node = null;
-				Node subnode = null;
 				if (nn.getLocalName() != null) {
 					switch (nn.getLocalName()) {
 						case "SpecifiedLineTradeAgreement":
@@ -719,28 +720,10 @@ public class ZUGFeRDImporter extends ZUGFeRDInvoiceImporter {
 						case "SpecifiedLineTradeDelivery":
 						case "SpecifiedSupplyChainTradeDelivery":
 							node = getNodeByName(nn.getChildNodes(), "BilledQuantity");
-							lineItem.setQuantity(XMLTools.tryBigDecimal(node));
-
-							node = getNodeByName(nn.getChildNodes(), "DeliveryNoteReferencedDocument");
 							if (node != null) {
-								subnode = getNodeByName(node.getChildNodes(), "IssuerAssignedID");
-								if (subnode != null) {
-									lineItem.setDeliveryNoteReferencedDocumentID(XMLTools.getNodeValue(subnode));
-								}
-								subnode = getNodeByName(node.getChildNodes(), "LineID");
-								if (subnode != null) {
-									lineItem.setDeliveryNoteReferencedDocumentLineID(XMLTools.getNodeValue(subnode));
-								}
-								node = getNodeByName(node.getChildNodes(), "FormattedIssueDateTime");
-								if (node != null) {
-									NodeList formattedIssueDateTimeChilds = node.getChildNodes();
-									for (int dateChildIndex = 0; dateChildIndex < formattedIssueDateTimeChilds.getLength(); dateChildIndex++) {
-										if ((formattedIssueDateTimeChilds.item(dateChildIndex).getLocalName() != null)
-											&& (formattedIssueDateTimeChilds.item(dateChildIndex).getLocalName().equals("DateTimeString"))) {
-											lineItem.setDeliveryNoteReferencedDocumentDate(XMLTools.tryDate(formattedIssueDateTimeChilds.item(dateChildIndex)));
-										}
-									}
-								}
+								lineItem.setQuantity(XMLTools.tryBigDecimal(node));
+								new NodeMap(node.getChildNodes()).getNode("DespatchAdviceReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> lineItem.setDespatchAdviceReferencedDocument(rd));
+								new NodeMap(node.getChildNodes()).getNode("DeliveryNoteReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> lineItem.setDeliveryNoteReferencedDocument(rd));
 							}
 							break;
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -60,7 +59,6 @@ import org.mustangproject.TradeParty;
 import org.mustangproject.XMLTools;
 import org.mustangproject.Exceptions.StructureException;
 import org.mustangproject.util.NodeMap;
-import org.mustangproject.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -570,9 +568,6 @@ public class ZUGFeRDInvoiceImporter {
 		Date issueDate = null;
 		Date dueDate = null;
 		Date deliveryDate = null;
-		String despatchAdviceReferencedDocument = null;
-		String deliveryNoteReferencedDocumentID = null;
-		Date deliveryNoteReferencedDocumentDate = null;
 
 		for (int i = 0; i < ExchangedDocumentNodes.getLength(); i++) {
 			Node exchangedDocumentNode = ExchangedDocumentNodes.item(i);
@@ -722,47 +717,16 @@ public class ZUGFeRDInvoiceImporter {
 							}
 						}
 					}
-
-					if (headerTradeDeliveryChilds.item(deliveryChildIndex).getLocalName().equals("DespatchAdviceReferencedDocument")) {
-						NodeList despatchAdviceChilds = headerTradeDeliveryChilds.item(deliveryChildIndex).getChildNodes();
-						for (int despatchAdviceChildIndex = 0; despatchAdviceChildIndex < despatchAdviceChilds.getLength(); despatchAdviceChildIndex++) {
-							if (despatchAdviceChilds.item(despatchAdviceChildIndex).getLocalName() != null
-								&& despatchAdviceChilds.item(despatchAdviceChildIndex).getLocalName().equals("IssuerAssignedID")) {
-								despatchAdviceReferencedDocument = XMLTools.trimOrNull(despatchAdviceChilds.item(despatchAdviceChildIndex));
-							}
-						}
-					}
-
-					if (headerTradeDeliveryChilds.item(deliveryChildIndex).getLocalName().equals("DeliveryNoteReferencedDocument")) {
-						NodeList deliveryNoteReferencedDocumentChilds = headerTradeDeliveryChilds.item(deliveryChildIndex).getChildNodes();
-						for (int deliveryNoteReferencedDocumentIndex = 0; deliveryNoteReferencedDocumentIndex < deliveryNoteReferencedDocumentChilds.getLength(); deliveryNoteReferencedDocumentIndex++) {
-							if (deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName() != null
-								&& deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName().equals("IssuerAssignedID")) {
-								deliveryNoteReferencedDocumentID = XMLTools.trimOrNull(deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex));
-							}
-
-							if ((deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName() != null)
-								&& (deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getLocalName().equals("FormattedIssueDateTime"))) {
-
-								NodeList FormattedIssueDateTimeChilds = deliveryNoteReferencedDocumentChilds.item(deliveryNoteReferencedDocumentIndex).getChildNodes();
-								for (int dateChildIndex = 0; dateChildIndex < FormattedIssueDateTimeChilds.getLength(); dateChildIndex++) {
-									if ((FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName() != null)
-										&& (FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName().equals("DateTimeString"))) {
-										deliveryNoteReferencedDocumentDate = XMLTools.tryDate(FormattedIssueDateTimeChilds.item(dateChildIndex));
-									}
-								}
-							}
-						}
-					}
 				}
 			}
+			NodeMap headerTradeDeliveryNodesMap = new NodeMap(headerTradeDeliveryChilds);
+			headerTradeDeliveryNodesMap.getNode("DespatchAdviceReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> zpp.setDespatchAdviceReferencedDocument(rd));
+			headerTradeDeliveryNodesMap.getNode("DeliveryNoteReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> zpp.setDeliveryNoteReferencedDocument(rd));
 		}
+
 
 		xpr = xpath.compile("//*[local-name()=\"ApplicableHeaderTradeAgreement\"]");
 		NodeList headerTradeAgreementNodes = (NodeList) xpr.evaluate(getDocument(), XPathConstants.NODESET);
-		String buyerOrderIssuerAssignedID = null;
-		String sellerOrderIssuerAssignedID = null;
-		String contractReferencedAssignedID = null;
 
 		for (int i = 0; i < headerTradeAgreementNodes.getLength(); i++) {
 			// XMLTools.trimOrNull(nodes.item(i)))) {
@@ -779,98 +743,15 @@ public class ZUGFeRDInvoiceImporter {
 							}
 						}
 					}
-
-					if (headerTradeAgreementChilds.item(agreementChildIndex).getLocalName().equals("BuyerOrderReferencedDocument")) {
-						NodeList buyerOrderChilds = headerTradeAgreementChilds.item(agreementChildIndex).getChildNodes();
-						for (int buyerOrderChildIndex = 0; buyerOrderChildIndex < buyerOrderChilds.getLength(); buyerOrderChildIndex++) {
-							if ((buyerOrderChilds.item(buyerOrderChildIndex).getLocalName() != null)
-								&& (buyerOrderChilds.item(buyerOrderChildIndex).getLocalName().equals("IssuerAssignedID"))) {
-								buyerOrderIssuerAssignedID = XMLTools.trimOrNull(buyerOrderChilds.item(buyerOrderChildIndex));
-							}
-						}
-					}
-
-					if (headerTradeAgreementChilds.item(agreementChildIndex).getLocalName().equals("SellerOrderReferencedDocument")) {
-						NodeList sellerOrderChilds = headerTradeAgreementChilds.item(agreementChildIndex).getChildNodes();
-						for (int sellerOrderChildIndex = 0; sellerOrderChildIndex < sellerOrderChilds.getLength(); sellerOrderChildIndex++) {
-							if ((sellerOrderChilds.item(sellerOrderChildIndex).getLocalName() != null)
-								&& (sellerOrderChilds.item(sellerOrderChildIndex).getLocalName().equals("IssuerAssignedID"))) {
-								sellerOrderIssuerAssignedID = XMLTools.trimOrNull(sellerOrderChilds.item(sellerOrderChildIndex));
-							}
-						}
-					}
-
-					if (headerTradeAgreementChilds.item(agreementChildIndex).getLocalName().equals("ContractReferencedDocument")) {
-						NodeList contractReferenceChilds = headerTradeAgreementChilds.item(agreementChildIndex).getChildNodes();
-						for (int index = 0; index < contractReferenceChilds.getLength(); index++) {
-							if ((contractReferenceChilds.item(index).getLocalName() != null)
-								&& (contractReferenceChilds.item(index).getLocalName().equals("IssuerAssignedID"))) {
-								contractReferencedAssignedID = XMLTools.trimOrNull(contractReferenceChilds.item(index));
-							}
-						}
-					}
-
-					int typeC = 0;
-					String additionalReferencedDocumentID = null;
-					String additionalReferencedDocumentName = null;
-					String additionalReferencedDocumentReferenceTypeCode = null;
-					Date additionalReferencedDocumentDate = null;
-					//Reading BT-17
-					if (headerTradeAgreementChilds.item(agreementChildIndex).getLocalName().equals("AdditionalReferencedDocument")) {
-						NodeList additionalChilds = headerTradeAgreementChilds.item(agreementChildIndex).getChildNodes();
-						for (int additionalChildIndex = 0; additionalChildIndex < additionalChilds.getLength(); additionalChildIndex++) {
-							if (additionalChilds.item(additionalChildIndex).getLocalName() != null) {
-								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("TypeCode")) {
-									typeC = Integer.parseInt(XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex)));
-								}
-								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("IssuerAssignedID")) {
-									additionalReferencedDocumentID = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
-								}
-								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("Name")) {
-									additionalReferencedDocumentName = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
-								}
-								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("ReferenceTypeCode")) {
-									additionalReferencedDocumentReferenceTypeCode = XMLTools.trimOrNull(additionalChilds.item(additionalChildIndex));
-								}
-								if (additionalChilds.item(additionalChildIndex).getLocalName().equals("FormattedIssueDateTime")) {
-									NodeList FormattedIssueDateTimeChilds = additionalChilds.item(additionalChildIndex).getChildNodes();
-									for (int dateChildIndex = 0; dateChildIndex < FormattedIssueDateTimeChilds.getLength(); dateChildIndex++) {
-										if ((FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName() != null)
-												&& (FormattedIssueDateTimeChilds.item(dateChildIndex).getLocalName().equals("DateTimeString"))) {
-											additionalReferencedDocumentDate = XMLTools.tryDate(FormattedIssueDateTimeChilds.item(dateChildIndex));
-										}
-									}
-								}
-							}
-						}
-						if (typeC == 50) {
-							if (additionalReferencedDocumentID != null) {
-								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
-								referencedDocument.setName(additionalReferencedDocumentName);
-								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
-								referencedDocument.setFormattedIssueDateTime(additionalReferencedDocumentDate);
-								zpp.setTenderReferencedDocument(referencedDocument);
-							}
-						} else if (typeC == 130) {
-							if (additionalReferencedDocumentID != null) {
-								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
-								referencedDocument.setName(additionalReferencedDocumentName);
-								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
-								referencedDocument.setFormattedIssueDateTime(additionalReferencedDocumentDate);
-								zpp.setObjectIdentifierReferencedDocument(referencedDocument);
-							}
-						} else if (typeC == 916) {
-							if (additionalReferencedDocumentID != null) {
-								ReferencedDocument referencedDocument = new ReferencedDocument(additionalReferencedDocumentID);
-								referencedDocument.setName(additionalReferencedDocumentName);
-								referencedDocument.setReferenceTypeCode(additionalReferencedDocumentReferenceTypeCode);
-								referencedDocument.setFormattedIssueDateTime(additionalReferencedDocumentDate);
-								zpp.setRelatedReferencedDocument(referencedDocument);
-							}
-						}
-					}
 				}
 			}
+			NodeMap headerTradeAgreementNodesMap = new NodeMap(headerTradeAgreementChilds);
+			headerTradeAgreementNodesMap.getNode("BuyerOrderReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> zpp.setBuyerOrderReferencedDocument(rd));
+			headerTradeAgreementNodesMap.getNode("SellerOrderReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> zpp.setSellerOrderReferencedDocument(rd));
+			headerTradeAgreementNodesMap.getNode("ContractReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> zpp.setContractReferencedDocument(rd));
+			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("50")).findFirst().ifPresent(rd -> zpp.setTenderReferencedDocument(rd));
+			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("130")).findFirst().ifPresent(rd -> zpp.setObjectIdentifierReferencedDocument(rd));
+			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("916")).findFirst().ifPresent(rd -> zpp.setRelatedReferencedDocument(rd));
 		}
 
 
@@ -1107,46 +988,30 @@ public class ZUGFeRDInvoiceImporter {
 			zpp.setPayee(new TradeParty(payeeNodes));
 		}
 
-		if (buyerOrderIssuerAssignedID != null) {
-			zpp.setBuyerOrderReferencedDocumentID(buyerOrderIssuerAssignedID);
-		} else {
+		if (zpp.getBuyerOrderReferencedDocument() == null) {
 			String s = extractString("//*[local-name()=\"OrderReference\"]/*[local-name()=\"ID\"]");
 			if (!s.isEmpty()) {
-				zpp.setBuyerOrderReferencedDocumentID(s);
+				zpp.setBuyerOrderReferencedDocument(new ReferencedDocument(s));
 			}
 		}
-		if (sellerOrderIssuerAssignedID != null) {
-			zpp.setSellerOrderReferencedDocumentID(sellerOrderIssuerAssignedID);
-		} else {
+
+		if (zpp.getSellerOrderReferencedDocument() == null) {
 			String s = extractString("//*[local-name()=\"OrderReference\"]/*[local-name()=\"SalesOrderID\"]");
 			if (!s.isEmpty()) {
-				zpp.setSellerOrderReferencedDocumentID(s);
+				zpp.setSellerOrderReferencedDocument(new ReferencedDocument(s));
 			}
 		}
-		if (despatchAdviceReferencedDocument != null) {
-			zpp.setDespatchAdviceReferencedDocumentID(despatchAdviceReferencedDocument);
-		} else {
+
+		if (zpp.getDespatchAdviceReferencedDocument() == null) {
 			String s = extractString("//*[local-name()=\"DespatchDocumentReference\"]/*[local-name()=\"ID\"]");
 			if (!s.isEmpty()) {
-				zpp.setDespatchAdviceReferencedDocumentID(s);
+				zpp.setDespatchAdviceReferencedDocument(new ReferencedDocument(s));
 			}
 		}
 
-		if (StringUtils.isNotBlank(contractReferencedAssignedID)) {
-			zpp.setContractReferencedDocument(contractReferencedAssignedID);
-		}
-
-		if (deliveryNoteReferencedDocumentID != null) {
-			zpp.setDeliveryNoteReferencedDocumentID(deliveryNoteReferencedDocumentID);
-		}
-
-		if (deliveryNoteReferencedDocumentDate != null) {
-			zpp.setDeliveryNoteReferencedDocumentDate(deliveryNoteReferencedDocumentDate);
-		}
-
-		String invoiceReferencedDocumentID = extractString("//*[local-name()=\"InvoiceReferencedDocument\"]/*[local-name()=\"IssuerAssignedID\"]|//*[local-name()=\"BillingReference\"]/*[local-name()=\"InvoiceDocumentReference\"]/*[local-name()=\"ID\"]");
+		String invoiceReferencedDocumentID = extractString("//*[local-name()=\"BillingReference\"]/*[local-name()=\"InvoiceDocumentReference\"]/*[local-name()=\"ID\"]");
 		if (!invoiceReferencedDocumentID.isEmpty()) {
-			zpp.setInvoiceReferencedDocumentID(invoiceReferencedDocumentID);
+			zpp.addInvoiceReferencedDocument(new ReferencedDocument(invoiceReferencedDocumentID));
 		}
 
 		xpr = xpath.compile("//*[local-name()=\"InvoiceReferencedDocument\"]");
@@ -1157,11 +1022,7 @@ public class ZUGFeRDInvoiceImporter {
 
 				Node currentItemNode = nodes.item(i);
 				ReferencedDocument doc = ReferencedDocument.fromNode(currentItemNode);
-				if (doc != null
-					&& (!Objects.equals(zpp.getInvoiceReferencedDocumentID(), doc.getIssuerAssignedID())
-					|| !Objects.equals(zpp.getInvoiceReferencedIssueDate(), doc.getFormattedIssueDateTime()))) {
-					zpp.addInvoiceReferencedDocument(doc);
-				}
+				zpp.addInvoiceReferencedDocument(doc);
 			}
 		}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDVisualizer.java
@@ -346,6 +346,7 @@ public class ZUGFeRDVisualizer {
 		return byteHolder.get();
 	}
 
+	@SuppressWarnings("unchecked")
 	private void toPDFfromFOP(String fopInput, Supplier<OutputStream> outputStreamDelegate, Consumer<OutputStream> consumerDelegate) {
 
 		DefaultConfigurationBuilder cfgBuilder = new DefaultConfigurationBuilder();
@@ -358,8 +359,8 @@ public class ZUGFeRDVisualizer {
 		}
 
 		FopFactoryBuilder builder = new FopFactoryBuilder(new File(".").toURI(), new ClasspathResolverURIAdapter()).setConfiguration(cfg);
-// Step 1: Construct a FopFactory by specifying a reference to the configuration file
-// (reuse if you plan to render multiple documents!)
+		// Step 1: Construct a FopFactory by specifying a reference to the configuration file
+		// (reuse if you plan to render multiple documents!)
 
 		FopFactory fopFactory = builder.build(); //FopFactory.newInstance(new File("c:\\Users\\jstaerk\\temp\\fop-config.xconf"));
 
@@ -372,8 +373,8 @@ public class ZUGFeRDVisualizer {
 
 		userAgent.getRendererOptions().put("pdf-a-mode", "PDF/A-3b");
 
-// Step 2: Set up output stream.
-// Note: Using BufferedOutputStream for performance reasons (helpful with FileOutputStreams).
+		// Step 2: Set up output stream.
+		// Note: Using BufferedOutputStream for performance reasons (helpful with FileOutputStreams).
 
 		try (OutputStream out = new BufferedOutputStream(outputStreamDelegate.get())) {
 

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/AllowanceChargeUBLRoundTripTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/AllowanceChargeUBLRoundTripTest.java
@@ -34,7 +34,6 @@ import javax.xml.xpath.XPathFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Date;
 
@@ -63,7 +62,13 @@ public class AllowanceChargeUBLRoundTripTest extends ResourceCase {
 		BigDecimal headerAllowanceBasis = new BigDecimal("100.00");
 
 		BigDecimal lineAllowanceAmount = new BigDecimal("2.00");
-		BigDecimal perUnitAllowanceAmount = new BigDecimal("1.00");
+		BigDecimal perUnitAllowanceAmount = new BigDecimal("1.0000");
+
+		Charge charge = new Charge(headerChargeAmount).setReason("Handling").setReasonCode("FC");
+		charge.setTaxRateApplicablePercent(new BigDecimal("19")).setTaxCategoryCode(TaxCategoryCodeTypeConstants.STANDARDRATE);
+
+		Charge allowance = new Allowance().setPercent(headerAllowancePercent).setBasisAmount(headerAllowanceBasis).setReason("Loyalty discount").setReasonCode("95");
+		allowance.setTaxCategoryCode(TaxCategoryCodeTypeConstants.STANDARDRATE).setTaxRateApplicablePercent(new BigDecimal("19"));
 
 		Product product = new Product("Testprodukt", "", "H87", new BigDecimal("19"));
 		// Bug 4 case: per-unit-price allowance, exported under GrossPriceProductTradePrice/AppliedTradeAllowanceCharge (CII)
@@ -85,12 +90,9 @@ public class AllowanceChargeUBLRoundTripTest extends ResourceCase {
 			.setRecipient(new TradeParty("Franz Mueller", "teststr.12", "55232", "Entenhausen", "DE"))
 			.addItem(item)
 			// Bug 2 amount-based case, with reason/reasonCode/taxPercent/categoryCode
-			.addCharge(new Charge(headerChargeAmount).setReason("Handling").setReasonCode("FC")
-				.setTaxPercent(new BigDecimal("19")).setCategoryCode(TaxCategoryCodeTypeConstants.STANDARDRATE))
+			.addCharge(charge)
 			// Bug 2 percent-only case (no ActualAmount at all) - this used to throw NumberFormatException on import
-			.addAllowance(new Allowance().setPercent(headerAllowancePercent).setBasisAmount(headerAllowanceBasis)
-				.setReason("Loyalty discount").setReasonCode("95")
-				.setTaxPercent(new BigDecimal("19")).setCategoryCode(TaxCategoryCodeTypeConstants.STANDARDRATE));
+			.addAllowance(allowance);
 
 		// 1. mustangproject: Invoice -> CII XML
 		ZUGFeRD2PullProvider originalProvider = new ZUGFeRD2PullProvider();
@@ -136,7 +138,7 @@ public class AllowanceChargeUBLRoundTripTest extends ResourceCase {
 		Node headerChargeTax = child(headerCharge, "CategoryTradeTax");
 		assertNotNull(headerChargeTax);
 		assertEquals(TaxCategoryCodeTypeConstants.STANDARDRATE, childText(headerChargeTax, "CategoryCode"));
-		assertDecimalEquals(new BigDecimal("19"), childDecimal(headerChargeTax, "RateApplicablePercent"));
+		assertDecimalEquals(new BigDecimal("19.00"), childDecimal(headerChargeTax, "RateApplicablePercent"));
 
 		// --- header level: percent-only allowance (the case that used to crash on import) ---
 		Node headerAllowance = findByIndicator(headerCharges, false);
@@ -149,7 +151,7 @@ public class AllowanceChargeUBLRoundTripTest extends ResourceCase {
 		Node headerAllowanceTax = child(headerAllowance, "CategoryTradeTax");
 		assertNotNull(headerAllowanceTax);
 		assertEquals(TaxCategoryCodeTypeConstants.STANDARDRATE, childText(headerAllowanceTax, "CategoryCode"));
-		assertDecimalEquals(new BigDecimal("19"), childDecimal(headerAllowanceTax, "RateApplicablePercent"));
+		assertDecimalEquals(new BigDecimal("19.00"), childDecimal(headerAllowanceTax, "RateApplicablePercent"));
 
 		// --- line level: genuine line-level allowance (BT-141 style, direct child of InvoiceLine in UBL) ---
 		NodeList lineAllowances = (NodeList) xpath.evaluate(
@@ -174,7 +176,7 @@ public class AllowanceChargeUBLRoundTripTest extends ResourceCase {
 
 	private static void assertDecimalEquals(BigDecimal expected, BigDecimal actual) {
 		assertNotNull("expected a numeric value but found none", actual);
-		assertTrue("expected " + expected + " but was " + actual, expected.compareTo(actual) == 0);
+		assertEquals("expected " + expected + " but was " + actual, expected, actual);
 	}
 
 	private static Node findByIndicator(NodeList nodes, boolean isCharge) {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/BackwardCompatibilityTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/BackwardCompatibilityTest.java
@@ -18,6 +18,8 @@
  *********************************************************************** */
 package org.mustangproject.ZUGFeRD;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,15 +34,15 @@ import org.mustangproject.TradeParty;
 
 /***
  * This is a test to confirm the minimum steps to implement a interface are still sufficient
- * 
+ *
  * @author jstaerk
  *
  */
 public class BackwardCompatibilityTest extends TestCase implements IExportableTransaction {
 
-	final String TARGET_PDF_ZF1 = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506zf1.pdf";
-	final String TARGET_PDF_ZF2 = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506zf2.pdf";
-	final String TARGET_PDF_FX = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506fx.pdf";
+	private static final String TARGET_PDF_ZF1 = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506zf1.pdf";
+	private static final String TARGET_PDF_ZF2 = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506zf2.pdf";
+	private static final String TARGET_PDF_FX = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506fx.pdf";
 
 	/**
 	 * The exporter test bases on @{code
@@ -54,11 +56,9 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 
 
 		// the writing part
-		try (InputStream SOURCE_PDF = this.getClass()
-			.getResourceAsStream("/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf");
-
-			 IZUGFeRDExporter ze = new ZUGFeRDExporterFromA1().setZUGFeRDVersion(1).setProfile(Profiles.getByName("Extended",1)).load(SOURCE_PDF)) {
-
+		try (InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf");
+			 IZUGFeRDExporter ze = new ZUGFeRDExporterFromA1()) {
+			ze.setZUGFeRDVersion(1).setProfile(Profiles.getByName("Extended",1)).load(SOURCE_PDF);
 			ze.setTransaction(this);
 			ze.disableAutoClose(true);
 			ze.export(TARGET_PDF_ZF1);
@@ -67,7 +67,7 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 			ze.export(baos);
 			ze.close();
 			String pdfContent = baos.toString(StandardCharsets.UTF_8);
-			assertFalse(pdfContent.indexOf("(via mustangproject.org") == -1);
+			assertNotEquals(-1, pdfContent.indexOf("(via mustangproject.org"));
 			// check for pdf-a schema extension
 //			assertFalse(pdfContent.indexOf("<zf:ConformanceLevel>EN 16931</zf:ConformanceLevel>") == -1);
 //			assertFalse(pdfContent.indexOf("<pdfaSchema:prefix>zf</pdfaSchema:prefix>") == -1);
@@ -86,19 +86,17 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 		assertEquals(zi.getIBAN(), getTradeSettlementPayment()[0].getOwnIBAN());
 		assertEquals(zi.getHolder(), getOwnOrganisationName());
 		assertEquals(zi.getForeignReference(), getNumber());
-		
-		
+
+
 	}
 
 	public void testZF2Export() {
 
-	
+
 		// the writing part
-		try (InputStream SOURCE_PDF = this.getClass()
-			.getResourceAsStream("/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf");
-
-			 IZUGFeRDExporter ze = new ZUGFeRDExporterFromA1().setZUGFeRDVersion(2).setProfile("EN16931").load(SOURCE_PDF)) {
-
+		try (InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf");
+			 IZUGFeRDExporter ze = new ZUGFeRDExporterFromA1()) {
+			ze.setZUGFeRDVersion(2).setProfile(Profiles.getByName("EN16931", 2)).load(SOURCE_PDF);
 			ze.setTransaction(this);
 			ze.disableAutoClose(true);
 			ze.export(TARGET_PDF_ZF2);
@@ -107,7 +105,7 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 			ze.export(baos);
 			ze.close();
 			String pdfContent = baos.toString(StandardCharsets.UTF_8);
-			assertFalse(pdfContent.indexOf("(via mustangproject.org") == -1);
+			assertNotEquals(-1, pdfContent.indexOf("(via mustangproject.org"));
 			// check for pdf-a schema extension
 //			assertFalse(pdfContent.indexOf("<zf:ConformanceLevel>EN 16931</zf:ConformanceLevel>") == -1);
 //			assertFalse(pdfContent.indexOf("<pdfaSchema:prefix>zf</pdfaSchema:prefix>") == -1);
@@ -126,17 +124,16 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 		assertEquals(zi.getIBAN(), getTradeSettlementPayment()[0].getOwnIBAN());
 		assertEquals(zi.getHolder(), getOwnOrganisationName());
 		assertEquals(zi.getForeignReference(), getNumber());
-		
-		
+
+
 	}
 	public void testFXExport() {
 
 		// the writing part
-		try (InputStream SOURCE_PDF = this.getClass()
-			.getResourceAsStream("/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf");
+		try (InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20190610_507blanko.pdf");
+			IZUGFeRDExporter ze = new ZUGFeRDExporterFromA1()) {
 
-			 IZUGFeRDExporter ze = new ZUGFeRDExporterFromA1().setZUGFeRDVersion(2).setProfile("EN16931").load(SOURCE_PDF)) {
-
+			ze.setZUGFeRDVersion(2).setProfile(Profiles.getByName("EN16931")).load(SOURCE_PDF);
 			ze.setTransaction(this);
 			ze.disableAutoClose(true);
 			ze.export(TARGET_PDF_FX);
@@ -145,7 +142,7 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 			ze.export(baos);
 			ze.close();
 			String pdfContent = baos.toString(StandardCharsets.UTF_8);
-			assertFalse(pdfContent.indexOf("(via mustangproject.org") == -1);
+			assertNotEquals(-1, pdfContent.indexOf("(via mustangproject.org"));
 			// check for pdf-a schema extension
 //			assertFalse(pdfContent.indexOf("<zf:ConformanceLevel>EN 16931</zf:ConformanceLevel>") == -1);
 //			assertFalse(pdfContent.indexOf("<pdfaSchema:prefix>zf</pdfaSchema:prefix>") == -1);
@@ -159,42 +156,47 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 		ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF_FX);
 
 		// Reading ZUGFeRD
-		assertEquals(zi.getAmount(), "571.04");
-		assertEquals(zi.getBIC(), getTradeSettlementPayment()[0].getOwnBIC());
-		assertEquals(zi.getIBAN(), getTradeSettlementPayment()[0].getOwnIBAN());
-		assertEquals(zi.getHolder(), getOwnOrganisationName());
-		assertEquals(zi.getForeignReference(), getNumber());
-		
-		
+		assertEquals("571.04", zi.getAmount());
+		assertEquals(getTradeSettlementPayment()[0].getOwnBIC(), zi.getBIC());
+		assertEquals(getTradeSettlementPayment()[0].getOwnIBAN(), zi.getIBAN());
+		assertEquals(getOwnOrganisationName(), zi.getHolder());
+		assertEquals(getNumber(), zi.getForeignReference());
 	}
+
 	class Contact implements IZUGFeRDExportableContact {
+		@Override
 		public String getCountry() {
 			return "DE";
 		}
 
+		@Override
 		public String getLocation() {
 			return "Spielkreis";
 		}
 
+		@Override
 		public String getName() {
 			return "Theodor Est";
 		}
 
+		@Override
 		public String getStreet() {
 			return "Bahnstr. 42";
 		}
 
+		@Override
 		public String getVATID() {
 			return "DE999999999";
 		}
 
+		@Override
 		public String getZIP() {
 			return "88802";
 		}
 
 	}
-   class Payment implements IZUGFeRDTradeSettlementPayment {
 
+	class Payment implements IZUGFeRDTradeSettlementPayment {
 		@Override
 		public String getOwnBIC() {
 			return "bla";
@@ -242,11 +244,13 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 			this.product = product;
 		}
 
+		@Override
 		public IZUGFeRDAllowanceCharge[] getItemAllowances() {
 			// TODO Auto-generated method stub
 			return null;
 		}
 
+		@Override
 		public IZUGFeRDAllowanceCharge[] getItemCharges() {
 			// TODO Auto-generated method stub
 			return null;
@@ -259,11 +263,12 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 			this.description = description;
 			this.name = name;
 			this.unit = unit;
-			VATPercent = vATPercent;
+			vatPercent = vATPercent;
 		}
 
 		private String description, name, unit;
-		private BigDecimal VATPercent;
+
+		private BigDecimal vatPercent;
 
 		public String getDescription() {
 			return description;
@@ -290,11 +295,11 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 		}
 
 		public BigDecimal getVATPercent() {
-			return VATPercent;
+			return vatPercent;
 		}
 
 		public void setVATPercent(BigDecimal vATPercent) {
-			VATPercent = vATPercent;
+			vatPercent = vATPercent;
 		}
 	}
 
@@ -314,22 +319,26 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 	public IZUGFeRDExportableTradeParty getSender() {
 		return new TradeParty("Bei Spiel GmbH","street","zip","city","DE");
 	}
-	
-		
+
+
 	//
-  public IZUGFeRDTradeSettlementPayment[] getTradeSettlementPayment() {
+	@Override
+	@Deprecated(forRemoval = true, since = "2.24.1")
+	@SuppressWarnings("deprecation")
+	public IZUGFeRDTradeSettlementPayment[] getTradeSettlementPayment() {
 		Payment P = new Payment();
 		IZUGFeRDTradeSettlementPayment[] allP = new Payment[1];
 		allP[0] = P;
 		return allP;
-
 	}
 
+	@Override
 	public IZUGFeRDAllowanceCharge[] getZFAllowances() {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
+	@Override
 	public IZUGFeRDAllowanceCharge[] getZFCharges() {
 		// TODO Auto-generated method stub
 		return null;
@@ -349,6 +358,7 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 		return allItems;
 	}
 
+	@Override
 	public IZUGFeRDLogisticsServiceCharge[] getZFLogisticsServiceCharges() {
 		// TODO Auto-generated method stub
 		return null;
@@ -389,7 +399,7 @@ public class BackwardCompatibilityTest extends TestCase implements IExportableTr
 	public String getOwnIBAN() {
 		return "DE88 2008 0000 0970 3757 00";
 	}
-	
+
 
 	@Override
 	public String getOwnLocation() {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/CalculationTest.java
@@ -105,6 +105,9 @@ public class CalculationTest extends ResourceCase {
 		Product product;
 		Item item;
 
+		Charge allowance = new Allowance().setPercent(new BigDecimal(10)).setReasonCode("ZZZ").setReason("Mengenrabatt");
+		allowance.setTaxRateApplicablePercent(new BigDecimal(25));
+
 		product = new Product("Pens", "", "H87", new BigDecimal(25));
 		product.addAllowance(new Allowance(new BigDecimal(1)));
 		item = new Item(product, new BigDecimal("9.50"), new BigDecimal(25));
@@ -118,7 +121,7 @@ public class CalculationTest extends ResourceCase {
 		lc = item.getCalculation();
 		assertEquals(new BigDecimal("64.12"), lc.getItemTotalNetAmount());
 		invoice.addItem(item);
-		invoice.addAllowance(new Allowance().setPercent(new BigDecimal(10)).setTaxPercent(new BigDecimal(25)).setReasonCode("ZZZ").setReason("Mengenrabatt"));
+		invoice.addAllowance(allowance);
 		invoice.addCharge(new Charge(new BigDecimal(15)).setReasonCode("ZZZ").setReason("Frachtkosten"));
 
 		TransactionCalculator calculator = new TransactionCalculator(invoice);
@@ -144,10 +147,8 @@ public class CalculationTest extends ResourceCase {
 			zii.setInputStream(new FileInputStream(inputCII));
 
 			invoice = zii.extractInvoice();
-		} catch (XPathExpressionException | ParseException e) {
-// handle Exceptions
-			hasExceptions = true;
-		} catch (FileNotFoundException e) {
+		} catch (XPathExpressionException | ParseException | FileNotFoundException e) {
+			// handle Exceptions
 			hasExceptions = true;
 		}
 		assertFalse(hasExceptions);
@@ -209,10 +210,14 @@ public class CalculationTest extends ResourceCase {
 
 		/* lines */
 		if (item_increase.compareTo(BigDecimal.ZERO) > 0) {
-			item.addCharge(new Charge().setPercent(item_increase).setTaxPercent(sales_tax_percent1).setReasonCode("ZZZ").setReason("Zuschlag"));
+			Charge charge = new Charge().setPercent(item_increase).setReasonCode("ZZZ").setReason("Zuschlag");
+			charge.setTaxRateApplicablePercent(sales_tax_percent1);
+			item.addCharge(charge);
 		}
 		if (item_discount.compareTo(BigDecimal.ZERO) > 0) {
-			item.addAllowance(new Allowance().setPercent(item_discount).setTaxPercent(sales_tax_percent1).setReasonCode("95").setReason("Rabatt"));
+			Charge allowance = new Allowance().setPercent(item_discount).setReasonCode("95").setReason("Rabatt");
+			allowance.setTaxRateApplicablePercent(sales_tax_percent1);
+			item.addAllowance(allowance);
 		}
 		invoice.addItem(item);
 
@@ -235,10 +240,14 @@ public class CalculationTest extends ResourceCase {
 
 
 		if (total_increase_percent.compareTo(BigDecimal.ZERO) > 0) {
-			invoice.addCharge(new Charge().setPercent(total_increase_percent).setTaxPercent(sales_tax_percent1).setReasonCode("ZZZ").setReason("Zuschläge"));
+			Charge charge = new Charge().setPercent(total_increase_percent).setReasonCode("ZZZ").setReason("Zuschläge");
+			charge.setTaxRateApplicablePercent(sales_tax_percent1);
+			invoice.addCharge(charge);
 		}
 		if (total_discount_percent.compareTo(BigDecimal.ZERO) > 0) {
-			invoice.addAllowance(new Allowance().setPercent(total_discount_percent).setTaxPercent(sales_tax_percent1).setReasonCode("95").setReason("Rabatte"));
+			Charge allowance = new Allowance().setPercent(total_discount_percent).setReasonCode("95").setReason("Rabatte");
+			allowance.setTaxRateApplicablePercent(sales_tax_percent1);
+			invoice.addAllowance(allowance);
 		}
 		TransactionCalculator calculator = new TransactionCalculator(invoice);
 		assertEquals(valueOf(101.85).stripTrailingZeros(), calculator.getGrandTotal().stripTrailingZeros());
@@ -328,7 +337,9 @@ public class CalculationTest extends ResourceCase {
 		product = new Product("AAA", "", "H87", BigDecimal.ZERO);
 		item = new Item(product, new BigDecimal("1.10"), new BigDecimal(5.00));
 
-		item.addAllowance(new Allowance().setPercent(new BigDecimal(10)).setTaxPercent(BigDecimal.ZERO));
+		Charge allowance = new Allowance().setPercent(new BigDecimal(10));
+		allowance.setTaxRateApplicablePercent(BigDecimal.ZERO);
+		item.addAllowance(allowance);
 		invoice.addItem(item);
 
 
@@ -383,7 +394,9 @@ public class CalculationTest extends ResourceCase {
 		product = new Product("AAA", "", "H87", BigDecimal.ZERO);
 		item = new Item(product, new BigDecimal("1.10"), new BigDecimal(5.00));
 
-		item.addCharge(new Charge().setPercent(new BigDecimal(10)).setTaxPercent(BigDecimal.ZERO));
+		Charge charge = new Charge().setPercent(new BigDecimal(10));
+		charge.setTaxRateApplicablePercent(BigDecimal.ZERO);
+		item.addCharge(charge);
 		invoice.addItem(item);
 
 
@@ -410,6 +423,8 @@ public class CalculationTest extends ResourceCase {
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
 
+		Charge charge = new Charge().setPercent(new BigDecimal(50)).setReasonCode("ABK");
+		charge.setTaxRateApplicablePercent(new BigDecimal(19));
 
 		// similar, but slightly less complicated to whats later testted in  testRelativeChargesAllowancesExport
 		Invoice i = new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
@@ -419,7 +434,7 @@ public class CalculationTest extends ResourceCase {
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
-				.addCharge(new Charge().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK"));
+			.addCharge(charge);
 		// 9+50%=>13,50 expected net
 		//		.addAllowance(new Allowance().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19)).setReason("Mengenrabatt"))
 		TransactionCalculator tc = new TransactionCalculator(i);
@@ -436,6 +451,8 @@ public class CalculationTest extends ResourceCase {
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
 
+		Charge allowance = new Allowance().setPercent(new BigDecimal(50)).setReasonCode("ABK");
+		allowance.setTaxRateApplicablePercent(new BigDecimal(19));
 
 		// similar, but slightly less complicated to whats later testted in  testRelativeChargesAllowancesExport
 		Invoice i = new Invoice().setCurrency("CHF").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
@@ -445,7 +462,7 @@ public class CalculationTest extends ResourceCase {
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, new BigDecimal(1.0)))
-			.addAllowance(new Allowance().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19)).setReasonCode("ABK"));
+			.addAllowance(allowance);
 		// 9-50%=>4,50 expected net
 		//		.addAllowance(new Allowance().setPercent(new BigDecimal(50)).setTaxPercent(new BigDecimal(19)).setReason("Mengenrabatt"))
 		TransactionCalculator tc = new TransactionCalculator(i);
@@ -490,7 +507,9 @@ public class CalculationTest extends ResourceCase {
 		product = new Product("AAA", "", "H87", BigDecimal.ZERO);
 		item = new Item(product, new BigDecimal("1.00"), new BigDecimal(5.00));
 
-		item.addAllowance(new Allowance(new BigDecimal(1)).setTaxPercent(BigDecimal.ZERO));
+		Charge allowance = new Allowance(new BigDecimal(1));
+		allowance.setTaxRateApplicablePercent(BigDecimal.ZERO);
+		item.addAllowance(allowance);
 		invoice.addItem(item);
 
 		TransactionCalculator calculator = new TransactionCalculator(invoice);
@@ -581,7 +600,10 @@ public class CalculationTest extends ResourceCase {
 		Product product = new Product("Testartikel", "", "LTR", BigDecimal.ZERO);
 		Item item = new Item(product, new BigDecimal("128.49"), new BigDecimal("50"));
 		item.setBasisQuantity(new BigDecimal("100"));
-		item.addAllowance(new Allowance().setPercent(new BigDecimal(10)).setTaxPercent(BigDecimal.ZERO));
+
+		Charge allowance = new Allowance().setPercent(new BigDecimal(10));
+		allowance.setTaxRateApplicablePercent(BigDecimal.ZERO);
+		item.addAllowance(allowance);
 		invoice.addItem(item);
 
 		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
@@ -624,7 +646,9 @@ public class CalculationTest extends ResourceCase {
 		Product product = new Product("Testartikel", "", "H87", BigDecimal.ZERO);
 		Item item = new Item(product, new BigDecimal("200.00"), new BigDecimal("10"));
 		item.setBasisQuantity(new BigDecimal("4"));
-		item.addCharge(new Charge().setPercent(new BigDecimal(5)).setTaxPercent(BigDecimal.ZERO));
+		Charge charge = new Charge().setPercent(new BigDecimal(5));
+		charge.setTaxRateApplicablePercent(BigDecimal.ZERO);
+		item.addCharge(charge);
 		invoice.addItem(item);
 
 		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DXTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DXTest.java
@@ -46,8 +46,8 @@ import static org.xmlunit.assertj.XmlAssert.assertThat;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DXTest extends MustangReaderTestCase {
-	final String TARGET_PDF = "./target/testout-DX.pdf";
-	final String TARGET_XML = "./target/testout-DX.xml";
+	private static final String TARGET_PDF = "./target/testout-DX.pdf";
+	private static final String TARGET_XML = "./target/testout-DX.xml";
 
 	protected class EdgeProduct implements IZUGFeRDExportableProduct {
 		private String description, name, unit;
@@ -280,12 +280,11 @@ public class DXTest extends MustangReaderTestCase {
 
 		// the writing part
 
-		try (InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
-
-			 DXExporterFromA1 oe = new DXExporterFromA1().setProducer("My Application")
-					 .setCreator(System.getProperty("user.name")).setZUGFeRDVersion(1).ignorePDFAErrors()
-					 .load(SOURCE_PDF)) {
+		try (InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+			 DXExporterFromA1 oe = new DXExporterFromA1()) {
+			oe.setProducer("My Application")
+				.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(1).ignorePDFAErrors()
+				.load(SOURCE_PDF);
 			oe.setTransaction(this);
 			String theXML = new String(oe.getProvider().getXML(), StandardCharsets.UTF_8);
 			assertTrue(theXML.contains("<SCRDMCCBDACIDAMessageStructure"));
@@ -302,12 +301,12 @@ public class DXTest extends MustangReaderTestCase {
 		assertTrue(zi.getUTF8().contains("<ram:ShipToTradeParty>"));
 		assertFalse(zi.getUTF8().contains("EUR"));
 
-		assertEquals(zi.getLineItemList().size(),3);
 		assertEquals(zi.getHolder(), getOwnOrganisationName());
 		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter(TARGET_PDF);
 		try {
 			Invoice i = zii.extractInvoice();
 
+			assertEquals(3, i.getZFItems().length);
 			assertEquals(new BigDecimal("400.0000"), i.getZFItems()[1].getQuantity());
 			/* getting the Quantity is more difficult than usual because in OrderX it's
 			called requestedQuantity, not BilledQuantity

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/DeSerializationTest.java
@@ -303,7 +303,7 @@ public class DeSerializationTest extends ResourceCase {
 			assertTrue(theXML.contains(base64));
 
 		} catch (Exception e) {
-			fail("No exception expected");
+			fail(e.getMessage());
 		}
 
 	}
@@ -440,16 +440,16 @@ public class DeSerializationTest extends ResourceCase {
 			SchemedID gln = new SchemedID("0088", "4304171000002");
 
 			SchemedID gtin = new SchemedID("0160", "2001015001325");
-			Item item = new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123").addBuyerOrderReferencedDocumentLineID("xxx").addNote("item level 1/1").setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15"));
+			Item item = new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123").setBuyerOrderReferencedDocument(new ReferencedDocument("xxx")).addNote("item level 1/1").setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15"));
 			Charge itemAllowance = new Allowance(new BigDecimal(0.02)).setReason("item discount");
 			itemAllowance.setTaxRateApplicablePercent(new BigDecimal(16));
 
 			Invoice i = new Invoice().setCurrency("CHF").addNote("document level 1/2").addNote("document level 2/2").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
-				.setSellerOrderReferencedDocumentID("9384").setBuyerOrderReferencedDocumentID("28934")
+				.setSellerOrderReferencedDocument(new ReferencedDocument("9384")).setBuyerOrderReferencedDocument(new ReferencedDocument("28934"))
 				.setDetailedDeliveryPeriod(new SimpleDateFormat("yyyyMMdd").parse(occurrenceFrom), new SimpleDateFormat("yyyyMMdd").parse(occurrenceTo))
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).setEmail("sender@test.org").setID(orgID).addVATID("DE0815"))
 				.setDeliveryAddress(new TradeParty("just the other side of the street", "teststr.12a", "55232", "Entenhausen", "DE").addVATID("DE47110"))
-				.setContractReferencedDocument(contractID)
+				.setContractReferencedDocument(new ReferencedDocument(contractID))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addGlobalID(gln).setEmail("recipient@test.org").addVATID("DE4711")
 					.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE").setFax("++49555123456")).setAdditionalAddress("Hinterhaus 3"))
 				.addItem(item)
@@ -463,7 +463,7 @@ public class DeSerializationTest extends ResourceCase {
 		} catch (JsonProcessingException | ParseException e) {
 			hasExceptions = true;
 		}
-		assertEquals(newInvoiceFromJSON.getBuyerOrderReferencedDocumentID(), "28934");
+		assertEquals(newInvoiceFromJSON.getBuyerOrderReferencedDocument().getIssuerAssignedID(), "28934");
 		assertFalse(hasExceptions);
 	}
 

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/IZUGFeRDAllowanceChargeImpl.java
@@ -44,6 +44,7 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge, IZU
 		return reasonCode;
 	}
 
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	@Override
 	public BigDecimal getTaxPercent() {
 		return taxPercent;
@@ -105,7 +106,7 @@ public class IZUGFeRDAllowanceChargeImpl implements IZUGFeRDAllowanceCharge, IZU
 	/**
 	 * @deprecated use getTaxCategoryCode() instead.
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true, since = "2.24.1")
 	@Override
 	public String getCategoryCode() {
 		return getTaxCategoryCode();

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/InvoicingPeriodTestCase.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/InvoicingPeriodTestCase.java
@@ -1,43 +1,56 @@
 package org.mustangproject.ZUGFeRD;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.Date;
 
+import javax.xml.xpath.XPathExpressionException;
+
 import org.junit.Test;
+import org.mustangproject.Invoice;
 
 public class InvoicingPeriodTestCase {
-  @Test
-  public void readBillingSpecification() throws IOException {
-    final String file = ResourceUtilities.readFile(Charset.defaultCharset(),
-        "src/test/resources/factur-x_invoicingPeriod.xml");
-    final ZUGFeRDImporter zi = new XRechnungImporter(file.getBytes());
+	@Test
+	public void readBillingSpecification() throws IOException {
+		final String file = ResourceUtilities.readFile(Charset.defaultCharset(), "src/test/resources/factur-x_invoicingPeriod.xml");
+		final ZUGFeRDImporter zi = new XRechnungImporter(file.getBytes());
 
-    // Reading ZUGFeRD
-    assertEquals(date("20220829"), zi.getLineItemList().get(0).getDetailedDeliveryPeriodFrom());
-    assertEquals(date("20220831"), zi.getLineItemList().get(0).getDetailedDeliveryPeriodTo());
-    assertEquals(date("20220901"), zi.getLineItemList().get(1).getDetailedDeliveryPeriodFrom());
-    assertEquals(date("20220902"), zi.getLineItemList().get(1).getDetailedDeliveryPeriodTo());
-    assertEquals(null, zi.getLineItemList().get(2).getDetailedDeliveryPeriodFrom());
-    assertEquals(date("20220909"), zi.getLineItemList().get(2).getDetailedDeliveryPeriodTo());
-    assertEquals(date("20220826"), zi.getDetailedDeliveryPeriodFrom());
-    assertEquals(date("20220902"), zi.getDetailedDeliveryPeriodTo());
-    //general asserts
-    assertEquals("1634.76", zi.getAmount());
-    assertEquals("RE1000", zi.getInvoiceID());
-    assertEquals("Sell", zi.getSellerTradePartyAddress().getCityName());
-    assertEquals("Beier", zi.getBuyerTradePartyName());
-  }
-  
-  private Date date(String toParse){
-    try {
-      return ZUGFeRDDateFormat.DATE.getFormatter().parse(toParse);
-    }
-    catch (final ParseException e) {
-      return null;
-    }
-  }
+		try {
+			Invoice invoice = zi.extractInvoice();
+
+			// Reading ZUGFeRD
+			assertEquals(date("20220829"), invoice.getZFItems()[0].getDetailedDeliveryPeriodFrom());
+			assertEquals(date("20220831"), invoice.getZFItems()[0].getDetailedDeliveryPeriodTo());
+
+			assertEquals(date("20220901"), invoice.getZFItems()[1].getDetailedDeliveryPeriodFrom());
+			assertEquals(date("20220902"), invoice.getZFItems()[1].getDetailedDeliveryPeriodTo());
+
+			assertNull(invoice.getZFItems()[2].getDetailedDeliveryPeriodFrom());
+			assertEquals(date("20220909"), invoice.getZFItems()[2].getDetailedDeliveryPeriodTo());
+
+			assertEquals(date("20220826"), zi.getDetailedDeliveryPeriodFrom());
+			assertEquals(date("20220902"), zi.getDetailedDeliveryPeriodTo());
+			//general asserts
+			assertEquals("1634.76", zi.getAmount());
+			assertEquals("RE1000", zi.getInvoiceID());
+			assertEquals("Sell", zi.getSellerTradePartyAddress().getCityName());
+			assertEquals("Beier", zi.getBuyerTradePartyName());
+		} catch ( ParseException | XPathExpressionException e ) {
+			fail(e.getMessage());
+		}
+	}
+
+	private Date date(String toParse){
+		try {
+			return ZUGFeRDDateFormat.DATE.getFormatter().parse(toParse);
+		}
+		catch (final ParseException e) {
+			return null;
+		}
+	}
 }

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/MustangReaderWriterCustomXMLTest.java
@@ -23,6 +23,9 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
+import org.mustangproject.Invoice;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -30,6 +33,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+
+import javax.xml.xpath.XPathExpressionException;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class MustangReaderWriterCustomXMLTest extends TestCase {
@@ -57,14 +62,13 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 		final String TARGET_PDF = "./target/testout-MustangGnuaccountingBeispielRE-20171118_506custom.pdf";
 		// the writing part
 
-		try {
+		try (IZUGFeRDExporter zea1 = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			IZUGFeRDExporter zea1 = new ZUGFeRDExporterFromA1().setProducer("My Application").setCreator("Test").setProfile(Profiles.getByName("EN16931"))
-					.load(SOURCE_PDF);
+			zea1.setProducer("My Application").setCreator("Test").setProfile(Profiles.getByName("EN16931")).load(SOURCE_PDF);
 
 			final byte[] UTF8ByteOrderMark = new byte[]{(byte) 0xef, (byte) 0xbb, (byte) 0xbf};
-			/* we have much more information than just in the basic profile (comfort or extended) but it's perfectly valid to provide more information, just not less. 
+			/* we have much more information than just in the basic profile (comfort or extended) but it's perfectly valid to provide more information, just not less.
 			 * test the export with bom (which is valid) because this will also test the import (which also needs to work and needs to be tested)
 			 * */
 			String ownZUGFeRDXML = new String(UTF8ByteOrderMark, StandardCharsets.UTF_8) + "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -272,8 +276,8 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 			zea1.export(baos);
 			zea1.close();
 			String pdfContent = baos.toString(StandardCharsets.UTF_8);
-			assertFalse(pdfContent.indexOf("(via mustangproject.org") == -1);
-			assertFalse(pdfContent.indexOf("<fx:ConformanceLevel>EN 16931</fx:ConformanceLevel>") == -1);
+			assertNotEquals(-1, pdfContent.indexOf("(via mustangproject.org"));
+			assertNotEquals(-1, pdfContent.indexOf("<fx:ConformanceLevel>EN 16931</fx:ConformanceLevel>"));
 
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -288,11 +292,12 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 		assertEquals(zi.getIBAN(), "DE88 2008 0000 0970 3757 00");
 		assertEquals(zi.getHolder(), "Bei Spiel GmbH");
 		assertEquals(zi.getForeignReference(), "RE-20171118/506");
-		assertEquals(zi.getLineItemList().get(0).getDeliveryNoteReferencedDocumentID(), "deliverynote123");
-		assertEquals(zi.getLineItemList().get(0).getDeliveryNoteReferencedDocumentLineID(), "deliverypos456");
 		try {
-			assertEquals(zi.getLineItemList().get(0).getDeliveryNoteReferencedDocumentDate(), new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026"));
-		} catch (ParseException e) {
+			Invoice invoice = zi.extractInvoice();
+			assertEquals("deliverynote123", invoice.getZFItems()[0].getDeliveryNoteReferencedDocument().getIssuerAssignedID());
+			assertEquals("deliverypos456", invoice.getZFItems()[0].getDeliveryNoteReferencedDocument().getLineID());
+			assertEquals(invoice.getZFItems()[0].getDeliveryNoteReferencedDocument().getFormattedIssueDateTime(), new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026"));
+		} catch (ParseException | XPathExpressionException e) {
 			e.printStackTrace();
 		}
 	}
@@ -310,11 +315,10 @@ public class MustangReaderWriterCustomXMLTest extends TestCase {
 		final String TARGET_PDF = "./target/testout-MustangGnuaccountingBeispielRE-20170509_505custom.pdf";
 		// the writing part
 
-		try {
+		try (IZUGFeRDExporter zea1 = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			IZUGFeRDExporter zea1 = new ZUGFeRDExporterFromA1()
-					.setProducer("My Application")
+			zea1.setProducer("My Application")
 					.setCreator("Test")
 					.setZUGFeRDVersion(1)
 					.setProfile(Profiles.getByName("BASIC",1))

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/OXTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/OXTest.java
@@ -42,9 +42,9 @@ import java.util.GregorianCalendar;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class OXTest extends MustangReaderTestCase {
-	final String TARGET_PDF = "./target/testout-OX.pdf";
-	final String TARGET_PDF_EDGE = "./target/testout-OX-edge.pdf";
-	final String TARGET_XML = "./target/testout-OX.xml";
+	private static final String TARGET_PDF = "./target/testout-OX.pdf";
+	private static final String TARGET_PDF_EDGE = "./target/testout-OX-edge.pdf";
+	private static final String TARGET_XML = "./target/testout-OX.xml";
 
 	protected class EdgeProduct implements IZUGFeRDExportableProduct {
 		private String description, name, unit;

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/UBLTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/UBLTest.java
@@ -37,6 +37,7 @@ import org.mustangproject.Contact;
 import org.mustangproject.Invoice;
 import org.mustangproject.Item;
 import org.mustangproject.Product;
+import org.mustangproject.ReferencedDocument;
 import org.mustangproject.TradeParty;
 
 import javax.xml.xpath.XPathExpressionException;
@@ -81,7 +82,7 @@ public class UBLTest extends ResourceCase {
 				.setSender(new TradeParty("Test company", "teststr", "55232", "teststadt", "DE").addTaxID("DE4711").addVATID("DE0815").setContact(new Contact("Hans Test", "+49123456789", "test@example.org")).addBankDetails(new BankDetails("DE12500105170648489890", "COBADEFXXX")))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
 				.setReferenceNumber("991-01484-64")//leitweg-id
-				.setNumber("123").addItem(new Item(new Product("Testprodukt", "", "C62", BigDecimal.ZERO), /*price*/ new BigDecimal("1.0"),  /*qty*/ new BigDecimal("1.0")).addBuyerOrderReferencedDocumentLineID("A12"));
+				.setNumber("123").addItem(new Item(new Product("Testprodukt", "", "C62", BigDecimal.ZERO), /*price*/ new BigDecimal("1.0"),  /*qty*/ new BigDecimal("1.0")).setBuyerOrderReferencedDocument(new ReferencedDocument().setLineID("A12")));
 
 
 		try {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/VATrelatedTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/VATrelatedTest.java
@@ -32,8 +32,8 @@ import java.util.Date;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class VATrelatedTest extends ResourceCase  {
-	final String TARGET_PDF_REVERSE = "./target/testout-ReverseCharge.pdf";
-	final String TARGET_PDF_Z = "./target/testout-TaxcodeZ.pdf";
+	private static final String TARGET_PDF_REVERSE = "./target/testout-ReverseCharge.pdf";
+	private static final String TARGET_PDF_Z = "./target/testout-TaxcodeZ.pdf";
 
 	public void testReverseCharge() {
 
@@ -41,10 +41,9 @@ public class VATrelatedTest extends ResourceCase  {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProfile(Profiles.getByName("Extended"));
 
@@ -53,14 +52,17 @@ public class VATrelatedTest extends ResourceCase  {
 			//					.addItem(new Item(new Product("Testprodukt", "", "H84", new BigDecimal(19)), amount, new BigDecimal(1.0)).addAllowance(new Allowance().setPercent(new BigDecimal(50)))));
 
 			Product p=new Product("Testprodukt", "", "H87", new BigDecimal(19));
+
+			Charge charge = new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AReason");
+			charge.setTaxRateApplicablePercent(new BigDecimal(19));
+
 			p.setReverseCharge();
 			Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815"))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")
 					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")).addVATID("DE0915"))
 				.setNumber(number)
-				.addCharge(new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AReason").setTaxPercent(new BigDecimal(19)))
-
+				.addCharge(charge)
 				.addItem(new Item(p, price, new BigDecimal(1.0)));
 			ze.setTransaction(i);
 
@@ -94,10 +96,12 @@ public class VATrelatedTest extends ResourceCase  {
 		String number = "123";
 		String priceStr = "3.00";
 		BigDecimal price = new BigDecimal(priceStr);
-		try {
+		Charge charge = new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AReason");
+		charge.setTaxRateApplicablePercent(new BigDecimal(19));
+
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
 			ze.setProfile(Profiles.getByName("Extended"));
 
@@ -122,7 +126,7 @@ public class VATrelatedTest extends ResourceCase  {
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE")
 					.setContact(new Contact("contact testname", "123456", "contact.testemail@example.org").setFax("0911623562")))
 				.setNumber(number)
-				.addCharge(new Charge(new BigDecimal(1)).setReasonCode("ABK").setReason("AReason").setTaxPercent(new BigDecimal(19)))
+				.addCharge(charge)
 
 				.addItem(new Item(p, price, new BigDecimal(1.0)));
 			ze.setTransaction(i);

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -163,6 +163,13 @@ public class XRTest extends TestCase {
 
 	public void testIssue830ApplicableHeaderTradeSettlementTax() throws XPathExpressionException, SAXException, IOException, ParserConfigurationException
 	{
+		Charge charge = new Charge(BigDecimal.ONE).setReasonCode("64");
+		charge.setTaxRateApplicablePercent(BigDecimal.valueOf(19));
+		Charge itemAllowance = new Allowance().setReasonCode("64").setTotalAmount(BigDecimal.valueOf(4));
+		itemAllowance.setTaxRateApplicablePercent(BigDecimal.ZERO);
+		Charge invoiceAllowance = new Allowance().setReasonCode("64").setTotalAmount(BigDecimal.valueOf(5));
+		invoiceAllowance.setTaxRateApplicablePercent(BigDecimal.valueOf(19));
+
 		final Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 			.setSender(new TradeParty("Test", "teststr", "55232", "teststadt", "DE").setEmail("sender@example.com").addTaxID("DE4711").addVATID("DE0815")
 				.setContact(new Contact("Hans Test", "+49123456789", "test@example.org"))
@@ -176,14 +183,14 @@ public class XRTest extends TestCase {
 			.addItem(new Item(new Product("Testprodukt2", "", "C62", BigDecimal.ZERO).setTaxCategoryCode("AE").setTaxExemptionReason("Reversecharge process"),
 				BigDecimal.ONE, BigDecimal.ONE))
 			.addItem(new Item(new Product("Testprodukt3", "", "C62", BigDecimal.valueOf(19)).setTaxCategoryCode("S"), BigDecimal.valueOf(9), BigDecimal.ONE)
-				.addCharge(new Charge(BigDecimal.ONE).setReasonCode("64").setTaxPercent(BigDecimal.valueOf(19))))
+				.addCharge(charge))
 			.addItem(new Item(
 				new Product("Testprodukt4", "", "C62", BigDecimal.ZERO).setTaxCategoryCode("AE").setTaxExemptionReason("Reversecharge process"),
 				BigDecimal.TEN, BigDecimal.ONE)
-					.addAllowance(new Allowance().setReasonCode("64").setTotalAmount(BigDecimal.valueOf(4)).setTaxPercent(BigDecimal.ZERO)))
+					.addAllowance(itemAllowance))
 			.setPayee(
 				new TradeParty().setName("VR Factoring GmbH").setID("DE813838785").setLegalOrganisation(new LegalOrganisation("391200LDDFJDMIPPMZ54", "0199")))
-			.addAllowance(new Allowance().setReasonCode("64").setTotalAmount(BigDecimal.valueOf(5)).setTaxPercent(BigDecimal.valueOf(19)));
+			.addAllowance(invoiceAllowance);
 
 		final ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
 
@@ -208,7 +215,7 @@ public class XRTest extends TestCase {
 		final String basisAmount0 = xpath
 			.compile("*[local-name()='BasisAmount']/text()")
 			.evaluate(taxNode0);
-		Assertions.assertTrue(BigDecimal.TEN.compareTo(new BigDecimal(basisAmount0)) == 0);
+		Assertions.assertEquals(0, BigDecimal.TEN.compareTo(new BigDecimal(basisAmount0)));
 
 		final Node taxNode1 = tradeTaxes.item(1);
 		final String categoryCode1 = xpath
@@ -218,7 +225,7 @@ public class XRTest extends TestCase {
 		final String basisAmount1 = xpath
 			.compile("*[local-name()='BasisAmount']/text()")
 			.evaluate(taxNode1);
-		Assertions.assertTrue(BigDecimal.valueOf(7).compareTo(new BigDecimal(basisAmount1)) == 0);
+		Assertions.assertEquals(0, BigDecimal.valueOf(7).compareTo(new BigDecimal(basisAmount1)));
 
 		final Node taxNode2 = tradeTaxes.item(2);
 		final String categoryCode2 = xpath
@@ -228,7 +235,7 @@ public class XRTest extends TestCase {
 		final String basisAmount2 = xpath
 			.compile("*[local-name()='BasisAmount']/text()")
 			.evaluate(taxNode2);
-		Assertions.assertTrue(BigDecimal.valueOf(5).compareTo(new BigDecimal(basisAmount2)) == 0);
+		Assertions.assertEquals(0, BigDecimal.valueOf(5).compareTo(new BigDecimal(basisAmount2)));
 	}
 
 	public void testXRExportWithoutStreet() {
@@ -265,7 +272,6 @@ public class XRTest extends TestCase {
 		String number = "123";
 		String amountStr = "1.00";
 		BigDecimal amount = new BigDecimal(amountStr);
-		byte[] b = {12, 13};
 
 		Invoice i = new Invoice().setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date())
 			.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").setEmail("sender@example.com").addTaxID("DE4711").addVATID("DE0815").setContact(new Contact("Hans Test", "+49123456789", "test@example.org")).addBankDetails(new BankDetails("DE12500105170648489890", "COBADEFXXX").setAccountName("kontoInhaber")))
@@ -349,15 +355,15 @@ public class XRTest extends TestCase {
 		// document-level allowance with category O — must NOT produce RateApplicablePercent (BR-O-06)
 		Allowance allowanceO = new Allowance(new BigDecimal("10.00"));
 		allowanceO.setReason("Discount");
-		allowanceO.setCategoryCode(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE);
-		allowanceO.setTaxPercent(BigDecimal.ZERO);
+		allowanceO.setTaxCategoryCode(TaxCategoryCodeTypeConstants.UNTAXEDSERVICE);
+		allowanceO.setTaxRateApplicablePercent(BigDecimal.ZERO);
 		invoice.addAllowance(allowanceO);
 
 		// document-level allowance with category AE — MUST produce RateApplicablePercent = 0 (BR-AE-06)
 		Allowance allowanceAE = new Allowance(new BigDecimal("5.00"));
 		allowanceAE.setReason("Reverse charge discount");
-		allowanceAE.setCategoryCode(TaxCategoryCodeTypeConstants.REVERSECHARGE);
-		allowanceAE.setTaxPercent(BigDecimal.ZERO);
+		allowanceAE.setTaxCategoryCode(TaxCategoryCodeTypeConstants.REVERSECHARGE);
+		allowanceAE.setTaxRateApplicablePercent(BigDecimal.ZERO);
 		invoice.addAllowance(allowanceAE);
 
 		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2EdgeTest.java
@@ -32,13 +32,14 @@ import java.util.GregorianCalendar;
 
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
+import org.mustangproject.ReferencedDocument;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZF2EdgeTest extends MustangReaderTestCase {
-	final String TARGET_PDF = "./target/testout-ZF2newEdge.pdf";
+	private static final String TARGET_PDF = "./target/testout-ZF2newEdge.pdf";
 
 	protected class EdgeProduct implements IZUGFeRDExportableProduct {
 		private String description, name, unit;
@@ -144,68 +145,17 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 		return "DE";
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public IReferencedDocument getTenderReferencedDocument() {
-		return new IReferencedDocument() {
-			@Override
-			public String getIssuerAssignedID() {
-				return "983-jk-787";
-			}
-
-			@Override
-			public String getTypeCode() {
-				return "50";
-			}
-
-			@Override
-			public String getReferenceTypeCode() {
-				return "";
-			}
-
-			@Override
-			public Date getFormattedIssueDateTime() {
-				SimpleDateFormat sdf=new SimpleDateFormat("YYYY-mm-dd");
-				try {
-					return sdf.parse("2025-10-12");
-				} catch (ParseException e) {
-					// wont happen, I promise :-)
-				}
-				return null; // wont happen either
-			}
-
-		};
+		return new ReferencedDocument("983-jk-787", "50", null, new Date(2025 - 1900, 10 - 1, 12));
 	}
 
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public IReferencedDocument getObjectIdentifierReferencedDocument() {
-		return new IReferencedDocument() {
-			@Override
-			public String getIssuerAssignedID() {
-				return "gPogKLtac0";
-			}
-
-			@Override
-			public String getTypeCode() {
-				return "130";
-			}
-
-			@Override
-			public String getReferenceTypeCode() {
-				return "";
-			}
-
-			@Override
-			public Date getFormattedIssueDateTime() {
-				SimpleDateFormat sdf=new SimpleDateFormat("YYYY-mm-dd");
-				try {
-					return sdf.parse("2026-01-26");
-				} catch (ParseException e) {
-					throw new RuntimeException(e);
-				}
-			}
-
-		};
+		return new ReferencedDocument("gPogKLtac0", "130", null, new Date(2026 - 1900, 1 - 1, 26));
 	}
 
 	@Override
@@ -332,18 +282,13 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 	}
 
 	@Override
-	public String getDespatchAdviceReferencedDocumentID() {
-		return "123";
+	public IReferencedDocument getDespatchAdviceReferencedDocument() {
+		return new ReferencedDocument("123");
 	}
 
 	@Override
-	public String getDeliveryNoteReferencedDocumentID() {
-		return "0815";
-	}
-
-	@Override
-	public Date getDeliveryNoteReferencedDocumentDate() {
-		return new GregorianCalendar(2016, Calendar.APRIL, 1).getTime();
+	public IReferencedDocument getDeliveryNoteReferencedDocument() {
+		return new ReferencedDocument("0815");
 	}
 
 	/**
@@ -375,11 +320,9 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 
 		// the writing part
 
-		try  {
-			InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
+		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
+			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 
-			ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1();
 			ze.ignorePDFAErrors();
 			ze.load(SOURCE_PDF);
 			ze.setProducer("My Application")
@@ -431,12 +374,9 @@ public class ZF2EdgeTest extends MustangReaderTestCase {
 		// the writing part
 
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		try (InputStream SOURCE_PDF = this.getClass()
-				.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505PDFA3.pdf");
-
-			 IZUGFeRDExporter ze = new ZUGFeRDExporterFromA3().setProducer("My Application")
-					 .setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).disableFacturX()
-					 .load(SOURCE_PDF)) {
+		try (InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505PDFA3.pdf");
+				IZUGFeRDExporter ze = new ZUGFeRDExporterFromA3()) {
+			ze.setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).disableFacturX().load(SOURCE_PDF);
 			ze.setTransaction(this);
 			String theXML = new String(ze.getProvider().getXML(), StandardCharsets.UTF_8);
 			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2PushTest.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -676,27 +677,28 @@ public class ZF2PushTest extends TestCase {
 			try {
 				SchemedID gtin = new SchemedID("0160", "2001015001325");
 				SchemedID gln = new SchemedID("0088", "4304171000002");
-				ReferencedDocument dr1=new ReferencedDocument("90-kl-98798-C", sdf.parse("2025-10-12"));
-				ReferencedDocument dr2=new ReferencedDocument("90-kl-98798-C1", sdf.parse("2025-10-13"));
-				dr2.setReferenceTypeCode("AAG");
+				ReferencedDocument dr1 = new ReferencedDocument("90-kl-98798-C", sdf.parse("2025-10-12"));
+				ReferencedDocument dr2 = new ReferencedDocument("90-kl-98798-C1", sdf.parse("2025-10-13")).setReferenceTypeCode("AAG");
+				ReferencedDocument dr3 = new ReferencedDocument("orderId").setLineID("xxx");
+				ReferencedDocument dr4 = new ReferencedDocument("deliverynote123", new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026")).setLineID("deliverypos456");
+
 				ze.setTransaction(new Invoice().setTestIndicator().setCurrency("CHF").addNote("document level 1/2").addNote("document level 2/2").setDueDate(new Date()).setIssueDate(new Date()).setDeliveryDate(new Date()).setPaymentReference("Verwendungszweck").setDocumentName("Rechnung")
-					.setSellerOrderReferencedDocumentID("9384").setBuyerOrderReferencedDocumentID("28934")
+					.setSellerOrderReferencedDocument(new ReferencedDocument("9384")).setBuyerOrderReferencedDocument(new ReferencedDocument("28934"))
 					.setDetailedDeliveryPeriod(new SimpleDateFormat("yyyyMMdd").parse(occurrenceFrom), new SimpleDateFormat("yyyyMMdd").parse(occurrenceTo))
 					.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID(taxID).setEmail("sender@test.org").setID(orgID).addVATID("DE0815"))
 					.setDeliveryAddress(new TradeParty("just the other side of the street", "teststr.12a", "55232", "Entenhausen", "DE").addVATID("DE47110"))
 					.setEndCustomerDeliveryAddress(new TradeParty("Max Mustermann", "Glückswinkel 42", "98765", "Musterhausen", "DE"))
-					.setContractReferencedDocument(contractID)
+					.setContractReferencedDocument(new ReferencedDocument(contractID))
 					.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addGlobalID(gln).setEmail("recipient@test.org").addVATID("DE4711")
 						.setContact(new Contact("Franz Müller", "01779999999", "franz@mueller.de", "teststr. 12", "55232", "Entenhausen", "DE").setFax("++49555123456")).setAdditionalAddress("Hinterhaus 3"))
 					.setInvoicer( new TradeParty("Abweichender Rechnungssteller", "Teststr.12", "04711", "Entenhausen", "DE") )
 					.setInvoicee( new TradeParty("Abweichender Rechnungsempfänger", "Teststr.42", "00815", "Entenhausen", "DE") )
 					.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(16)).addGlobalID(gtin).setSellerAssignedID("4711"), price, new BigDecimal(1.0)).setId("a123")
-						.addAdditionalReference(dr2).addBuyerOrderReferencedDocumentID("orderId").addBuyerOrderReferencedDocumentLineID("xxx")
+						.addAdditionalReference(dr2)
+						.setBuyerOrderReferencedDocument(dr3)
 						.addNote("item level 1/1")
 						.addAllowance(itemAllowance).setDetailedDeliveryPeriod(sdf.parse("2020-01-13"), sdf.parse("2020-01-15"))
-						.setDeliveryNoteReferencedDocumentID("deliverynote123")
-						.setDeliveryNoteReferencedDocumentLineID("deliverypos456")
-						.setDeliveryNoteReferencedDocumentDate(new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026"))
+						.setDeliveryNoteReferencedDocument(dr4)
 						.setAccountingReference("#11111#2222#xxxx#")
 					)
 					.addCharge(charge)
@@ -704,7 +706,7 @@ public class ZF2PushTest extends TestCase {
 					.addCashDiscount(new CashDiscount(new BigDecimal(2), 14))
 					.setTenderReferencedDocument(dr1)
 					.setDeliveryDate(sdf.parse("2020-11-02")).setNumber(number).setVATDueDateTypeCode(EventTimeCodeTypeConstants.PAYMENT_DATE)
-					.setInvoiceReferencedDocumentID("abc123").addInvoiceReferencedDocument(new ReferencedDocument("abcd1234"))
+					.addInvoiceReferencedDocument(new ReferencedDocument("abcd1234"))
 					.setDeliveryTypeCode("EXW")
 				);
 			} catch (ParseException e) {
@@ -737,11 +739,11 @@ public class ZF2PushTest extends TestCase {
 		assertTrue(zi.getUTF8().contains(occurrenceTo));
 		assertTrue(zi.getUTF8().contains(contractID));
 		assertTrue(zi.getUTF8().contains("EXW"));
-		assertEquals(zi.importedInvoice.getZFItems()[0].getId(), "a123");
-		assertEquals(zi.importedInvoice.getZFItems()[0].getDeliveryNoteReferencedDocumentID(), "deliverynote123");
-		assertEquals(zi.importedInvoice.getZFItems()[0].getDeliveryNoteReferencedDocumentLineID(), "deliverypos456");
+		assertEquals("a123", zi.importedInvoice.getZFItems()[0].getId());
+		assertEquals("deliverynote123", zi.importedInvoice.getZFItems()[0].getDeliveryNoteReferencedDocument().getIssuerAssignedID());
+		assertEquals("deliverypos456", zi.importedInvoice.getZFItems()[0].getDeliveryNoteReferencedDocument().getLineID());
 		try {
-			assertEquals(zi.importedInvoice.getZFItems()[0].getDeliveryNoteReferencedDocumentDate(), new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026"));
+			assertEquals(new SimpleDateFormat("dd.MM.yyyy").parse("14.01.2026"), zi.importedInvoice.getZFItems()[0].getDeliveryNoteReferencedDocument().getFormattedIssueDateTime());
 		} catch (ParseException e) {
 			e.printStackTrace();
 		}
@@ -761,7 +763,6 @@ public class ZF2PushTest extends TestCase {
 		try {
 			Invoice i = zii.extractInvoice();
 
-			assertEquals("abc123", i.getInvoiceReferencedDocumentID());
 			assertEquals("EXW", i.getDeliveryTypeCode());
 			assertEquals(1, i.getInvoiceReferencedDocuments().size());
 			assertEquals("abcd1234", i.getInvoiceReferencedDocuments().get(0).getIssuerAssignedID());
@@ -956,13 +957,13 @@ public class ZF2PushTest extends TestCase {
 		try (ZUGFeRDExporterFromA1 ze = new ZUGFeRDExporterFromA1()) {
 			InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505blanko.pdf");
 			ze.ignorePDFAErrors().load(SOURCE_PDF);
-			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2);
+			ze.setProducer("My Application").setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("EXTENDED");
 			Invoice i = new Invoice().setIssueDate(new Date()).setDueDate(new Date()).setDetailedDeliveryPeriod(new Date(), new Date()).setDeliveryDate(new Date())
 				.setSender(new TradeParty(orgname, "teststr", "55232", "teststadt", "DE").addTaxID("4711").addVATID("DE0815").addBankDetails(new BankDetails("DE88200800000970375700", "COBADEFFXXX")))
 				.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE").addVATID("DE0815"))
-				.setNumber(number).setDespatchAdviceReferencedDocumentID(despatchAdviceReferencedDocumentID)
-				.setDeliveryNoteReferencedDocumentID("0815")
-				.setDeliveryNoteReferencedDocumentDate(new SimpleDateFormat("dd.MM.yyyy").parse("01.04.2016"))
+				.setNumber(number)
+				.setDespatchAdviceReferencedDocument(new ReferencedDocument(despatchAdviceReferencedDocumentID))
+				.setDeliveryNoteReferencedDocument(new ReferencedDocument("0815").setFormattedIssueDateTime(new SimpleDateFormat("dd.MM.yyyy").parse("01.04.2016")))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty))
 				.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty)).setCreditNote();
@@ -995,9 +996,9 @@ public class ZF2PushTest extends TestCase {
 		try {
 			Invoice i = zii.extractInvoice();
 
-			assertEquals(despatchAdviceReferencedDocumentID, i.getDespatchAdviceReferencedDocumentID());
-			assertEquals("0815", i.getDeliveryNoteReferencedDocumentID());
-			assertEquals(new SimpleDateFormat("dd.MM.yyyy").parse("01.04.2016"), i.getDeliveryNoteReferencedDocumentDate());
+			assertEquals(despatchAdviceReferencedDocumentID, i.getDespatchAdviceReferencedDocument().getIssuerAssignedID());
+			assertEquals("0815", i.getDeliveryNoteReferencedDocument().getIssuerAssignedID());
+			assertEquals(new SimpleDateFormat("dd.MM.yyyy").parse("01.04.2016"), i.getDeliveryNoteReferencedDocument().getFormattedIssueDateTime());
 
 		} catch (XPathExpressionException e) {
 			fail("XPathExpressionException should not be raised");
@@ -1023,13 +1024,15 @@ public class ZF2PushTest extends TestCase {
 			.setNumber(number)
 			.addItem(new Item(new Product("Testprodukt", "", "H87", new BigDecimal(19)), price, qty));
 
+		ArrayList<ReferencedDocument> invoiceReferencedDocuments = new ArrayList<>();
+		invoiceReferencedDocuments.add(new ReferencedDocument(""));
 		// empty strings for document id's
-		i.setSellerOrderReferencedDocumentID("")
-			.setBuyerOrderReferencedDocumentID("")
-			.setContractReferencedDocument("")
-			.setDespatchAdviceReferencedDocumentID("")
-			.setDeliveryNoteReferencedDocumentID("")
-			.setInvoiceReferencedDocumentID("");
+		i.setSellerOrderReferencedDocument(new ReferencedDocument(""))
+			.setBuyerOrderReferencedDocument(new ReferencedDocument(""))
+			.setContractReferencedDocument(new ReferencedDocument(""))
+			.setDespatchAdviceReferencedDocument(new ReferencedDocument(""))
+			.setDeliveryNoteReferencedDocument(new ReferencedDocument(""))
+			.setInvoiceReferencedDocuments(invoiceReferencedDocuments);
 
 		zf2p.generateXML(i);
 		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
@@ -1040,13 +1043,15 @@ public class ZF2PushTest extends TestCase {
 		assertFalse(theXML.contains("<ram:DespatchAdviceReferencedDocument"));
 		assertFalse(theXML.contains("<ram:InvoiceReferencedDocument"));
 
+		invoiceReferencedDocuments.clear();
+		invoiceReferencedDocuments.add(new ReferencedDocument("     "));
 		// effective empty strings for document id's
-		i.setSellerOrderReferencedDocumentID(" ")
-			.setBuyerOrderReferencedDocumentID("  ")
-			.setContractReferencedDocument("   ")
-			.setDespatchAdviceReferencedDocumentID("    ")
-			.setDeliveryNoteReferencedDocumentID("    ")
-			.setInvoiceReferencedDocumentID("     ");
+		i.setSellerOrderReferencedDocument(new ReferencedDocument(" "))
+			.setBuyerOrderReferencedDocument(new ReferencedDocument("  "))
+			.setContractReferencedDocument(new ReferencedDocument("   "))
+			.setDespatchAdviceReferencedDocument(new ReferencedDocument("    "))
+			.setDeliveryNoteReferencedDocument(new ReferencedDocument("    "))
+			.setInvoiceReferencedDocuments(invoiceReferencedDocuments);
 
 		zf2p.generateXML(i);
 		theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2Test.java
@@ -29,17 +29,17 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.List;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
+import org.mustangproject.Invoice;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ZF2Test extends MustangReaderTestCase {
-	final String TARGET_PDF = "./target/testout-ZF2new.pdf";
+	private static final String TARGET_PDF = "./target/testout-ZF2new.pdf";
 
 
 	@Override
@@ -165,87 +165,84 @@ public class ZF2Test extends MustangReaderTestCase {
 	 * values.
 	 */
 	public void testExport() {
-
-		// the writing part
-
-		try (InputStream SOURCE_PDF = this.getClass()
-			.getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505PDFA3.pdf");
-
-			 ZUGFeRDExporterFromA3 ze = new ZUGFeRDExporterFromA3().setProducer("My Application")
-				 .setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("EN16931")
-				 .load(SOURCE_PDF)) {
-
-			ze.setTransaction(this);
-			final String theXML = new String(ze.getProvider().getXML(), StandardCharsets.UTF_8);
-			assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
-			ze.export(TARGET_PDF);
-		} catch (final IOException e) {
-			fail("IOException should not be raised in testEdgeExport");
-		}
-
-		// now check the contents (like MustangReaderTest)
-		final ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF);
-
-		assertTrue(zi.getUTF8().contains("<ram:DueDateDateTime>"));
-
-		// Reading ZUGFeRD
-		assertEquals(zi.getAmount(), "571.04");
-		assertEquals(zi.getInvoiceID(), "RE-20170509/505");
-		assertEquals(zi.getZUGFeRDProfil(), "COMFORT");
-		assertEquals(zi.getInvoiceCurrencyCode(), "EUR");
-		assertEquals(zi.getIssuerAssignedID(), "");
-		assertEquals(zi.getIssueDate(), "20170509");
-		assertEquals(zi.getTaxPointDate(), "20170507");
-		assertEquals(zi.getPaymentTerms(), "Zahlbar ohne Abzug bis zum 30.05.2017");
-		assertEquals(zi.getLineTotalAmount(), "496.00");
-		assertEquals(zi.getTaxBasisTotalAmount(), "496.00");
-		assertEquals(zi.getTaxTotalAmount(), "75.04");
-		assertEquals(zi.getRoundingAmount(), "");
-		assertEquals(zi.getPaidAmount(), "0.00");
-		assertEquals(zi.getBuyerTradePartyName(), "Theodor Est");
-		assertEquals(zi.getBuyerTradePartyGlobalID(), "");
-		assertEquals(zi.getSellerTradePartyGlobalID(), "");
-		assertEquals(zi.getBuyerTradePartyID(), "DE999999999");
-		assertEquals(zi.getBuyertradePartySpecifiedTaxRegistrationID(), "DE999999999");
-		assertEquals(zi.getIncludedNote(), "");
-		assertEquals(zi.getHolder(), getOwnOrganisationName());
-		assertEquals(zi.getDocumentCode(), "380");
-		assertEquals(zi.getReference(), "AB321");
-		assertEquals(zi.getAmount(), "571.04");
-		assertEquals(zi.getBIC(), "COBADEFFXXX");
-		assertEquals(zi.getIBAN(), "DE88 2008 0000 0970 3757 00");
-		assertEquals(zi.getHolder(), getOwnOrganisationName());
-		assertEquals(zi.getForeignReference(), getNumber());
-		assertEquals(zi.getBuyerTradePartyAddress().getPostcodeCode(), "88802");
-		assertEquals(zi.getBuyerTradePartyAddress().getLineOne(), "Bahnstr. 42");
-		assertEquals(zi.getBuyerTradePartyAddress().getLineTwo(), "Hinterhaus");
-		assertEquals(zi.getBuyerTradePartyAddress().getLineThree(), "Zweiter Stock");
-		assertEquals(zi.getBuyerTradePartyAddress().getCountrySubDivisionName(), null);
-		assertEquals(zi.getBuyerTradePartyAddress().getCountryID(), "DE");
-		assertEquals(zi.getBuyerTradePartyAddress().getCityName(), "Spielkreis");
-		assertEquals(zi.getSellerTradePartyAddress().getPostcodeCode(), "12345");
-		assertEquals(zi.getSellerTradePartyAddress().getLineOne(), "Ecke 12");
-		assertEquals(zi.getSellerTradePartyAddress().getLineTwo(), null);
-		assertEquals(zi.getSellerTradePartyAddress().getLineThree(), null);
-		assertEquals(zi.getSellerTradePartyAddress().getCountrySubDivisionName(), null);
-		assertEquals(zi.getSellerTradePartyAddress().getCountryID(), "DE");
-		assertEquals(zi.getSellerTradePartyAddress().getCityName(), "Stadthausen");
-
-		final List<org.mustangproject.Item> li = zi.getLineItemList();
-		assertEquals(li.get(0).getId().toString(), "1");
-		assertEquals(li.get(0).getProduct().getBuyerAssignedID(), "");
-		assertEquals(li.get(0).getProduct().getSellerAssignedID(), "");
-		assertEquals(li.get(0).getLineTotalAmount().toString(), "160.00");
-		assertEquals(li.get(0).getQuantity().toString(), "1.0000");
-		assertEquals(li.get(0).getProduct().getVATPercent().toString(), "7.00");
-		assertEquals(li.get(0).getProduct().getName(), "Künstlerische Gestaltung (Stunde): Einer Beispielrechnung");
-		assertEquals(li.get(0).getProduct().getDescription(), "");
-
 		try {
+			// the writing part
+			try (InputStream SOURCE_PDF = this.getClass().getResourceAsStream("/MustangGnuaccountingBeispielRE-20170509_505PDFA3.pdf");
+					ZUGFeRDExporterFromA3 ze = new ZUGFeRDExporterFromA3()) {
+
+				 ze.setProducer("My Application")
+					 .setCreator(System.getProperty("user.name")).setZUGFeRDVersion(2).setProfile("EN16931")
+					 .load(SOURCE_PDF);
+
+				ze.setTransaction(this);
+				final String theXML = new String(ze.getProvider().getXML(), StandardCharsets.UTF_8);
+				assertTrue(theXML.contains("<rsm:CrossIndustryInvoice"));
+				ze.export(TARGET_PDF);
+			} catch (final IOException e) {
+				fail("IOException should not be raised in testEdgeExport");
+			}
+
+			// now check the contents (like MustangReaderTest)
+			final ZUGFeRDImporter zi = new ZUGFeRDImporter(TARGET_PDF);
+
+			assertTrue(zi.getUTF8().contains("<ram:DueDateDateTime>"));
+
+			// Reading ZUGFeRD
+			assertEquals(zi.getAmount(), "571.04");
+			assertEquals(zi.getInvoiceID(), "RE-20170509/505");
+			assertEquals(zi.getZUGFeRDProfil(), "COMFORT");
+			assertEquals(zi.getInvoiceCurrencyCode(), "EUR");
+			assertEquals(zi.getIssuerAssignedID(), "");
+			assertEquals(zi.getIssueDate(), "20170509");
+			assertEquals(zi.getTaxPointDate(), "20170507");
+			assertEquals(zi.getPaymentTerms(), "Zahlbar ohne Abzug bis zum 30.05.2017");
+			assertEquals(zi.getLineTotalAmount(), "496.00");
+			assertEquals(zi.getTaxBasisTotalAmount(), "496.00");
+			assertEquals(zi.getTaxTotalAmount(), "75.04");
+			assertEquals(zi.getRoundingAmount(), "");
+			assertEquals(zi.getPaidAmount(), "0.00");
+			assertEquals(zi.getBuyerTradePartyName(), "Theodor Est");
+			assertEquals(zi.getBuyerTradePartyGlobalID(), "");
+			assertEquals(zi.getSellerTradePartyGlobalID(), "");
+			assertEquals(zi.getBuyerTradePartyID(), "DE999999999");
+			assertEquals(zi.getBuyertradePartySpecifiedTaxRegistrationID(), "DE999999999");
+			assertEquals(zi.getIncludedNote(), "");
+			assertEquals(zi.getHolder(), getOwnOrganisationName());
+			assertEquals(zi.getDocumentCode(), "380");
+			assertEquals(zi.getReference(), "AB321");
+			assertEquals(zi.getAmount(), "571.04");
+			assertEquals(zi.getBIC(), "COBADEFFXXX");
+			assertEquals(zi.getIBAN(), "DE88 2008 0000 0970 3757 00");
+			assertEquals(zi.getHolder(), getOwnOrganisationName());
+			assertEquals(zi.getForeignReference(), getNumber());
+			assertEquals(zi.getBuyerTradePartyAddress().getPostcodeCode(), "88802");
+			assertEquals(zi.getBuyerTradePartyAddress().getLineOne(), "Bahnstr. 42");
+			assertEquals(zi.getBuyerTradePartyAddress().getLineTwo(), "Hinterhaus");
+			assertEquals(zi.getBuyerTradePartyAddress().getLineThree(), "Zweiter Stock");
+			assertEquals(zi.getBuyerTradePartyAddress().getCountrySubDivisionName(), null);
+			assertEquals(zi.getBuyerTradePartyAddress().getCountryID(), "DE");
+			assertEquals(zi.getBuyerTradePartyAddress().getCityName(), "Spielkreis");
+			assertEquals(zi.getSellerTradePartyAddress().getPostcodeCode(), "12345");
+			assertEquals(zi.getSellerTradePartyAddress().getLineOne(), "Ecke 12");
+			assertEquals(zi.getSellerTradePartyAddress().getLineTwo(), null);
+			assertEquals(zi.getSellerTradePartyAddress().getLineThree(), null);
+			assertEquals(zi.getSellerTradePartyAddress().getCountrySubDivisionName(), null);
+			assertEquals(zi.getSellerTradePartyAddress().getCountryID(), "DE");
+			assertEquals(zi.getSellerTradePartyAddress().getCityName(), "Stadthausen");
+
+			Invoice invoice = zi.extractInvoice();
+			assertEquals("1", invoice.getZFItems()[0].getId());
+			assertEquals(null, invoice.getZFItems()[0].getProduct().getBuyerAssignedID());
+			assertEquals(null, invoice.getZFItems()[0].getProduct().getSellerAssignedID());
+			assertEquals("160.00", invoice.getZFItems()[0].getLineTotalAmount().toString());
+			assertEquals("1.0000", invoice.getZFItems()[0].getQuantity().toString());
+			assertEquals("7.00", invoice.getZFItems()[0].getProduct().getVATPercent().toString());
+			assertEquals("Künstlerische Gestaltung (Stunde): Einer Beispielrechnung", invoice.getZFItems()[0].getProduct().getName());
+			assertEquals(null, invoice.getZFItems()[0].getProduct().getDescription());
+
 			assertEquals(zi.getVersion(), 2);
-		} catch (final Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		} catch ( Exception e ) {
+			fail(e.getMessage());
 		}
 	}
 
@@ -307,7 +304,6 @@ public class ZF2Test extends MustangReaderTestCase {
 		try {
 			assertEquals(zi.getVersion(), 2);
 		} catch (final Exception e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 	}

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/ZF2ZInvoiceImporterTest.java
@@ -181,7 +181,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		SimpleDateFormat sdf=new SimpleDateFormat("YYYY-MM-dd");
 		// Reading ZUGFeRD
 		assertEquals("4711", invoice.getZFItems()[0].getProduct().getSellerAssignedID());
-		assertEquals("9384", invoice.getSellerOrderReferencedDocumentID());
+		assertEquals("9384", invoice.getSellerOrderReferencedDocument().getIssuerAssignedID());
 		assertEquals("90-kl-98798-C", invoice.getTenderReferencedDocument().getIssuerAssignedID());
 
 		IReferencedDocument[] rd=invoice.getZFItems()[0].getAdditionalReferences();
@@ -194,11 +194,7 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		assertEquals("2025-10-12", sdf.format(invoice.getTenderReferencedDocument().getFormattedIssueDateTime()));
 		assertEquals("sender@test.org", invoice.getSender().getEmail());
 		assertEquals("recipient@test.org", invoice.getRecipient().getEmail());
-		assertEquals("28934", invoice.getBuyerOrderReferencedDocumentID());
-
-
-
-
+		assertEquals("28934", invoice.getBuyerOrderReferencedDocument().getIssuerAssignedID());
 	}
 
 
@@ -899,12 +895,12 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		assertNull(invoice.getDeliveryAddress());
 		assertNull(invoice.getPayee());
 
-		assertNull(invoice.getBuyerOrderReferencedDocumentID());
-		assertNull(invoice.getSellerOrderReferencedDocumentID());
-		assertNull(invoice.getDespatchAdviceReferencedDocumentID());
-		assertNull(invoice.getInvoiceReferencedDocumentID());
-		assertNull(invoice.getDeliveryNoteReferencedDocumentID());
-		assertNull(invoice.getDeliveryNoteReferencedDocumentDate());
+		assertNull(invoice.getBuyerOrderReferencedDocument());
+		assertNull(invoice.getSellerOrderReferencedDocument());
+		assertNull(invoice.getDespatchAdviceReferencedDocument());
+		assertNull(invoice.getInvoiceReferencedDocuments());
+		assertNull(invoice.getDeliveryNoteReferencedDocument());
+		assertNull(invoice.getDeliveryNoteReferencedDocument());
 	}
 
 	@Test
@@ -1089,6 +1085,9 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		zii.setInputStream(new FileInputStream(inputFile));
 
 		Invoice invoice = zii.extractInvoice();
+		assertNotNull(invoice.getZFItems()[0].getSellerOrderReferencedDocument());
+		assertNotNull(invoice.getZFItems()[0].getBuyerOrderReferencedDocument());
+		assertNotNull(invoice.getZFItems()[0].getContractReferencedDocument());
 
 		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
 		zf2p.setProfile(Profiles.getByName("EN16931"));
@@ -1096,6 +1095,9 @@ public class ZF2ZInvoiceImporterTest extends ResourceCase {
 		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
 
 		assertTrue(theXML.contains("issuer-assigned-id_PPg9iTcig5UG0978"));
+		assertTrue(theXML.contains("Verkäufer"));
+		assertTrue(theXML.contains("Käufer"));
+		assertTrue(theXML.contains("Vertrag"));
 	}
 
 	@Test

--- a/library/src/test/resources/testContractReferencedDocument.xml
+++ b/library/src/test/resources/testContractReferencedDocument.xml
@@ -31,6 +31,15 @@
                 <ram:Name>PATAT FRITES 10MM 10KG</ram:Name>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
+	            <ram:SellerOrderReferencedDocument>
+	                <ram:IssuerAssignedID>Verkäufer-Dokument</ram:IssuerAssignedID>
+	            </ram:SellerOrderReferencedDocument>
+	            <ram:BuyerOrderReferencedDocument>
+	                <ram:IssuerAssignedID>Käufer-Dokument</ram:IssuerAssignedID>
+	            </ram:BuyerOrderReferencedDocument>
+	            <ram:ContractReferencedDocument>
+	                <ram:IssuerAssignedID>Vertrags-Dokument</ram:IssuerAssignedID>
+	            </ram:ContractReferencedDocument>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>9.95</ram:ChargeAmount>
                 </ram:NetPriceProductTradePrice>

--- a/validator/src/main/resources/schema/ZF_250/BASIC-WL/FACTUR-X_BASIC-WL_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
+++ b/validator/src/main/resources/schema/ZF_250/BASIC-WL/FACTUR-X_BASIC-WL_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
@@ -5,8 +5,8 @@
     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
     targetNamespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
     elementFormDefault="qualified">
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="Factur-X_1.09_BASICWL_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="Factur-X_1.09_BASICWL_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="FACTUR-X_BASICWL_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="FACTUR-X_BASICWL_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
   <xs:complexType name="CreditorFinancialAccountType">
     <xs:sequence>
       <xs:element name="IBANID" type="udt:IDType" minOccurs="0"/>

--- a/validator/src/main/resources/schema/ZF_250/BASIC/FACTUR-X_BASIC_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
+++ b/validator/src/main/resources/schema/ZF_250/BASIC/FACTUR-X_BASIC_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
@@ -5,8 +5,8 @@
     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
     targetNamespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
     elementFormDefault="qualified">
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="Factur-X_1.09_BASIC_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="Factur-X_1.09_BASIC_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="FACTUR-X_BASIC_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="FACTUR-X_BASIC_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
   <xs:complexType name="CreditorFinancialAccountType">
     <xs:sequence>
       <xs:element name="IBANID" type="udt:IDType" minOccurs="0"/>

--- a/validator/src/main/resources/schema/ZF_250/EN16931/FACTUR-X_EN16931_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
+++ b/validator/src/main/resources/schema/ZF_250/EN16931/FACTUR-X_EN16931_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
@@ -5,8 +5,8 @@
     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
     targetNamespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
     elementFormDefault="qualified">
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="Factur-X_1.09_EN16931_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="Factur-X_1.09_EN16931_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="FACTUR-X_EN16931_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="FACTUR-X_EN16931_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
   <xs:complexType name="CreditorFinancialAccountType">
     <xs:sequence>
       <xs:element name="IBANID" type="udt:IDType" minOccurs="0"/>

--- a/validator/src/main/resources/schema/ZF_250/EXTENDED/FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
+++ b/validator/src/main/resources/schema/ZF_250/EXTENDED/FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
@@ -5,8 +5,8 @@
     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
     targetNamespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
     elementFormDefault="qualified">
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="Factur-X_1.09_EXTENDED_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="Factur-X_1.09_EXTENDED_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="FACTUR-X_EXTENDED_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
   <xs:complexType name="AdvancePaymentType">
     <xs:sequence>
       <xs:element name="PaidAmount" type="udt:AmountType"/>

--- a/validator/src/main/resources/schema/ZF_250/MINIMUM/FACTUR-X_MINIMUM_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
+++ b/validator/src/main/resources/schema/ZF_250/MINIMUM/FACTUR-X_MINIMUM_urn_un_unece_uncefact_data_standard_ReusableAggregateBusinessInformationEntity_100.xsd
@@ -5,8 +5,8 @@
     xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100"
     targetNamespace="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
     elementFormDefault="qualified">
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="Factur-X_1.09_MINIMUM_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
-  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="Factur-X_1.09_MINIMUM_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" schemaLocation="FACTUR-X_MINIMUM_urn_un_unece_uncefact_data_standard_QualifiedDataType_100.xsd"/>
+  <xs:import namespace="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" schemaLocation="FACTUR-X_MINIMUM_urn_un_unece_uncefact_data_standard_UnqualifiedDataType_100.xsd"/>
   <xs:complexType name="DocumentContextParameterType">
     <xs:sequence>
       <xs:element name="ID" type="udt:IDType"/>


### PR DESCRIPTION
Replaced separate fields  like deliveryNoteReferencedDocumentID, deliveryNoteReferencedDocumentDate and deliveryNoteReferencedDocumentLineID by ReferencedDocument deliveryNoteReferencedDocument .
Kept the getters and setters for the old fields, but changed their implementation to the new ReferencedDocument class and marked them as Deprecated(forRemoval = true, since = "2.24.1").
Parsing and writing of the xml fragments is done in ReferencedDocument only, with some exceptions.
Removed some dead code and a lot of warnings.