### PR TITLE
Fix malformed ram:Name opening tag for BT-123

### DIFF
--- a/library/src/main/java/org/mustangproject/ReferencedDocument.java
+++ b/library/src/main/java/org/mustangproject/ReferencedDocument.java
@@ -229,7 +229,7 @@ public class ReferencedDocument implements IReferencedDocument {
 			xml.append("<ram:TypeCode>" + XMLTools.encodeXML(this.getTypeCode()) + "</ram:TypeCode>");
 		}
 		if (StringUtils.isNotBlank(this.getName())) {
-			xml.append("<ram:name>" + XMLTools.encodeXML(this.getName()) + "</ram:Name>");
+			xml.append("<ram:Name>" + XMLTools.encodeXML(this.getName()) + "</ram:Name>");
 		}
 		if (this.getAttachmentBinaryObject() != null) {
 			FileAttachment f = this.getAttachmentBinaryObject();

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/BT123ReferencedDocumentNameTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/BT123ReferencedDocumentNameTest.java
@@ -1,0 +1,58 @@
+package org.mustangproject.ZUGFeRD;
+
+import junit.framework.TestCase;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.ReferencedDocument;
+import org.mustangproject.TradeParty;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.xmlunit.assertj.XmlAssert.assertThat;
+
+public class BT123ReferencedDocumentNameTest extends TestCase {
+
+	/**
+	 * BT-123 (supporting document description) used to be written as
+	 * &lt;ram:name&gt;...&lt;/ram:Name&gt; — a lowercase opening tag with an uppercase closing tag.
+	 * That makes the whole document non-wellformed, so ZUGFeRD2PullProvider#getXML cannot re-parse
+	 * its own output: dom4j fails, the Document stays null and XMLWriter#write(null) throws a
+	 * NullPointerException without a message. Any invoice with a named referenced document (e.g. an
+	 * attached PDF) was therefore unwritable.
+	 */
+	public void testReferencedDocumentNameIsWellformed() {
+		Invoice i = new Invoice()
+			.setIssueDate(new Date())
+			.setDueDate(new Date())
+			.setDeliveryDate(new Date())
+			.setSender(new TradeParty("Test company", "teststr", "55232", "teststadt", "DE"))
+			.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+			.setNumber("INV-123")
+			.addItem(new Item(
+				new Product("Testprodukt", "", "C62", BigDecimal.ZERO),
+				new BigDecimal("1.00"),
+				BigDecimal.ONE
+			));
+
+		ReferencedDocument rd = new ReferencedDocument("ID unique");
+		rd.setName("Delivery note description");
+		i.setObjectIdentifierReferencedDocument(rd);
+
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("XRechnung"));
+		zf2p.generateXML(i);
+
+		String xml = new String(zf2p.getXML(), StandardCharsets.UTF_8);
+
+		// getXML() pretty-prints through dom4j, so a non-wellformed name element would have left
+		// the output empty (and NPEd) instead of returning a parseable CII invoice.
+		assertTrue(xml.contains("<rsm:CrossIndustryInvoice"));
+
+		assertThat(xml)
+			.valueByXPath("string(//*[local-name()='AdditionalReferencedDocument']/*[local-name()='Name'])")
+			.isEqualTo("Delivery note description");
+	}
+}


### PR DESCRIPTION
### Problem

`ReferencedDocument#getAsCII` writes BT-123 as `<ram:name>...</ram:Name>` — lowercase opening tag, uppercase closing tag. XML element names are case-sensitive, so every referenced document that carries a name (a supporting document description, e.g. an attached PDF) produces a non-wellformed CII document.

`ZUGFeRD2PullProvider#getXML` re-parses its own output with dom4j before pretty-printing. On such a document `DocumentHelper.parseText` fails, the `Document` stays `null`, and `XMLWriter#write(null)` throws a `NullPointerException` **without a message**:

```
NullPointerException: Cannot invoke "org.dom4j.Document.getDocType()" because "doc" is null
    at org.dom4j.io.XMLWriter.write(XMLWriter.java:340)
    at org.mustangproject.ZUGFeRD.ZUGFeRD2PullProvider.getXML(ZUGFeRD2PullProvider.java:101)
```

So the invoice cannot be written at all, and the real cause is invisible in the exception. This affects both header-level and line-level referenced documents, since both go through `getAsCII()`.

The name serialization is new in 2.25.0, so 2.24.0 is not affected.

### Fix

One character: `<ram:name>` → `<ram:Name>`.

### Test

`BT123ReferencedDocumentNameTest` writes an invoice with a named `AdditionalReferencedDocument` and asserts the value can be read back by XPath. It fails with the `NullPointerException` above without the fix.
