### PR TITLE
Modify valid version array in PDFValidator

### DIFF
--- a/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
+++ b/validator/src/main/java/org/mustangproject/validator/PDFValidator.java
@@ -274,7 +274,7 @@ public class PDFValidator extends Validator {
 
 				boolean versionValid = false;
 				for (int i = 0; i < nodes.getLength(); i++) {
-					final String[] valueArray = {"1.0", "1p0", "2p0", "1.2", "2.0", "2.1", "2.2", "2.3", "3.0"}; //1.2, 2.0, 2.1, 2.2, 2.3 and 3.0 are for xrechnung 1.2, 2p0 can be ZF 2.0, 2.1, 2.1.1
+					final String[] valueArray = {"1.0", "1p0", "2p0", "3p0", "1.2", "2.0", "2.1", "2.2", "2.3", "3.0"}; //1.2, 2.0, 2.1, 2.2, 2.3 and 3.0 are for xrechnung 1.2, 2p0 can be ZF 2.0, 2.1, 2.1.1
 
 					if (stringArrayContains(valueArray, nodes.item(i).getTextContent())) {
 						versionValid = true;


### PR DESCRIPTION
### Description

The `PDFValidator` rejects `fx:Version = "3p0"` as invalid, even though `"1p0"` and `"2p0"` are accepted. This causes XRechnung 3.0 invoices to fail PDF validation with:

> XMP Metadata: Version contains invalid value (Section 16)

The PDF/A-3b validation via veraPDF passes (`isCompliant=true`), but the overall result is marked as invalid due to this version check.

### Root Cause

In [`PDFValidator.java`](https://github.com/ZUGFeRD/mustangproject/blob/master/validator/src/main/java/org/mustangproject/validator/PDFValidator.java):

```java
final String[] valueArray = {"1.0", "1p0", "2p0", "1.2", "2.0", "2.1", "2.2", "2.3", "3.0"};
```

`"3p0"` is missing. The pattern `{N}p{N}` is used by `XMPSchemaZugferd` for ZUGFeRD versions (see `1p0`, `2p0`), so `3p0` should be accepted as well.

### How to Reproduce

Validate any PDF with these XMP metadata fields:
```xml
<fx:ConformanceLevel>XRECHNUNG</fx:ConformanceLevel>
<fx:Version>3p0</fx:Version>
<fx:DocumentFileName>xrechnung.xml</fx:DocumentFileName>
```

The XML inside uses:
```xml
<ram:ID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</ram:ID>
```

### Suggested Fix

```java
final String[] valueArray = {"1.0", "1p0", "2p0", "3p0", "1.2", "2.0", "2.1", "2.2", "2.3", "3.0"};
```

