### PR TITLE
Prevent NPE in Item.enrichProductFromVATBreakdown for VAT category "O".

### DIFF
--- a/library/src/main/java/org/mustangproject/Item.java
+++ b/library/src/main/java/org/mustangproject/Item.java
@@ -168,7 +168,6 @@ public class Item implements IZUGFeRDExportableItem {
 			.forEach(this::addAdditionalReference);
 
 		// ubl
-
 		itemMap.getAsNodeMap("OrderLineReference")
 			// ubl
 			.flatMap(bordNodes -> bordNodes.getAsString("LineID"))
@@ -399,8 +398,8 @@ public class Item implements IZUGFeRDExportableItem {
 				String taxCategoryCode = taxChildMap.getAsStringOrNull("CategoryCode");
 				BigDecimal rateApplicablePercent = taxChildMap.getAsBigDecimal("RateApplicablePercent", "ApplicablePercent").orElse(null);
 
-				if (taxCategoryCode != null && rateApplicablePercent != null && taxCategoryCode.equals(this.product.taxCategoryCode) && rateApplicablePercent.compareTo(this.product.getVATPercent()) == 0) {
-					// If product Exemption not already set (i.e. by per line-item exemption fields, set it from VAT Breakdown
+				if (taxCategoryCode != null && rateApplicablePercent != null && taxCategoryCode.equals(this.product.taxCategoryCode) && (this.product.getVATPercent() == null || rateApplicablePercent.compareTo(this.product.getVATPercent()) == 0)) {
+					// If product Exempt not already set (i.e. by per line-item exempt fields, set it from VAT Breakdown
 					if (this.product.getTaxExemptionReason() == null) {
 						this.product.setTaxExemptionReason(taxChildMap.getAsStringOrNull("ExemptionReason"));
 					}

--- a/validator/src/test/java/org/mustangproject/validator/XMLValidatorTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/XMLValidatorTest.java
@@ -547,4 +547,25 @@ public class XMLValidatorTest extends ResourceCase {
 			// ignore, will be in XML output anyway
 		}
 	}
+
+  public void testVAT_O() {
+		final ValidationContext ctx = new ValidationContext(null);
+		final XMLValidator xv = new XMLValidator(ctx);
+		final XPathEngine xpath = new JAXPXPathEngine();
+
+		File tempFile = getResourceAsFile("valid_with_VAT_O.xml");
+		try {
+			xv.setFilename(tempFile.getAbsolutePath());
+			xv.validate();
+
+			String s = "<validation>" + xv.getXMLResult() + "</validation>";
+			Source source = Input.fromString(s).build();
+			String content = xpath.evaluate("/validation/summary/@status", source);
+			assertEquals("invalid", content);
+			assertThat(s).valueByXPath("count(//warning)").asInt().isEqualTo(1);
+		} catch (final IrrecoverableValidationError e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
 }

--- a/validator/src/test/java/org/mustangproject/validator/ZUGFeRDValidatorTest.java
+++ b/validator/src/test/java/org/mustangproject/validator/ZUGFeRDValidatorTest.java
@@ -284,4 +284,14 @@ public class ZUGFeRDValidatorTest extends ResourceCase {
 			.isEqualTo("valid");
 
 	}
+
+	public void testVAT_O() {
+		File tempFile = getResourceAsFile("valid_with_VAT_O.xml");
+
+		ZUGFeRDValidator zfv = new ZUGFeRDValidator();
+
+		String res = zfv.validate(tempFile.getAbsolutePath());
+
+		assertThat(res).valueByXPath("/validation/xml/summary/@status").isEqualTo("invalid");
+	}
 }

--- a/validator/src/test/resources/valid_with_VAT_O.xml
+++ b/validator/src/test/resources/valid_with_VAT_O.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+        xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100"
+        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>REPRO-1</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20260805</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Repro item</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>100.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="C62">1</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:ExemptionReason>Not subject to VAT</ram:ExemptionReason>
+                    <ram:CategoryCode>O</ram:CategoryCode>
+                    <!-- BR-O-05: line-level VAT for category O MUST NOT contain a rate -->
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>100.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:Name>Seller GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:Name>Buyer GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery/>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>0.00</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:ExemptionReason>Not subject to VAT</ram:ExemptionReason>
+                <ram:BasisAmount>100.00</ram:BasisAmount>
+                <ram:CategoryCode>O</ram:CategoryCode>
+                <!-- BR-DE-14: header VAT breakdown MUST contain a rate (0.00) even for category O -->
+                <ram:RateApplicablePercent>0.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>100.00</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>100.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">0.00</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>100.00</ram:GrandTotalAmount>
+                <ram:DuePayableAmount>100.00</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
Related to #1219

Added tests to ZUGFeRD- and XML-Validator with the given xml.
Check this.product.getVATPercent() == null in org.mustangproject.Item.enrichProductFromVATBreakdown(NodeList).