### PR TITLE
Do not import an embedded BG-24 attachment twice

### DIFF
--- a/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
+++ b/library/src/main/java/org/mustangproject/ZUGFeRD/ZUGFeRDInvoiceImporter.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -60,6 +61,7 @@ import org.mustangproject.TradeParty;
 import org.mustangproject.XMLTools;
 import org.mustangproject.Exceptions.StructureException;
 import org.mustangproject.util.NodeMap;
+import org.mustangproject.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -796,7 +798,7 @@ public class ZUGFeRDInvoiceImporter {
 			headerTradeAgreementNodesMap.getNode("ContractReferencedDocument").map(ReferencedDocument::fromNode).ifPresent(rd -> zpp.setContractReferencedDocument(rd));
 			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("50")).findFirst().ifPresent(rd -> zpp.setTenderReferencedDocument(rd));
 			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("130")).findFirst().ifPresent(rd -> zpp.setObjectIdentifierReferencedDocument(rd));
-			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("916")).findFirst().ifPresent(rd -> zpp.setRelatedReferencedDocument(rd));
+			headerTradeAgreementNodesMap.getAllNodes("AdditionalReferencedDocument").map(ReferencedDocument::fromNode).filter(rd -> rd.getTypeCode().equals("916")).filter(rd -> !isPlainEmbeddedAttachment(rd)).findFirst().ifPresent(rd -> zpp.setRelatedReferencedDocument(rd));
 		}
 
 
@@ -1400,6 +1402,32 @@ public class ZUGFeRDInvoiceImporter {
 			}
 		}
 		return zpp;
+	}
+
+	/**
+	 * Whether this TypeCode-916 element is a BG-24 supporting document that the AttachmentBinaryObject /
+	 * EmbeddedDocumentBinaryObject scan already imports as an additionalReferencedDocument
+	 * (Invoice#embedFileInXML). Importing it into relatedReferencedDocument as well would make
+	 * ZUGFeRD2PullProvider write the very same element - payload included - a second time.
+	 *
+	 * Reported only when the FileAttachment can carry every value the element holds, so that dropping the
+	 * second copy cannot change what is written. The FileAttachment branch of the writer emits BT-122 from
+	 * the FILENAME, the type code, BT-123 from the description and BT-125 from the mime type + payload:
+	 *
+	 * - an element whose IssuerAssignedID differs from AttachmentBinaryObject/@filename (both are allowed
+	 *   to differ) would come back re-labelled with the filename, so it is kept;
+	 * - so is one declaring URIID, LineID, ReferenceTypeCode or FormattedIssueDateTime, which that branch
+	 *   cannot express at all.
+	 *
+	 * Writing a document twice is recoverable, losing a field the source declared is not.
+	 */
+	private static boolean isPlainEmbeddedAttachment(ReferencedDocument rd) {
+		return rd.getAttachmentBinaryObject() != null
+			&& Objects.equals(rd.getIssuerAssignedID(), rd.getAttachmentBinaryObject().getFilename())
+			&& StringUtils.isBlank(rd.getUriID())
+			&& StringUtils.isBlank(rd.getLineID())
+			&& StringUtils.isBlank(rd.getReferenceTypeCode())
+			&& rd.getFormattedIssueDateTime() == null;
 	}
 
 	private Date parseDate(String issueDateString, String datePattern) throws ParseException {

--- a/library/src/test/java/org/mustangproject/ZUGFeRD/BG24AttachmentRoundTripTest.java
+++ b/library/src/test/java/org/mustangproject/ZUGFeRD/BG24AttachmentRoundTripTest.java
@@ -1,0 +1,132 @@
+package org.mustangproject.ZUGFeRD;
+
+import junit.framework.TestCase;
+import org.mustangproject.FileAttachment;
+import org.mustangproject.Invoice;
+import org.mustangproject.Item;
+import org.mustangproject.Product;
+import org.mustangproject.ReferencedDocument;
+import org.mustangproject.TradeParty;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.xmlunit.assertj.XmlAssert.assertThat;
+
+public class BG24AttachmentRoundTripTest extends TestCase {
+
+	private Invoice createInvoice() {
+		return new Invoice()
+			.setIssueDate(new Date())
+			.setDueDate(new Date())
+			.setDeliveryDate(new Date())
+			.setSender(new TradeParty("Test company", "teststr", "55232", "teststadt", "DE"))
+			.setRecipient(new TradeParty("Franz Müller", "teststr.12", "55232", "Entenhausen", "DE"))
+			.setNumber("INV-123")
+			.addItem(new Item(
+				new Product("Testprodukt", "", "C62", BigDecimal.ZERO),
+				new BigDecimal("1.00"),
+				BigDecimal.ONE
+			));
+	}
+
+	private String writeCII(Invoice i) {
+		ZUGFeRD2PullProvider zf2p = new ZUGFeRD2PullProvider();
+		zf2p.setProfile(Profiles.getByName("EN16931"));
+		zf2p.generateXML(i);
+		return new String(zf2p.getXML(), StandardCharsets.UTF_8);
+	}
+
+	private Invoice readCII(String xml) throws Exception {
+		ZUGFeRDInvoiceImporter zii = new ZUGFeRDInvoiceImporter();
+		zii.doIgnoreCalculationErrors();
+		zii.setRawXML(xml.getBytes(StandardCharsets.UTF_8));
+		return zii.extractInvoice();
+	}
+
+	/**
+	 * A BG-24 supporting document with an embedded binary (BT-122 + BT-125) is one
+	 * ram:AdditionalReferencedDocument with TypeCode 916. The importer used to store it TWICE: the
+	 * AttachmentBinaryObject scan puts it into additionalReferencedDocuments (Invoice#embedFileInXML)
+	 * and the header trade agreement pass mapped the same element to relatedReferencedDocument.
+	 * ZUGFeRD2PullProvider writes both, so every import/export round trip duplicated the attachment —
+	 * and each further round trip added another copy.
+	 */
+	public void testEmbeddedAttachmentIsNotDuplicatedOnRoundTrip() throws Exception {
+		Invoice i = createInvoice();
+		i.embedFileInXML(new FileAttachment("attachment.pdf", "application/pdf", "Data",
+			new byte[]{1, 2, 3}));
+
+		String source = writeCII(i);
+		assertThat(source).valueByXPath(
+				"count(//*[local-name()='ApplicableHeaderTradeAgreement']/*[local-name()='AdditionalReferencedDocument'])")
+			.asInt()
+			.isEqualTo(1);
+
+		String reExported = writeCII(readCII(source));
+
+		assertThat(reExported).valueByXPath(
+				"count(//*[local-name()='ApplicableHeaderTradeAgreement']/*[local-name()='AdditionalReferencedDocument'])")
+			.asInt()
+			.isEqualTo(1);
+		assertThat(reExported).valueByXPath(
+				"count(//*[local-name()='AttachmentBinaryObject'])")
+			.asInt()
+			.isEqualTo(1);
+	}
+
+	/**
+	 * The duplicate is only suppressed when the FileAttachment can carry everything the source element
+	 * declared. A 916 element with a binary AND e.g. an issue date must still reach
+	 * relatedReferencedDocument, because the FileAttachment branch of the writer cannot express that date -
+	 * writing the document twice is recoverable, losing a declared field is not.
+	 */
+	public void testEmbeddedAttachmentWithExtraMetadataIsKept() throws Exception {
+		Invoice i = createInvoice();
+		Date issueDate = new SimpleDateFormat("yyyyMMdd").parse("20260722");
+		ReferencedDocument rd = new ReferencedDocument("attachment.pdf");
+		rd.setAttachmentBinaryObject(new FileAttachment("attachment.pdf", "application/pdf", "Data",
+			new byte[]{1, 2, 3}));
+		rd.setFormattedIssueDateTime(issueDate);
+		i.setRelatedReferencedDocument(rd);
+
+		Invoice imported = readCII(writeCII(i));
+
+		assertNotNull(imported.getRelatedReferencedDocument());
+		assertEquals(issueDate, imported.getRelatedReferencedDocument().getFormattedIssueDateTime());
+	}
+
+	/**
+	 * CII allows ram:IssuerAssignedID and AttachmentBinaryObject/@filename to differ. The FileAttachment
+	 * branch of the writer rebuilds BT-122 from the filename, so such an element must keep going into
+	 * relatedReferencedDocument - otherwise the reference would silently come back re-labelled.
+	 */
+	public void testEmbeddedAttachmentWithOwnIssuerAssignedIdIsKept() throws Exception {
+		Invoice i = createInvoice();
+		ReferencedDocument rd = new ReferencedDocument("SUPPORT-DOC-4711");
+		rd.setAttachmentBinaryObject(new FileAttachment("attachment.pdf", "application/pdf", "Data",
+			new byte[]{1, 2, 3}));
+		i.setRelatedReferencedDocument(rd);
+
+		Invoice imported = readCII(writeCII(i));
+
+		assertNotNull(imported.getRelatedReferencedDocument());
+		assertEquals("SUPPORT-DOC-4711", imported.getRelatedReferencedDocument().getIssuerAssignedID());
+	}
+
+	/**
+	 * A 916 reference WITHOUT a binary is not a BG-24 attachment and nothing else carries it, so it
+	 * must still reach relatedReferencedDocument and survive the round trip.
+	 */
+	public void testReferenceWithoutBinaryStillRoundTrips() throws Exception {
+		Invoice i = createInvoice();
+		i.setRelatedReferencedDocument(new ReferencedDocument("related-document-id"));
+
+		Invoice imported = readCII(writeCII(i));
+
+		assertNotNull(imported.getRelatedReferencedDocument());
+		assertEquals("related-document-id", imported.getRelatedReferencedDocument().getIssuerAssignedID());
+	}
+}


### PR DESCRIPTION
A BG-24 supporting document with an embedded binary (BT-122 + BT-125) is a single ram:AdditionalReferencedDocument with TypeCode 916. ZUGFeRDInvoiceImporter stored it twice: the AttachmentBinaryObject/EmbeddedDocumentBinaryObject scan puts it into additionalReferencedDocuments (Invoice#embedFileInXML), and the header trade agreement pass mapped the first TypeCode-916 element to relatedReferencedDocument as well.

ZUGFeRD2PullProvider writes both fields, so every import/export round trip duplicated the attachment - including the base64 payload - and each further round trip added another copy. A reader that regenerates the CII from the imported model therefore ends up with two identical AdditionalReferencedDocument elements, one carrying the FileAttachment description as BT-123 and one without.

Only 916 elements WITHOUT an AttachmentBinaryObject are mapped to relatedReferencedDocument now. Nothing is lost: filename, mime type and payload of an embedded document are all kept in the FileAttachment the other branch creates, and a 916 reference that carries no binary is not a BG-24 attachment, so it still reaches relatedReferencedDocument and round trips as before.

Added BG24AttachmentRoundTripTest: the first test fails with 2 instead of 1 AdditionalReferencedDocument before this change, the second one guards the reference-without-binary case.