### PR TITLE
Support writing the seller tax representative (BG-11) in CII

### DIFF
--- a/library/src/main/java/org/mustangproject/Invoice.java
+++ b/library/src/main/java/org/mustangproject/Invoice.java
@@ -56,7 +56,7 @@ public class Invoice implements IExportableTransaction {
 	protected String documentName, documentCode, number, ownOrganisationFullPlaintextInfo, referenceNumber, shipToOrganisationID, shipToOrganisationName, shipToStreet, shipToZIP, shipToLocation, shipToCountry, ownForeignOrganisationID, ownOrganisationName, currency, paymentTermDescription;
 	protected String deliveryTypeCode;
 	protected Date issueDate, dueDate, deliveryDate;
-	protected TradeParty sender, recipient, deliveryAddress, endCustomerDeliveryAddress, payee, invoicer, invoicee;
+	protected TradeParty sender, recipient, deliveryAddress, endCustomerDeliveryAddress, payee, invoicer, invoicee, taxRepresentative;
 	protected ArrayList<CashDiscount> cashDiscounts;
 	@JsonDeserialize(contentAs = Item.class)
 	protected List<IZUGFeRDExportableItem> zfItems;
@@ -987,6 +987,22 @@ public class Invoice implements IExportableTransaction {
 	 */
 	public Invoice setPayee(TradeParty payee) {
 		this.payee = payee;
+		return this;
+	}
+
+	@Override
+	public TradeParty getTaxRepresentative() {
+		return this.taxRepresentative;
+	}
+
+	/***
+	 * seller's tax representative (BG-11), to be used when the seller invoices
+	 * under the VAT ID of a fiscal representative in another member state
+	 * @param taxRepresentative the seller's fiscal representative
+	 * @return fluent setter
+	 */
+	public Invoice setTaxRepresentative(TradeParty taxRepresentative) {
+		this.taxRepresentative = taxRepresentative;
 		return this;
 	}
 

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/IExportableTransaction.java
@@ -564,6 +564,17 @@ public interface IExportableTransaction {
 	}
 
 	/***
+	 * seller's tax representative (BG-11), used when the seller invoices under the
+	 * VAT ID of a fiscal representative in another member state,
+	 * ram:SellerTaxRepresentativeTradeParty (only supported for zf2)
+	 *
+	 * @return the IZUGFeRDExportableTradeParty tax representative of the seller, or null if none
+	 */
+	default IZUGFeRDExportableTradeParty getTaxRepresentative() {
+		return null;
+	}
+
+	/***
 	 * invoicer / invoice sender, if different from seller, ram:InvoicerTradeParty
 	 *
 	 * @return the IZUGFeRDExportableTradeParty invoice sender, if different from seller

--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRD2PullProvider.java
@@ -707,6 +707,11 @@ public class ZUGFeRD2PullProvider implements IXMLProvider {
 		xml.append("<ram:SellerTradeParty>" + getTradePartyAsXML(trans.getSender(), true, false) + "</ram:SellerTradeParty>");
 		xml.append("<ram:BuyerTradeParty>" + getTradePartyAsXML(trans.getRecipient(), false, false) + "</ram:BuyerTradeParty>");
 
+		// seller's fiscal representative (BG-11), an EN16931 element carried by every profile except Minimum
+		if (trans.getTaxRepresentative() != null && getProfile() != Profiles.getByName("Minimum")) {
+			xml.append("<ram:SellerTaxRepresentativeTradeParty>" + getTradePartyAsXML(trans.getTaxRepresentative(), false, false) + "</ram:SellerTaxRepresentativeTradeParty>");
+		}
+
 		if (trans.getDeliveryTypeCode() != null && getProfile() == Profiles.getByName("Extended")) {
 			xml.append("<ram:ApplicableTradeDeliveryTerms>"
 				+ "<ram:DeliveryTypeCode>"

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/XRTest.java
@@ -385,6 +385,65 @@ public class XRTest extends TestCase {
 			.isEqualTo(1);
 	}
 
+	public void testSellerTaxRepresentative() {
+		// BG-11: seller's fiscal representative, used e.g. for intra-community supplies
+		// from a warehouse in another member state.
+		TradeParty recipient = new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE");
+		Invoice i = createInvoice(recipient)
+			.setTaxRepresentative(new TradeParty("Fiskalvertreter B.V.", "Voorbeeldstraat 1", "1011 AB", "Amsterdam", "NL")
+				.addVATID("NL123456789B01"))
+			// a following element in the same aggregate, to assert schema ordering
+			.setContractReferencedDocument(new ReferencedDocument("contract-4711"));
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("XRechnung"));
+		zf2p.generateXML(i);
+		String theXML = new String(zf2p.getXML(), StandardCharsets.UTF_8);
+
+		// the party is present with name, address and its own VAT ID (BT-62/63/66/67/69)
+		assertThat(theXML).valueByXPath("count(//*[local-name()='SellerTaxRepresentativeTradeParty'])")
+			.asInt().isEqualTo(1);
+		assertThat(theXML).valueByXPath("//*[local-name()='SellerTaxRepresentativeTradeParty']/*[local-name()='Name']")
+			.isEqualTo("Fiskalvertreter B.V.");
+		assertThat(theXML).valueByXPath("//*[local-name()='SellerTaxRepresentativeTradeParty']/*[local-name()='PostalTradeAddress']/*[local-name()='CountryID']")
+			.isEqualTo("NL");
+		assertThat(theXML).valueByXPath("//*[local-name()='SellerTaxRepresentativeTradeParty']/*[local-name()='SpecifiedTaxRegistration']/*[local-name()='ID'][@schemeID='VA']")
+			.isEqualTo("NL123456789B01");
+
+		// schema ordering (HeaderTradeAgreementType): after BuyerTradeParty, before ContractReferencedDocument
+		assertThat(theXML).valueByXPath("count(//*[local-name()='SellerTaxRepresentativeTradeParty']/preceding-sibling::*[local-name()='BuyerTradeParty'])")
+			.asInt().isEqualTo(1);
+		assertThat(theXML).valueByXPath("count(//*[local-name()='SellerTaxRepresentativeTradeParty']/following-sibling::*[local-name()='ContractReferencedDocument'])")
+			.asInt().isEqualTo(1);
+	}
+
+	public void testSellerTaxRepresentativeSuppressedInMinimum() {
+		// BG-11 is carried by every profile except Minimum (Basic/BasicWL/EN16931/Extended all
+		// declare and validate SellerTaxRepresentativeTradeParty), so it must be dropped only for Minimum.
+		TradeParty representative = new TradeParty("Fiskalvertreter B.V.", "Voorbeeldstraat 1", "1011 AB", "Amsterdam", "NL")
+			.addVATID("NL123456789B01");
+
+		// Minimum: element must not be emitted
+		Invoice min = createInvoice(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+			.setTaxRepresentative(representative);
+		ZUGFeRD2PullProvider minProvider = new ZUGFeRD2PullProvider();
+		minProvider.setProfile(Profiles.getByName("Minimum"));
+		minProvider.generateXML(min);
+		assertThat(new String(minProvider.getXML(), StandardCharsets.UTF_8))
+			.valueByXPath("count(//*[local-name()='SellerTaxRepresentativeTradeParty'])")
+			.asInt().isEqualTo(0);
+
+		// Basic: element is part of the profile and must be emitted
+		Invoice basic = createInvoice(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+			.setTaxRepresentative(representative);
+		ZUGFeRD2PullProvider basicProvider = new ZUGFeRD2PullProvider();
+		basicProvider.setProfile(Profiles.getByName("Basic"));
+		basicProvider.generateXML(basic);
+		assertThat(new String(basicProvider.getXML(), StandardCharsets.UTF_8))
+			.valueByXPath("count(//*[local-name()='SellerTaxRepresentativeTradeParty'])")
+			.asInt().isEqualTo(1);
+	}
+
 	private org.mustangproject.Invoice createInvoice(TradeParty recipient) {
 		String orgname = "Test company";
 		String number = "123";


### PR DESCRIPTION
Closes #1233.

## What

Adds the ability to write the seller's tax representative party (EN16931 group **BG-11**, `ram:SellerTaxRepresentativeTradeParty`) in the CII output. Before this change the model had no API for it and the writer never emitted the element, so none of BT-62..BT-69 could be expressed.

Use case: intra-community supplies out of a warehouse in another member state, where the seller invoices under the VAT identifier of a fiscal representative established there. `BR-DE-16` lists BG-11 as one of the alternatives (next to BT-31 / BT-32) that satisfy the seller tax-identification requirement.

## Changes

- **`Invoice`** — new `taxRepresentative` field with fluent `setTaxRepresentative(TradeParty)` / `getTaxRepresentative()`, mirroring the existing optional `payee` party.
- **`IExportableTransaction`** — `default IZUGFeRDExportableTradeParty getTaxRepresentative() { return null; }`, so no existing implementation breaks (same pattern as `getPayee()`).
- **`ZUGFeRD2PullProvider`** — emits `SellerTaxRepresentativeTradeParty` right after `BuyerTradeParty` and before `ApplicableTradeDeliveryTerms`, as required by the `HeaderTradeAgreementType` sequence (element 10 of 27). Reuses the existing `getTradePartyAsXML(...)` helper, which already renders `Name` → `PostalTradeAddress` → `SpecifiedTaxRegistration` in the required order.
- **Profiles** — emitted for every profile whose schema declares the element (BASIC, BASIC-WL, EN16931, EXTENDED, XRECHNUNG — all of which also carry the `BR-18/19/20/56` rules for it); suppressed only for MINIMUM, the sole profile whose XSD omits `SellerTaxRepresentativeTradeParty`.

## Produced XML

```xml
<ram:SellerTaxRepresentativeTradeParty>
    <ram:Name>Fiskalvertreter B.V.</ram:Name>
    <ram:PostalTradeAddress>
        <ram:PostcodeCode>1011 AB</ram:PostcodeCode>
        <ram:LineOne>Voorbeeldstraat 1</ram:LineOne>
        <ram:CityName>Amsterdam</ram:CityName>
        <ram:CountryID>NL</ram:CountryID>
    </ram:PostalTradeAddress>
    <ram:SpecifiedTaxRegistration>
        <ram:ID schemeID="VA">NL123456789B01</ram:ID>
    </ram:SpecifiedTaxRegistration>
</ram:SellerTaxRepresentativeTradeParty>
```

## Tests

Two tests in `XRTest`:
- `testSellerTaxRepresentative` — asserts the element's presence, its name / country / VAT-ID contents, and its **schema ordering** (a preceding `BuyerTradeParty` and a following `ContractReferencedDocument`), not merely that it occurs.
- `testSellerTaxRepresentativeSuppressedInMinimum` — asserts it is dropped for MINIMUM and emitted for BASIC.

## Scope

- Field-to-BT mapping was verified against the bundled EN16931 XSD (party/address `complexType` ordering), the CII→XR read-path stylesheet (`cii-xr.xsl`), and the `BR-18/19/20/56` / `BR-DE-16` Schematron rules: BT-62 `Name`, BT-63 `SpecifiedTaxRegistration/ID[@schemeID='VA']`, BT-64/65 `LineOne`/`LineTwo`, BT-66 `CityName`, BT-67 `PostcodeCode`, BT-69 `CountryID`. BT-68 (country subdivision) is optional and not modelled by `TradeParty`, so it is omitted.
- The **UBL** writer is a separate path and is intentionally left out of this PR to keep it focused.
