### PR TITLE
(fix): prevent NPE when generating XML invoice for invoice without an issue date

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -421,9 +421,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		if (profile == Profiles.getByName("Extended") && trans.getDocumentName() != null) {
 			xml.append("<ram:Name>" + XMLTools.encodeXML(trans.getDocumentName()) + "</ram:Name>");
 		}
-		xml.append("<ram:TypeCode>" + typecode + "</ram:TypeCode>"
-			+ "<ram:IssueDateTime>" + DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>" // date
-			+ buildNotes(trans)
+		xml.append("<ram:TypeCode>" + typecode + "</ram:TypeCode>");
+		if (trans.getIssueDate() != null) {
+			xml.append("<ram:IssueDateTime>" + DATE.udtFormat(trans.getIssueDate()) + "</ram:IssueDateTime>"); // date
+		}
+		xml.append(buildNotes(trans)
 			+ "</rsm:ExchangedDocument>"
 			+ "<rsm:SupplyChainTradeTransaction>");
 		int lineID = 0;


### PR DESCRIPTION
fixes #1203

Changes proposed in this pull request:

- Add null guard around the use of the `issue date` in `ZuGFERD2PullProivder.generateXML()` method, to prevent NPE for invoices without an issue date.